### PR TITLE
For Ubuntu 10.04: update gems_dir to true location, update chef version to latest and chef_root to true location

### DIFF
--- a/lib/fauxhai/platforms/ubuntu/10.04.json
+++ b/lib/fauxhai/platforms/ubuntu/10.04.json
@@ -398,7 +398,7 @@
     },
     "ohai": {
       "version": "6.14.0",
-      "ohai_root": "/usr/local/gems/ohai-6.14.0/lib/ohai"
+      "ohai_root": "/usr/local/lib/ruby/gems/1.9.1/gems/ohai-6.14.0/lib/ohai"
     }
   },
   "counters": {


### PR DESCRIPTION
I just set up an ec2 ami on Ubuntu 10.04 and noticed that one of my cookbooks was failing because a path in some file was wrong. After digging through it, I found that my spec for the cookbook was asserting based on the gem_dir set in Fauxhai, but that gem_dir didn't match the actual directory on the Ubuntu instance.
