### PR TITLE
Add Gentoo 2.1 platform version mock data

### DIFF
--- a/lib/fauxhai/platforms/gentoo/2.1.json
+++ b/lib/fauxhai/platforms/gentoo/2.1.json
@@ -1,0 +1,401 @@
+{
+  "kernel": {
+    "name": "Linux",
+    "release": "3.6.11-gentoo",
+    "version": "#1 SMP Sat Feb 2 20:58:41 UTC 2013",
+    "machine": "x86_64",
+    "modules": {
+      "vboxsf": {
+        "size": "30548",
+        "refcount": "2"
+      },
+      "vboxguest": {
+        "size": "162490",
+        "refcount": "2"
+      },
+      "ablk_helper": {
+        "size": "1789",
+        "refcount": "0"
+      },
+      "cryptd": {
+        "size": "7454",
+        "refcount": "1"
+      }
+    },
+    "os": "GNU/Linux"
+  },
+  "os": "linux",
+  "os_version": "3.6.11-gentoo",
+  "platform": "gentoo",
+  "platform_version": "2.1",
+  "platform_family": "gentoo",
+  "dmi": {
+  },
+  "command": {
+    "ps": "ps -ef"
+  },
+  "ohai_time": 1371713160.2930377,
+  "filesystem": {
+    "rootfs": {
+      "kb_size": "9025908",
+      "kb_used": "2811072",
+      "kb_available": "5756344",
+      "percent_used": "33%",
+      "mount": "/",
+      "fs_type": "rootfs",
+      "mount_options": [
+        "rw"
+      ]
+    },
+    "udev": {
+      "kb_size": "10240",
+      "kb_used": "4",
+      "kb_available": "10236",
+      "percent_used": "1%",
+      "mount": "/dev",
+      "fs_type": "devtmpfs",
+      "mount_options": [
+        "rw",
+        "nosuid",
+        "relatime",
+        "size=10240k",
+        "nr_inodes=126912",
+        "mode=755"
+      ]
+    },
+    "/dev/sda4": {
+      "kb_size": "9025908",
+      "kb_used": "2811072",
+      "kb_available": "5756344",
+      "percent_used": "33%",
+      "mount": "/",
+      "fs_type": "ext4",
+      "mount_options": [
+        "rw",
+        "noatime",
+        "data=ordered"
+      ],
+      "uuid": "4f58d419-7271-4450-8c0e-37de35362ba8"
+    },
+    "tmpfs": {
+      "kb_size": "509816",
+      "kb_used": "284",
+      "kb_available": "509532",
+      "percent_used": "1%",
+      "mount": "/run",
+      "fs_type": "tmpfs",
+      "mount_options": [
+        "rw",
+        "nosuid",
+        "nodev",
+        "relatime",
+        "mode=755"
+      ]
+    },
+    "none": {
+      "kb_size": "509816",
+      "kb_used": "0",
+      "kb_available": "509816",
+      "percent_used": "0%",
+      "mount": "/dev/shm",
+      "fs_type": "tmpfs",
+      "mount_options": [
+        "rw",
+        "nosuid",
+        "nodev",
+        "noexec",
+        "relatime"
+      ]
+    },
+    "cgroup_root": {
+      "kb_size": "10240",
+      "kb_used": "0",
+      "kb_available": "10240",
+      "percent_used": "0%",
+      "mount": "/sys/fs/cgroup",
+      "fs_type": "tmpfs",
+      "mount_options": [
+        "rw",
+        "nosuid",
+        "nodev",
+        "noexec",
+        "relatime",
+        "size=10240k",
+        "mode=755"
+      ]
+    },
+    "/vagrant": {
+      "kb_size": "244277768",
+      "kb_used": "145714296",
+      "kb_available": "98563472",
+      "percent_used": "60%",
+      "mount": "/vagrant",
+      "fs_type": "vboxsf",
+      "mount_options": [
+        "uid=999",
+        "gid=246",
+        "rw"
+      ]
+    },
+    "/tmp/vagrant-chef-1/chef-solo-1/cookbooks": {
+      "kb_size": "244277768",
+      "kb_used": "145714296",
+      "kb_available": "98563472",
+      "percent_used": "60%",
+      "mount": "/tmp/vagrant-chef-1/chef-solo-1/cookbooks",
+      "fs_type": "vboxsf",
+      "mount_options": [
+        "uid=999",
+        "gid=246",
+        "rw"
+      ]
+    },
+    "proc": {
+      "mount": "/proc",
+      "fs_type": "proc",
+      "mount_options": [
+        "rw",
+        "nosuid",
+        "nodev",
+        "noexec",
+        "relatime"
+      ]
+    },
+    "devpts": {
+      "mount": "/dev/pts",
+      "fs_type": "devpts",
+      "mount_options": [
+        "rw",
+        "relatime",
+        "gid=5",
+        "mode=620"
+      ]
+    },
+    "sysfs": {
+      "mount": "/sys",
+      "fs_type": "sysfs",
+      "mount_options": [
+        "rw",
+        "nosuid",
+        "nodev",
+        "noexec",
+        "relatime"
+      ]
+    },
+    "debugfs": {
+      "mount": "/sys/kernel/debug",
+      "fs_type": "debugfs",
+      "mount_options": [
+        "rw",
+        "nosuid",
+        "nodev",
+        "noexec",
+        "relatime"
+      ]
+    },
+    "openrc": {
+      "mount": "/sys/fs/cgroup/openrc",
+      "fs_type": "cgroup",
+      "mount_options": [
+        "rw",
+        "nosuid",
+        "nodev",
+        "noexec",
+        "relatime",
+        "release_agent=/lib64/rc/sh/cgroup-release-agent.sh",
+        "name=openrc"
+      ]
+    },
+    "cpuset": {
+      "mount": "/sys/fs/cgroup/cpuset",
+      "fs_type": "cgroup",
+      "mount_options": [
+        "rw",
+        "nosuid",
+        "nodev",
+        "noexec",
+        "relatime",
+        "cpuset"
+      ]
+    },
+    "cpu": {
+      "mount": "/sys/fs/cgroup/cpu",
+      "fs_type": "cgroup",
+      "mount_options": [
+        "rw",
+        "nosuid",
+        "nodev",
+        "noexec",
+        "relatime",
+        "cpu"
+      ]
+    },
+    "cpuacct": {
+      "mount": "/sys/fs/cgroup/cpuacct",
+      "fs_type": "cgroup",
+      "mount_options": [
+        "rw",
+        "nosuid",
+        "nodev",
+        "noexec",
+        "relatime",
+        "cpuacct"
+      ]
+    },
+    "freezer": {
+      "mount": "/sys/fs/cgroup/freezer",
+      "fs_type": "cgroup",
+      "mount_options": [
+        "rw",
+        "nosuid",
+        "nodev",
+        "noexec",
+        "relatime",
+        "freezer"
+      ]
+    },
+    "binfmt_misc": {
+      "mount": "/proc/sys/fs/binfmt_misc",
+      "fs_type": "binfmt_misc",
+      "mount_options": [
+        "rw",
+        "noexec",
+        "nosuid",
+        "nodev"
+      ]
+    },
+    "/dev/sda1": {
+      "fs_type": "ext2",
+      "uuid": "71605135-acfe-42d0-9a59-a01c468da70d"
+    },
+    "/dev/sda3": {
+      "fs_type": "swap",
+      "uuid": "491c133d-4e65-461b-9d0b-563d30c0dc38"
+    }
+  },
+  "languages": {
+    "ruby": {
+      "platform": "x86_64-linux",
+      "version": "1.9.3",
+      "release_date": "2012-04-20",
+      "target": "x86_64-pc-linux-gnu",
+      "target_cpu": "x86_64",
+      "target_vendor": "pc",
+      "target_os": "linux",
+      "host": "x86_64-pc-linux-gnu",
+      "host_cpu": "x86_64",
+      "host_os": "linux-gnu",
+      "host_vendor": "pc",
+      "bin_dir": "/usr/local/bin",
+      "ruby_bin": "/usr/local/bin/ruby",
+      "gems_dir": "/usr/local/gems",
+      "gem_bin": "/usr/local/bin/gem"
+    }
+  },
+  "chef_packages": {
+    "chef": {
+      "version": "10.24.0",
+      "chef_root": "/usr/local/gems/chef-10.24.0/lib"
+    },
+    "ohai": {
+      "version": "6.16.0",
+      "ohai_root": "/usr/local/gems/ohai-6.16.0/lib/ohai"
+    }
+  },
+  "counters": {
+    "network": {
+      "interfaces": {
+        "eth0": {
+          "rx": {
+            "bytes": "0",
+            "packets": "0",
+            "errors": "0",
+            "drop": 0,
+            "overrun": 0,
+            "frame": 0,
+            "compressed": 0,
+            "multicast": 0
+          },
+          "tx": {
+            "bytes": "342",
+            "packets": "0",
+            "errors": "0",
+            "drop": 0,
+            "overrun": 0,
+            "collisions": "0",
+            "carrier": 0,
+            "compressed": 0
+          }
+        }
+      }
+    }
+  },
+  "current_user": "fauxhai",
+  "domain": "local",
+  "etc": {
+    "passwd": {
+      "fauxhai": {
+        "dir": "/home/fauxhai",
+        "gid": 0,
+        "uid": 0,
+        "shell": "/bin/bash",
+        "gecos": "Fauxhai"
+      }
+    },
+    "group": {
+      "fauxhai": {
+        "gid": 0,
+        "members": [
+          "fauxhai"
+        ]
+      }
+    }
+  },
+  "hostname": "Fauxhai",
+  "fqdn": "fauxhai.local",
+  "ipaddress": "10.0.0.2",
+  "keys": {
+    "ssh": {
+      "host_dsa_public": "ssh-dss AAAAB3NzaC1kc3MAAACBAJFo9BLAw4WKEs5hgipk5m423FzBsDXCZSMcC9ca/om/1VYzMqImixGe3uICDzNFUWxFoLJTQAOccyzo6MXZiQqwWJDLFi5qOSr6w2XcMyE+zd4wOyMoDiVM5fizmG8K3FzrqvGjwBcHcBdOQnavSijoj38DN25J9zhrid5BY4WlAAAAFQDxXrCyG52XCzn3FV4ej38wJBkomQAAAIBovGPJ4mP2P6BK8lHl0PPbktwQbWlpJ13oz6REJFDVcUi7vV26bX/BjQX+ohzZQzljdz1SpUbPc/8nuA4darYkVh91eBi307EN8IdxRHj2eBgp/ZG4yshIebG3WHrwJD/xUjjZ1MRfyDT1ermVi4LvjjPgWDxLZnPpMaR6S1nzgQAAAIEAj0Vd6DCWslvlsZ8+N53HWsqPi3gnx35JoLPz9Z2epkKIKqmEHav+93G3hdfztVa4I4t3phoPniQchYryF5+RNg8hqxKzjNtrIqUYCeuf2NJrksNsH7OZygPHZpqt4kTuwAGZxjxEGfAI0y8DhkU2ntp2LnzRnWH106BQBCmcXwo= fauxhai.local",
+      "host_rsa_public": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCtLCeqtqr/HbnORckw1ukdLhpfGoOPFi5/esKEokzTqq1gsgQ2V8emmyjfq1i6XXfRtSBxkdlHv/GWdP5wBTuE2G85MzBkVSQPvmwQN8lX/JMPEEtKXkeOo0o92/PiSmvY4eRsdF0mw40Uvg7jtE3f3fxj497kzh5fKtkrHnF4x9gXCbVdr3FqXJfggR5IJwAxToerbK7x/uRS+7YuZI9Pip3tt14nv9ezwXcuGb/tvjWOZINiFl8izVIFKi7sxfTX09p4NgamxRS7TD2Yd0jT8nEoF9UZTsgXcJ1kDSx7N7NxFfNfP6rCdOGRRz4gUhXtsUjG/XkxPeCwZ7A9VnOD fauxhai.local"
+    }
+  },
+  "macaddress": "11:11:11:11:11:11",
+  "network": {
+    "default_gateway": "10.0.0.1",
+    "default_interface": "eth0",
+    "eth0": {
+      "addresses": {
+        "10.0.0.2": {
+          "broadcast": "10.0.0.255",
+          "family": "inet",
+          "netmask": "255.255.255.0",
+          "prefixlen": "23",
+          "scope": "Global"
+        }
+      },
+      "arp": {
+        "10.0.0.1": "fe:ff:ff:ff:ff:ff"
+      },
+      "encapsulation": "Ethernet",
+      "flags": [
+        "BROADCAST",
+        "MULTICAST",
+        "UP",
+        "LOWER_UP"
+      ],
+      "mtu": "1500",
+      "number": "0",
+      "routes": {
+        "10.0.0.0/255": {
+          "scope": "link",
+          "src": "10.0.0.2"
+        }
+      },
+      "state": "up",
+      "type": "eth"
+    }
+  },
+  "uptime": "30 days 15 hours 07 minutes 30 seconds",
+  "uptime_seconds": 2646450
+}


### PR DESCRIPTION
Thanks so much for building this tool. It's super useful with ChefSpec.

Hopefully I can use it with Gentoo now ;-)
