### PR TITLE
Fix error under bundler 1.5.0.rc.1

### DIFF
--- a/fauxhai.gemspec
+++ b/fauxhai.gemspec
@@ -9,7 +9,7 @@ Gem::Specification.new do |spec|
   spec.description   = %q{Easily mock out ohai data}
   spec.summary       = %q{Fauxhai provides an easy way to mock out your ohai data for testing with chefspec!}
   spec.homepage      = 'https://github.com/customink/fauxhai'
-  s.license          = 'MIT'
+  spec.license       = 'MIT'
 
   spec.required_ruby_version = '>= 1.9'
 


### PR DESCRIPTION
Running bundle using bundler 1.5.0.rc.1 is throwing an error.

```
There was a NameError while loading fauxhai.gemspec:
   undefined local variable or method `s' for main:Object from
     /Users/doug/Code/open_source/fauxhai/fauxhai.gemspec:12:in `block in
     <main>'
```

This error also affects downstream projects that try to use "bundle outdated".
