### PR TITLE
Added missing platform_family information for centos

### DIFF
--- a/lib/fauxhai/platforms/centos/6.0.json
+++ b/lib/fauxhai/platforms/centos/6.0.json
@@ -143,6 +143,7 @@
     "ps": "ps -ef"
   },
   "platform": "centos",
+  "platform_family": "rhel",
   "platform_version": "6.0",
   "dmi": {
   },


### PR DESCRIPTION
platform_family was added to Ohai in 6.12
https://github.com/opscode/ohai/blob/master/lib/ohai/plugins/linux/platform.rb#L92
