### PR TITLE
platform_family was null due to ohai bug

### DIFF
--- a/lib/fauxhai/platforms/solaris2/5.11.json
+++ b/lib/fauxhai/platforms/solaris2/5.11.json
@@ -1038,7 +1038,7 @@
   "os_version": "5.11",
   "platform_version": "5.11",
   "platform_build": "11.1",
-  "platform_family": null,
+  "platform_family": "solaris2",
   "filesystem": {
     "rpool/ROOT/solaris": {
       "kb_size": "15095808",


### PR DESCRIPTION
I've fixed the bug upstream, but this data must have been collected with the broken ohai.
