### PR TITLE
New JSON must be massaged

### DIFF
--- a/README.md
+++ b/README.md
@@ -178,7 +178,7 @@ Fauxhai is community-maintained and updated. Aside from the initial files, all o
 2. Install chef, ohai, and fauxhai
 3. Run the following at the command line:
 
-        sudo fauxhai > /tmp/fauxhai.json
+        sudo fauxhai | sed '/ WARN: /D' > /tmp/fauxhai.json
 
 4. This will create a file `/tmp/fauxhai.json`
 5. Copy the contents of this file to your local development machine (using scp or sftp, for example)


### PR DESCRIPTION
I wasted 2 hours of my life because 'sudo fauxhai > /tmp/fauxhai.json' wrote out a JSON file that included the initial line:

```
[2013-10-10T10:43:19-04:00] WARN: unable to detect ip6address
```

:(

Since this clearly should have gone to stderr (I've opened an issue in Opscode JIRA for this re: ohai), and not stdout into my file, it silently produces an invalid JSON file.

The updated instructions are at least a _little_ better now as they indicate you should pipe to `sed '/ WARN: /D'`
