### PR TITLE
Require platform version option

### DIFF
--- a/lib/fauxhai/exception.rb
+++ b/lib/fauxhai/exception.rb
@@ -1,6 +1,6 @@
 module Fauxhai
   module Exception
-    class InvalidVersion < ArgumentError; end
     class InvalidPlatform < ArgumentError; end
+    class InvalidVersion < ArgumentError; end
   end
 end

--- a/lib/fauxhai/mocker.rb
+++ b/lib/fauxhai/mocker.rb
@@ -55,7 +55,7 @@ module Fauxhai
             File.open(filepath, 'w'){ |f| f.write(response.body) }
             return JSON.parse(response.body)
           else
-            raise Fauxhai::Exception::InvalidVersion.new("Could not find version #{@options[:version]} in any of the sources!")
+            raise Fauxhai::Exception::InvalidPlatform.new("Could not find platform '#{platform}/#{version}' in any of the sources!")
           end
         end
       end.call
@@ -66,13 +66,7 @@ module Fauxhai
     end
 
     def platform_path
-      @platform_path ||= lambda do
-        if path = File.join(Fauxhai.root, 'lib', 'fauxhai', 'platforms', platform)
-          path
-        else
-          raise Fauxhai::Exception::InvalidPlatform.new('Platform not found!')
-        end
-      end.call
+      File.join(Fauxhai.root, 'lib', 'fauxhai', 'platforms', platform)
     end
 
     def version


### PR DESCRIPTION
Maintain compatibility with ChefSpec, but otherwise always require `platform` and `version` options (or `path`).

Continuation for cleanup in #25.
