### PR TITLE
Clarify contribution instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -178,9 +178,11 @@ Fauxhai is community-maintained and updated. Aside from the initial files, all o
 2. Install chef, ohai, and fauxhai
 3. Run the following at the command line:
 
-        sudo fauxhai > /tmp/fauxhai.json
+        UNIX/Linux:  sudo fauxhai > /tmp/fauxhai.json
 
-4. This will create a file `/tmp/fauxhai.json`
+        Windows:     fauxhai > C:\Someplace\fauxhai.json
+
+4. This will create a file in JSON format at the path indicated. You should examine it (via whatever means you choose) to ensure that it looks like valid JSON.
 5. Copy the contents of this file to your local development machine (using scp or sftp, for example)
 6. Clone and `bundle` this repo:
 


### PR DESCRIPTION
Since the previous "better than it was before..." PR of mine showed the usage of sed, and Seth pointed out w/o merge that "Sed doesn't exist on Windows", I have gone through hoops to:
1. Close the other PR since it was made via "Edit" on GH
2. Change the _EXISTING UNIX/Linux-specific instructions mentioning sudo_ (_AHEM_) to show how to do things on both Windows and UNIX/Linux.
3. Kept sed out of the information and suggested people examine the JSON file however they see fit (but to examine it).

Hopefully this will satiate everyone's extremely stringent requirements for utmost precision community contributions to a README prior to merge, in order to save others the 2 hours I wasted chasing this down.

:|
