### PR TITLE
fix syntax, space after method calls?

### DIFF
--- a/lib/fauxhai/mocker.rb
+++ b/lib/fauxhai/mocker.rb
@@ -73,7 +73,7 @@ module Fauxhai
     end
 
     def version
-      @options[:version] ||= chefspec_version || raise Fauxhai::Exception::InvalidVersion.new('Platform version not specified')
+      @options[:version] ||= chefspec_version || raise(Fauxhai::Exception::InvalidVersion.new('Platform version not specified'))
     end
 
     def chefspec_version


### PR DESCRIPTION
I am getting this error:
ranjib@ranjib-pd:~/workspace/foss/fauxhai [master] $ irb
irb(main):001:0> require 'fauxhai'
SyntaxError: /home/ranjib/.rbenv/versions/1.9.3-p392/lib/ruby/gems/1.9.1/gems/fauxhai-1.0.0.rc1/lib/fauxhai/mocker.rb:76: syntax error, unexpected tCONSTANT, expecting keyword_do or '{' or '('
...efspec_version || raise Fauxhai::Exception::InvalidVersion.n...
...                               ^
    from /home/ranjib/.rbenv/versions/1.9.3-p392/lib/ruby/1.9.1/rubygems/custom_require.rb:36:in `require'
    from /home/ranjib/.rbenv/versions/1.9.3-p392/lib/ruby/1.9.1/rubygems/custom_require.rb:36:in`require'
    from /home/ranjib/.rbenv/versions/1.9.3-p392/lib/ruby/gems/1.9.1/gems/fauxhai-1.0.0.rc1/lib/fauxhai.rb:4:in `<module:Fauxhai>'
    from /home/ranjib/.rbenv/versions/1.9.3-p392/lib/ruby/gems/1.9.1/gems/fauxhai-1.0.0.rc1/lib/fauxhai.rb:1:in`<top (required)>'
    from /home/ranjib/.rbenv/versions/1.9.3-p392/lib/ruby/1.9.1/rubygems/custom_require.rb:60:in `require'
    from /home/ranjib/.rbenv/versions/1.9.3-p392/lib/ruby/1.9.1/rubygems/custom_require.rb:60:in`rescue in require'
    from /home/ranjib/.rbenv/versions/1.9.3-p392/lib/ruby/1.9.1/rubygems/custom_require.rb:35:in `require'
    from (irb):1
    from /home/ranjib/.rbenv/versions/1.9.3-p392/bin/irb:12:in`<main>'
irb(main):002:0> 
