### PR TITLE
update readme to redirect fauxhai command

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,7 +150,7 @@ Fauxhai is community-maintained and updated. Aside from the initial files, all o
 2. Install chef, ohai, and fauxhai
 3. Run the following at the command line:
 
-        sudo fauxhai
+        sudo fauxhai > /tmp/fauxhai.json
 
 4. This will create a file `/tmp/fauxhai.json`
 5. Copy the contents of this file to your local development machine (using scp or sftp, for example)


### PR DESCRIPTION
In the instructions for contributing, it says to run the fauxhai
command. This is fine, except the next step says the
`/tmp/fauxhai.json` file is created. This wasn't the case on my
machine, so I redirected the output to the file.
- Platform: mac_os_x
- Version: 10.8.2
