### PR TITLE
Adds perl, php, python to the language parser. Refs #39

### DIFF
--- a/lib/fauxhai/runner.rb
+++ b/lib/fauxhai/runner.rb
@@ -153,6 +153,18 @@ module Fauxhai
           'gem_bin' => gem_bin,
           'gems_dir' => gems_dir,
           'ruby_bin' => ruby_bin,
+        }),
+        'perl' => @system.data['languages']['perl'].merge({
+          'archname' => archname,
+          'version' => version,
+        }),
+        'php' => @system.data['languages']['php'].merge({
+          'builddate' => builddate,
+          'version' => version,
+        }),
+        'python' => @system.data['languages']['python'].merge({
+          'builddate' => builddate,
+          'version' => version,
         })
       }
     end


### PR DESCRIPTION
This follows the attributes that ohai outputs for the particular language.

See these for the ohai code:
- https://github.com/opscode/ohai/blob/master/lib/ohai/plugins/perl.rb
- https://github.com/opscode/ohai/blob/master/lib/ohai/plugins/php.rb
- https://github.com/opscode/ohai/blob/master/lib/ohai/plugins/python.rb

This is the direction I was hoping this would go. If accepted, I will add others - all the related non-node-specific details that ohai reports.
