### PR TITLE
add empty lsb for opensuse-12.3 platform

### DIFF
--- a/lib/fauxhai/platforms/opensuse/12.3.json
+++ b/lib/fauxhai/platforms/opensuse/12.3.json
@@ -458,6 +458,9 @@
     }
   },
   "current_user": "fauxhai",
+  "lsb": {
+  
+  },
   "domain": "local",
   "etc": {
     "passwd": {


### PR DESCRIPTION
this avoid some problems such as:

NoMethodError
------------- undefined method `[]' for nil:NilClass

...

26>> default['erlang']['esl']['lsb_codename'] = node['lsb']['codename']

from the erlang cookbook
