### PR TITLE
Improve languages ruby data for chefspec

### DIFF
--- a/lib/fauxhai/platforms/chefspec/0.6.1.json
+++ b/lib/fauxhai/platforms/chefspec/0.6.1.json
@@ -6,7 +6,12 @@
   "ipaddress": "127.0.0.1",
   "hostname": "chefspec",
   "languages": {
-    "ruby": "/usr/somewhere"
+    "ruby": {
+      "bin_dir": "/usr/local/bin",
+      "ruby_bin": "/usr/local/bin/ruby",
+      "gems_dir": "/usr/local/gems",
+      "gem_bin": "/usr/local/bin/gem"
+    }
   },
   "kernel": {
     "machine": "i386"


### PR DESCRIPTION
Some cookbooks reference the languages/ruby attributes (e.g. the chef cookbook https://github.com/opscode-cookbooks/chef/blob/master/attributes/server_proxy.rb#L23). This change adds a more reasonable set of attributes for the ChefSpec platform so that the attributes no longer need to specified in tests.
