### PR TITLE
change gems dir to the seemingly incorrect location that '/usr/local/bin/ruby /usr/local/bin/gem env gemdir' reports

### DIFF
--- a/lib/fauxhai/platforms/ubuntu/10.04.json
+++ b/lib/fauxhai/platforms/ubuntu/10.04.json
@@ -387,7 +387,7 @@
       "host_vendor": "unknown",
       "bin_dir": "/usr/local/bin",
       "ruby_bin": "/usr/local/bin/ruby",
-      "gems_dir": "/usr/local/lib/ruby/gems/1.9.1/gems",
+      "gems_dir": "/usr/local/lib/ruby/gems/1.9.1",
       "gem_bin": "/usr/local/bin/gem"
     }
   },


### PR DESCRIPTION
Sorry for this correcting pull request, but I have more information now that changes something I was mistaken about earlier

I had thought that the `gems_dir` ohai was reporting was incorrectly `/usr/local/lib/ruby/gems/1.9.1` but it turns out that's the directory that rubygems is reporting to ohai:

``` bash
$> /usr/local/bin/ruby /usr/local/bin/gem env gemdir # the command that ohai runs
/usr/local/lib/ruby/gems/1.9.1
$> /usr/local/bin/ruby /usr/local/bin/gem env # to provide context
RubyGems Environment:
  - RUBYGEMS VERSION: 1.8.23
  - RUBY VERSION: 1.9.3 (2012-04-20 patchlevel 194) [x86_64-linux]
  - INSTALLATION DIRECTORY: /usr/local/lib/ruby/gems/1.9.1
  - RUBY EXECUTABLE: /usr/local/bin/ruby
  - EXECUTABLE DIRECTORY: /usr/local/bin
  - RUBYGEMS PLATFORMS:
    - ruby
    - x86_64-linux
  - GEM PATHS:
     - /usr/local/lib/ruby/gems/1.9.1
     - /home/ubuntu/.gem/ruby/1.9.1
  - GEM CONFIGURATION:
     - :update_sources => true
     - :verbose => true
     - :benchmark => false
     - :backtrace => false
     - :bulk_threshold => 1000
     - "install" => "--no-rdoc --no-ri"
     - "update" => "--no-rdoc --no-ri"
  - REMOTE SOURCES:
     - http://rubygems.org/
```

The extra `/gems` that I added at the end of the `gems_dir` is something that cookbooks tend to add manually, and I guess now I know why.
