### PR TITLE
Add platform_family to chefspec data set

### DIFF
--- a/lib/fauxhai/platforms/chefspec/0.6.1.json
+++ b/lib/fauxhai/platforms/chefspec/0.6.1.json
@@ -1,6 +1,7 @@
 {
   "os": "chefspec",
   "os_version": "0.6.1",
+  "platform_family": "chefspec",
   "fqdn": "chefspec.local",
   "domain": "local",
   "ipaddress": "127.0.0.1",


### PR DESCRIPTION
I am running specs through the `build-essential` and it checks the node by platform_family. Missing the `platform_family` makes it an unclear error message to those troubleshooting the problem.

I sent a pull request to `build-essential` to support the `chefspec` platform_family so that it will not show this error message and instead log a debug message that it was loaded.
