### PR TITLE
Add fedora 19 to fauxhai

### DIFF
--- a/lib/fauxhai/platforms/fedora/19.json
+++ b/lib/fauxhai/platforms/fedora/19.json
@@ -1,0 +1,471 @@
+{
+  "kernel": {
+    "name": "Linux",
+    "release": "3.9.5-301.fc19.x86_64",
+    "version": "#1 SMP Tue Jun 11 19:39:38 UTC 2013",
+    "machine": "x86_64",
+    "modules": {
+      "nf_conntrack_netbios_ns": {
+        "size": "12665",
+        "refcount": "0"
+      },
+      "nf_conntrack_broadcast": {
+        "size": "12527",
+        "refcount": "1"
+      },
+      "ipt_MASQUERADE": {
+        "size": "12880",
+        "refcount": "1"
+      },
+      "ip6table_nat": {
+        "size": "13015",
+        "refcount": "1"
+      },
+      "nf_nat_ipv6": {
+        "size": "13213",
+        "refcount": "1"
+      },
+      "ip6table_mangle": {
+        "size": "12700",
+        "refcount": "1"
+      },
+      "ip6t_REJECT": {
+        "size": "12939",
+        "refcount": "2"
+      },
+      "nf_conntrack_ipv6": {
+        "size": "18782",
+        "refcount": "24"
+      },
+      "nf_defrag_ipv6": {
+        "size": "18205",
+        "refcount": "1"
+      },
+      "iptable_nat": {
+        "size": "13011",
+        "refcount": "1"
+      },
+      "nf_nat_ipv4": {
+        "size": "13199",
+        "refcount": "1"
+      },
+      "nf_nat": {
+        "size": "25743",
+        "refcount": "5"
+      },
+      "iptable_mangle": {
+        "size": "12695",
+        "refcount": "1"
+      },
+      "nf_conntrack_ipv4": {
+        "size": "14808",
+        "refcount": "20"
+      },
+      "nf_defrag_ipv4": {
+        "size": "12673",
+        "refcount": "1"
+      },
+      "vboxsf": {
+        "size": "39687",
+        "refcount": "0"
+      },
+      "xt_conntrack": {
+        "size": "12760",
+        "refcount": "42"
+      },
+      "nf_conntrack": {
+        "size": "86376",
+        "refcount": "11"
+      },
+      "ebtable_filter": {
+        "size": "12827",
+        "refcount": "0"
+      },
+      "ebtables": {
+        "size": "30758",
+        "refcount": "1"
+      },
+      "ip6table_filter": {
+        "size": "12815",
+        "refcount": "1"
+      },
+      "ip6_tables": {
+        "size": "26808",
+        "refcount": "3"
+      },
+      "vboxvideo": {
+        "size": "12658",
+        "refcount": "0"
+      },
+      "drm": {
+        "size": "268517",
+        "refcount": "1"
+      },
+      "e1000": {
+        "size": "145118",
+        "refcount": "0"
+      },
+      "ppdev": {
+        "size": "17635",
+        "refcount": "0"
+      },
+      "i2c_piix4": {
+        "size": "22106",
+        "refcount": "0"
+      },
+      "i2c_core": {
+        "size": "34059",
+        "refcount": "2"
+      },
+      "microcode": {
+        "size": "23403",
+        "refcount": "0"
+      },
+      "vboxguest": {
+        "size": "223500",
+        "refcount": "2"
+      },
+      "parport_pc": {
+        "size": "28048",
+        "refcount": "0"
+      },
+      "parport": {
+        "size": "40425",
+        "refcount": "2"
+      }
+    },
+    "os": "GNU/Linux"
+  },
+  "os": "linux",
+  "os_version": "3.9.5-301.fc19.x86_64",
+  "lsb": {
+  },
+  "platform": "fedora",
+  "platform_version": "19",
+  "platform_family": "fedora",
+  "dmi": {
+  },
+  "ohai_time": 1393946212.9141555,
+  "command": {
+    "ps": "ps -ef"
+  },
+  "filesystem": {
+    "/dev/mapper/vg_vagrant-lv_root": {
+      "kb_size": "39572896",
+      "kb_used": "1473440",
+      "kb_available": "36082588",
+      "percent_used": "4%",
+      "mount": "/",
+      "fs_type": "ext4",
+      "mount_options": [
+        "rw",
+        "relatime",
+        "data=ordered"
+      ],
+      "uuid": "65169bc1-9a73-4789-a030-bd816fa219cf"
+    },
+    "devtmpfs": {
+      "kb_size": "502256",
+      "kb_used": "0",
+      "kb_available": "502256",
+      "percent_used": "0%",
+      "mount": "/dev",
+      "fs_type": "devtmpfs",
+      "mount_options": [
+        "rw",
+        "nosuid",
+        "size=502256k",
+        "nr_inodes=125564",
+        "mode=755"
+      ]
+    },
+    "tmpfs": {
+      "kb_size": "509816",
+      "kb_used": "8",
+      "kb_available": "509808",
+      "percent_used": "1%",
+      "mount": "/tmp",
+      "fs_type": "tmpfs",
+      "mount_options": [
+        "rw"
+      ]
+    },
+    "/dev/sda1": {
+      "kb_size": "487652",
+      "kb_used": "62785",
+      "kb_available": "399267",
+      "percent_used": "14%",
+      "mount": "/boot",
+      "fs_type": "ext4",
+      "mount_options": [
+        "rw",
+        "relatime",
+        "data=ordered"
+      ],
+      "uuid": "5bd69298-3ef2-4f30-b3a6-7adb88967905"
+    },
+    "proc": {
+      "mount": "/proc",
+      "fs_type": "proc",
+      "mount_options": [
+        "rw",
+        "nosuid",
+        "nodev",
+        "noexec",
+        "relatime"
+      ]
+    },
+    "sysfs": {
+      "mount": "/sys",
+      "fs_type": "sysfs",
+      "mount_options": [
+        "rw",
+        "nosuid",
+        "nodev",
+        "noexec",
+        "relatime"
+      ]
+    },
+    "securityfs": {
+      "mount": "/sys/kernel/security",
+      "fs_type": "securityfs",
+      "mount_options": [
+        "rw",
+        "nosuid",
+        "nodev",
+        "noexec",
+        "relatime"
+      ]
+    },
+    "devpts": {
+      "mount": "/dev/pts",
+      "fs_type": "devpts",
+      "mount_options": [
+        "rw",
+        "nosuid",
+        "noexec",
+        "relatime",
+        "gid=5",
+        "mode=620",
+        "ptmxmode=000"
+      ]
+    },
+    "cgroup": {
+      "mount": "/sys/fs/cgroup/perf_event",
+      "fs_type": "cgroup",
+      "mount_options": [
+        "rw",
+        "nosuid",
+        "nodev",
+        "noexec",
+        "relatime",
+        "perf_event"
+      ]
+    },
+    "pstore": {
+      "mount": "/sys/fs/pstore",
+      "fs_type": "pstore",
+      "mount_options": [
+        "rw",
+        "nosuid",
+        "nodev",
+        "noexec",
+        "relatime"
+      ]
+    },
+    "systemd-1": {
+      "mount": "/proc/sys/fs/binfmt_misc",
+      "fs_type": "autofs",
+      "mount_options": [
+        "rw",
+        "relatime",
+        "fd=29",
+        "pgrp=1",
+        "timeout=300",
+        "minproto=5",
+        "maxproto=5",
+        "direct"
+      ]
+    },
+    "mqueue": {
+      "mount": "/dev/mqueue",
+      "fs_type": "mqueue",
+      "mount_options": [
+        "rw",
+        "relatime"
+      ]
+    },
+    "hugetlbfs": {
+      "mount": "/dev/hugepages",
+      "fs_type": "hugetlbfs",
+      "mount_options": [
+        "rw",
+        "relatime"
+      ]
+    },
+    "debugfs": {
+      "mount": "/sys/kernel/debug",
+      "fs_type": "debugfs",
+      "mount_options": [
+        "rw",
+        "relatime"
+      ]
+    },
+    "configfs": {
+      "mount": "/sys/kernel/config",
+      "fs_type": "configfs",
+      "mount_options": [
+        "rw",
+        "relatime"
+      ]
+    },
+    "/dev/sda2": {
+      "fs_type": "LVM2_member",
+      "uuid": "B6c1BT-c9rZ-mx5w-5vcj-fwRJ-psGi-L2uQKs"
+    },
+    "/dev/mapper/vg_vagrant-lv_swap": {
+      "fs_type": "swap",
+      "uuid": "37593c05-844a-4674-817b-9ecaa5c26dc6"
+    },
+    "rootfs": {
+      "mount": "/",
+      "fs_type": "rootfs",
+      "mount_options": [
+        "rw"
+      ]
+    }
+  },
+  "languages": {
+    "ruby": {
+      "platform": "x86_64-linux",
+      "version": "2.0.0",
+      "release_date": "2013-11-22",
+      "target": "x86_64-redhat-linux-gnu",
+      "target_cpu": "x86_64",
+      "target_vendor": "redhat",
+      "target_os": "linux",
+      "host": "x86_64-redhat-linux-gnu",
+      "host_cpu": "x86_64",
+      "host_os": "linux-gnu",
+      "host_vendor": "redhat",
+      "bin_dir": "/usr/local/bin",
+      "ruby_bin": "/usr/local/bin/ruby",
+      "gems_dir": "/usr/local/gems",
+      "gem_bin": "/usr/local/bin/gem"
+    }
+  },
+  "chef_packages": {
+    "chef": {
+      "version": "11.10.4",
+      "chef_root": "/usr/local/gems/chef-11.10.4/lib"
+    },
+    "ohai": {
+      "version": "6.20.0",
+      "ohai_root": "/usr/local/gems/ohai-6.20.0/lib/ohai"
+    }
+  },
+  "counters": {
+    "network": {
+      "interfaces": {
+        "eth0": {
+          "rx": {
+            "bytes": "0",
+            "packets": "0",
+            "errors": "0",
+            "drop": 0,
+            "overrun": 0,
+            "frame": 0,
+            "compressed": 0,
+            "multicast": 0
+          },
+          "tx": {
+            "bytes": "342",
+            "packets": "0",
+            "errors": "0",
+            "drop": 0,
+            "overrun": 0,
+            "collisions": "0",
+            "carrier": 0,
+            "compressed": 0
+          }
+        }
+      }
+    }
+  },
+  "current_user": "fauxhai",
+  "domain": "local",
+  "etc": {
+    "passwd": {
+      "fauxhai": {
+        "dir": "/home/fauxhai",
+        "gid": 0,
+        "uid": 0,
+        "shell": "/bin/bash",
+        "gecos": "Fauxhai"
+      }
+    },
+    "group": {
+      "fauxhai": {
+        "gid": 0,
+        "members": [
+          "fauxhai"
+        ]
+      }
+    }
+  },
+  "hostname": "Fauxhai",
+  "fqdn": "fauxhai.local",
+  "ipaddress": "10.0.0.2",
+  "keys": {
+    "ssh": {
+      "host_dsa_public": "ssh-dss AAAAB3NzaC1kc3MAAACBAJFo9BLAw4WKEs5hgipk5m423FzBsDXCZSMcC9ca/om/1VYzMqImixGe3uICDzNFUWxFoLJTQAOccyzo6MXZiQqwWJDLFi5qOSr6w2XcMyE+zd4wOyMoDiVM5fizmG8K3FzrqvGjwBcHcBdOQnavSijoj38DN25J9zhrid5BY4WlAAAAFQDxXrCyG52XCzn3FV4ej38wJBkomQAAAIBovGPJ4mP2P6BK8lHl0PPbktwQbWlpJ13oz6REJFDVcUi7vV26bX/BjQX+ohzZQzljdz1SpUbPc/8nuA4darYkVh91eBi307EN8IdxRHj2eBgp/ZG4yshIebG3WHrwJD/xUjjZ1MRfyDT1ermVi4LvjjPgWDxLZnPpMaR6S1nzgQAAAIEAj0Vd6DCWslvlsZ8+N53HWsqPi3gnx35JoLPz9Z2epkKIKqmEHav+93G3hdfztVa4I4t3phoPniQchYryF5+RNg8hqxKzjNtrIqUYCeuf2NJrksNsH7OZygPHZpqt4kTuwAGZxjxEGfAI0y8DhkU2ntp2LnzRnWH106BQBCmcXwo= fauxhai.local",
+      "host_rsa_public": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCtLCeqtqr/HbnORckw1ukdLhpfGoOPFi5/esKEokzTqq1gsgQ2V8emmyjfq1i6XXfRtSBxkdlHv/GWdP5wBTuE2G85MzBkVSQPvmwQN8lX/JMPEEtKXkeOo0o92/PiSmvY4eRsdF0mw40Uvg7jtE3f3fxj497kzh5fKtkrHnF4x9gXCbVdr3FqXJfggR5IJwAxToerbK7x/uRS+7YuZI9Pip3tt14nv9ezwXcuGb/tvjWOZINiFl8izVIFKi7sxfTX09p4NgamxRS7TD2Yd0jT8nEoF9UZTsgXcJ1kDSx7N7NxFfNfP6rCdOGRRz4gUhXtsUjG/XkxPeCwZ7A9VnOD fauxhai.local"
+    }
+  },
+  "macaddress": "11:11:11:11:11:11",
+  "network": {
+    "default_gateway": "10.0.0.1",
+    "default_interface": "eth0",
+    "settings": {
+    },
+    "interfaces": {
+      "eth0": {
+        "addresses": {
+          "10.0.0.2": {
+            "broadcast": "10.0.0.255",
+            "family": "inet",
+            "netmask": "255.255.255.0",
+            "prefixlen": "23",
+            "scope": "Global"
+          }
+        },
+        "arp": {
+          "10.0.0.1": "fe:ff:ff:ff:ff:ff"
+        },
+        "encapsulation": "Ethernet",
+        "flags": [
+          "BROADCAST",
+          "MULTICAST",
+          "UP",
+          "LOWER_UP"
+        ],
+        "mtu": "1500",
+        "number": "0",
+        "routes": {
+          "10.0.0.0/255": {
+            "scope": "link",
+            "src": "10.0.0.2"
+          }
+        },
+        "state": "up",
+        "type": "eth"
+      }
+    }
+  },
+  "uptime": "30 days 15 hours 07 minutes 30 seconds",
+  "uptime_seconds": 2646450,
+  "cpu": {
+    "real": 1,
+    "total": 1
+  }
+}


### PR DESCRIPTION
The fedora 18 already in fauxhai is 32-bit.  This one is 64-bit.  I can make a different pull request with 32-bit fedora 19 if that's preferred.
