### PR TITLE
Add fedora 18 platform

### DIFF
--- a/lib/fauxhai/platforms/fedora/18.json
+++ b/lib/fauxhai/platforms/fedora/18.json
@@ -1,0 +1,463 @@
+{
+  "kernel": {
+    "name": "Linux",
+    "release": "3.8.4-202.fc18.i686.PAE",
+    "version": "#1 SMP Thu Mar 21 17:14:12 UTC 2013",
+    "machine": "i686",
+    "modules": {
+      "nf_conntrack_netbios_ns": {
+        "size": "12585",
+        "refcount": "0"
+      },
+      "nf_conntrack_broadcast": {
+        "size": "12487",
+        "refcount": "1"
+      },
+      "ipt_MASQUERADE": {
+        "size": "12760",
+        "refcount": "1"
+      },
+      "ip6table_mangle": {
+        "size": "12620",
+        "refcount": "1"
+      },
+      "ip6t_REJECT": {
+        "size": "12826",
+        "refcount": "2"
+      },
+      "nf_conntrack_ipv6": {
+        "size": "18318",
+        "refcount": "23"
+      },
+      "nf_defrag_ipv6": {
+        "size": "17824",
+        "refcount": "1"
+      },
+      "iptable_nat": {
+        "size": "12867",
+        "refcount": "1"
+      },
+      "nf_nat_ipv4": {
+        "size": "13039",
+        "refcount": "1"
+      },
+      "nf_nat": {
+        "size": "24669",
+        "refcount": "3"
+      },
+      "iptable_mangle": {
+        "size": "12615",
+        "refcount": "1"
+      },
+      "nf_conntrack_ipv4": {
+        "size": "14320",
+        "refcount": "20"
+      },
+      "nf_defrag_ipv4": {
+        "size": "12601",
+        "refcount": "1"
+      },
+      "xt_conntrack": {
+        "size": "12664",
+        "refcount": "42"
+      },
+      "nf_conntrack": {
+        "size": "72168",
+        "refcount": "9"
+      },
+      "ebtable_filter": {
+        "size": "12715",
+        "refcount": "0"
+      },
+      "ebtables": {
+        "size": "21315",
+        "refcount": "1"
+      },
+      "ip6table_filter": {
+        "size": "12711",
+        "refcount": "1"
+      },
+      "ip6_tables": {
+        "size": "17634",
+        "refcount": "2"
+      },
+      "ppdev": {
+        "size": "17363",
+        "refcount": "0"
+      },
+      "parport_pc": {
+        "size": "27403",
+        "refcount": "0"
+      },
+      "parport": {
+        "size": "39143",
+        "refcount": "2"
+      },
+      "i2c_piix4": {
+        "size": "17682",
+        "refcount": "0"
+      },
+      "e1000": {
+        "size": "132831",
+        "refcount": "0"
+      },
+      "i2c_core": {
+        "size": "28449",
+        "refcount": "1"
+      },
+      "microcode": {
+        "size": "18726",
+        "refcount": "0"
+      },
+      "vboxsf": {
+        "size": "42541",
+        "refcount": "1"
+      },
+      "vboxguest": {
+        "size": "188485",
+        "refcount": "2"
+      }
+    },
+    "os": "GNU/Linux"
+  },
+  "os": "linux",
+  "os_version": "3.8.4-202.fc18.i686.PAE",
+  "command": {
+    "ps": "ps -ef"
+  },
+  "ohai_time": 1370732302.4638762,
+  "platform": "fedora",
+  "platform_version": "18",
+  "platform_family": "fedora",
+  "dmi": {
+  },
+  "filesystem": {
+    "devtmpfs": {
+      "kb_size": "375372",
+      "kb_used": "0",
+      "kb_available": "375372",
+      "percent_used": "0%",
+      "mount": "/dev",
+      "fs_type": "devtmpfs",
+      "mount_options": [
+        "rw",
+        "nosuid",
+        "seclabel",
+        "size=375372k",
+        "nr_inodes=93843",
+        "mode=755"
+      ]
+    },
+    "tmpfs": {
+      "kb_size": "383868",
+      "kb_used": "0",
+      "kb_available": "383868",
+      "percent_used": "0%",
+      "mount": "/tmp",
+      "fs_type": "tmpfs",
+      "mount_options": [
+        "rw",
+        "seclabel"
+      ]
+    },
+    "/dev/mapper/fedora-root": {
+      "kb_size": "29550460",
+      "kb_used": "809040",
+      "kb_available": "27233684",
+      "percent_used": "3%",
+      "mount": "/",
+      "fs_type": "ext4",
+      "mount_options": [
+        "rw",
+        "relatime",
+        "seclabel",
+        "data=ordered"
+      ],
+      "uuid": "a24f47a4-946e-45c2-99fa-8c956aa3d0fb"
+    },
+    "/dev/sda1": {
+      "kb_size": "487652",
+      "kb_used": "39709",
+      "kb_available": "422343",
+      "percent_used": "9%",
+      "mount": "/boot",
+      "fs_type": "ext4",
+      "mount_options": [
+        "rw",
+        "relatime",
+        "seclabel",
+        "data=ordered"
+      ],
+      "uuid": "85e5935b-73c2-4449-85cb-94abdc2c1f8d"
+    },
+    "none": {
+      "kb_size": "244277768",
+      "kb_used": "98776704",
+      "kb_available": "145501064",
+      "percent_used": "41%",
+      "mount": "/vagrant",
+      "fs_type": "vboxsf",
+      "mount_options": [
+        "rw",
+        "nodev",
+        "relatime"
+      ]
+    },
+    "proc": {
+      "mount": "/proc",
+      "fs_type": "proc",
+      "mount_options": [
+        "rw",
+        "nosuid",
+        "nodev",
+        "noexec",
+        "relatime"
+      ]
+    },
+    "sysfs": {
+      "mount": "/sys",
+      "fs_type": "sysfs",
+      "mount_options": [
+        "rw",
+        "nosuid",
+        "nodev",
+        "noexec",
+        "relatime",
+        "seclabel"
+      ]
+    },
+    "securityfs": {
+      "mount": "/sys/kernel/security",
+      "fs_type": "securityfs",
+      "mount_options": [
+        "rw",
+        "nosuid",
+        "nodev",
+        "noexec",
+        "relatime"
+      ]
+    },
+    "selinuxfs": {
+      "mount": "/sys/fs/selinux",
+      "fs_type": "selinuxfs",
+      "mount_options": [
+        "rw",
+        "relatime"
+      ]
+    },
+    "devpts": {
+      "mount": "/dev/pts",
+      "fs_type": "devpts",
+      "mount_options": [
+        "rw",
+        "nosuid",
+        "noexec",
+        "relatime",
+        "seclabel",
+        "gid=5",
+        "mode=620",
+        "ptmxmode=000"
+      ]
+    },
+    "cgroup": {
+      "mount": "/sys/fs/cgroup/perf_event",
+      "fs_type": "cgroup",
+      "mount_options": [
+        "rw",
+        "nosuid",
+        "nodev",
+        "noexec",
+        "relatime",
+        "perf_event"
+      ]
+    },
+    "systemd-1": {
+      "mount": "/proc/sys/fs/binfmt_misc",
+      "fs_type": "autofs",
+      "mount_options": [
+        "rw",
+        "relatime",
+        "fd=28",
+        "pgrp=1",
+        "timeout=300",
+        "minproto=5",
+        "maxproto=5",
+        "direct"
+      ]
+    },
+    "hugetlbfs": {
+      "mount": "/dev/hugepages",
+      "fs_type": "hugetlbfs",
+      "mount_options": [
+        "rw",
+        "relatime",
+        "seclabel"
+      ]
+    },
+    "mqueue": {
+      "mount": "/dev/mqueue",
+      "fs_type": "mqueue",
+      "mount_options": [
+        "rw",
+        "relatime",
+        "seclabel"
+      ]
+    },
+    "configfs": {
+      "mount": "/sys/kernel/config",
+      "fs_type": "configfs",
+      "mount_options": [
+        "rw",
+        "relatime"
+      ]
+    },
+    "debugfs": {
+      "mount": "/sys/kernel/debug",
+      "fs_type": "debugfs",
+      "mount_options": [
+        "rw",
+        "relatime"
+      ]
+    },
+    "/dev/sda2": {
+      "fs_type": "LVM2_member",
+      "uuid": "u1IOAZ-dSJw-2Vbh-Kr14-6exW-qYZT-w3fibZ"
+    },
+    "/dev/mapper/fedora-swap": {
+      "fs_type": "swap",
+      "uuid": "20d2931f-4efb-4964-b7be-75e1274ee074"
+    },
+    "rootfs": {
+      "mount": "/",
+      "fs_type": "rootfs",
+      "mount_options": [
+        "rw"
+      ]
+    }
+  },
+  "languages": {
+    "ruby": {
+      "platform": "i386-linux",
+      "version": "1.9.3",
+      "release_date": "2013-02-22",
+      "target": "i686-redhat-linux-gnu",
+      "target_cpu": "i386",
+      "target_vendor": "redhat",
+      "target_os": "linux",
+      "host": "i686-redhat-linux-gnu",
+      "host_cpu": "i686",
+      "host_os": "linux-gnu",
+      "host_vendor": "redhat",
+      "bin_dir": "/usr/local/bin",
+      "ruby_bin": "/usr/local/bin/ruby",
+      "gems_dir": "/usr/local/gems",
+      "gem_bin": "/usr/local/bin/gem"
+    }
+  },
+  "chef_packages": {
+    "chef": {
+      "version": "11.4.0",
+      "chef_root": "/usr/local/gems/chef-11.4.0/lib"
+    },
+    "ohai": {
+      "version": "6.16.0",
+      "ohai_root": "/usr/local/gems/ohai-6.16.0/lib/ohai"
+    }
+  },
+  "counters": {
+    "network": {
+      "interfaces": {
+        "eth0": {
+          "rx": {
+            "bytes": "0",
+            "packets": "0",
+            "errors": "0",
+            "drop": 0,
+            "overrun": 0,
+            "frame": 0,
+            "compressed": 0,
+            "multicast": 0
+          },
+          "tx": {
+            "bytes": "342",
+            "packets": "0",
+            "errors": "0",
+            "drop": 0,
+            "overrun": 0,
+            "collisions": "0",
+            "carrier": 0,
+            "compressed": 0
+          }
+        }
+      }
+    }
+  },
+  "current_user": "fauxhai",
+  "domain": "local",
+  "etc": {
+    "passwd": {
+      "fauxhai": {
+        "dir": "/home/fauxhai",
+        "gid": 0,
+        "uid": 0,
+        "shell": "/bin/bash",
+        "gecos": "Fauxhai"
+      }
+    },
+    "group": {
+      "fauxhai": {
+        "gid": 0,
+        "members": [
+          "fauxhai"
+        ]
+      }
+    }
+  },
+  "hostname": "Fauxhai",
+  "fqdn": "fauxhai.local",
+  "ipaddress": "10.0.0.2",
+  "keys": {
+    "ssh": {
+      "host_dsa_public": "ssh-dss AAAAB3NzaC1kc3MAAACBAJFo9BLAw4WKEs5hgipk5m423FzBsDXCZSMcC9ca/om/1VYzMqImixGe3uICDzNFUWxFoLJTQAOccyzo6MXZiQqwWJDLFi5qOSr6w2XcMyE+zd4wOyMoDiVM5fizmG8K3FzrqvGjwBcHcBdOQnavSijoj38DN25J9zhrid5BY4WlAAAAFQDxXrCyG52XCzn3FV4ej38wJBkomQAAAIBovGPJ4mP2P6BK8lHl0PPbktwQbWlpJ13oz6REJFDVcUi7vV26bX/BjQX+ohzZQzljdz1SpUbPc/8nuA4darYkVh91eBi307EN8IdxRHj2eBgp/ZG4yshIebG3WHrwJD/xUjjZ1MRfyDT1ermVi4LvjjPgWDxLZnPpMaR6S1nzgQAAAIEAj0Vd6DCWslvlsZ8+N53HWsqPi3gnx35JoLPz9Z2epkKIKqmEHav+93G3hdfztVa4I4t3phoPniQchYryF5+RNg8hqxKzjNtrIqUYCeuf2NJrksNsH7OZygPHZpqt4kTuwAGZxjxEGfAI0y8DhkU2ntp2LnzRnWH106BQBCmcXwo= fauxhai.local",
+      "host_rsa_public": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCtLCeqtqr/HbnORckw1ukdLhpfGoOPFi5/esKEokzTqq1gsgQ2V8emmyjfq1i6XXfRtSBxkdlHv/GWdP5wBTuE2G85MzBkVSQPvmwQN8lX/JMPEEtKXkeOo0o92/PiSmvY4eRsdF0mw40Uvg7jtE3f3fxj497kzh5fKtkrHnF4x9gXCbVdr3FqXJfggR5IJwAxToerbK7x/uRS+7YuZI9Pip3tt14nv9ezwXcuGb/tvjWOZINiFl8izVIFKi7sxfTX09p4NgamxRS7TD2Yd0jT8nEoF9UZTsgXcJ1kDSx7N7NxFfNfP6rCdOGRRz4gUhXtsUjG/XkxPeCwZ7A9VnOD fauxhai.local"
+    }
+  },
+  "macaddress": "11:11:11:11:11:11",
+  "network": {
+    "default_gateway": "10.0.0.1",
+    "default_interface": "eth0",
+    "eth0": {
+      "addresses": {
+        "10.0.0.2": {
+          "broadcast": "10.0.0.255",
+          "family": "inet",
+          "netmask": "255.255.255.0",
+          "prefixlen": "23",
+          "scope": "Global"
+        }
+      },
+      "arp": {
+        "10.0.0.1": "fe:ff:ff:ff:ff:ff"
+      },
+      "encapsulation": "Ethernet",
+      "flags": [
+        "BROADCAST",
+        "MULTICAST",
+        "UP",
+        "LOWER_UP"
+      ],
+      "mtu": "1500",
+      "number": "0",
+      "routes": {
+        "10.0.0.0/255": {
+          "scope": "link",
+          "src": "10.0.0.2"
+        }
+      },
+      "state": "up",
+      "type": "eth"
+    }
+  },
+  "uptime": "30 days 15 hours 07 minutes 30 seconds",
+  "uptime_seconds": 2646450
+}


### PR DESCRIPTION
This patch was built from a Fedora 18 Vagrant Box from
  http://static.stasiak.at/fedora-18-x86-2.box
