### PR TITLE
add support for redhat 7.0

### DIFF
--- a/lib/fauxhai/platforms/redhat/7.0.json
+++ b/lib/fauxhai/platforms/redhat/7.0.json
@@ -1,0 +1,847 @@
+{
+  "filesystem": {
+    "/dev/mapper/rhel-root": {
+      "kb_size": "7022592",
+      "kb_used": "3882112",
+      "kb_available": "3140480",
+      "percent_used": "56%",
+      "mount": "/",
+      "fs_type": "xfs",
+      "mount_options": [
+        "rw",
+        "relatime",
+        "seclabel",
+        "attr2",
+        "inode64",
+        "noquota"
+      ],
+      "uuid": "d4d9c899-4b67-41b0-9dc0-6a1ad51273ae"
+    },
+    "devtmpfs": {
+      "kb_size": "933900",
+      "kb_used": "0",
+      "kb_available": "933900",
+      "percent_used": "0%",
+      "mount": "/dev",
+      "fs_type": "devtmpfs",
+      "mount_options": [
+        "rw",
+        "nosuid",
+        "seclabel",
+        "size=933900k",
+        "nr_inodes=233475",
+        "mode=755"
+      ]
+    },
+    "tmpfs": {
+      "kb_size": "942792",
+      "kb_used": "0",
+      "kb_available": "942792",
+      "percent_used": "0%",
+      "mount": "/sys/fs/cgroup",
+      "fs_type": "tmpfs",
+      "mount_options": [
+        "rw",
+        "nosuid",
+        "nodev",
+        "noexec",
+        "seclabel",
+        "mode=755"
+      ]
+    },
+    "/dev/sda1": {
+      "kb_size": "508588",
+      "kb_used": "161188",
+      "kb_available": "347400",
+      "percent_used": "32%",
+      "mount": "/boot",
+      "fs_type": "xfs",
+      "mount_options": [
+        "rw",
+        "relatime",
+        "seclabel",
+        "attr2",
+        "inode64",
+        "noquota"
+      ],
+      "uuid": "d7500c4e-d8e7-484a-bf61-065fbb50a7f0"
+    },
+    "proc": {
+      "mount": "/proc",
+      "fs_type": "proc",
+      "mount_options": [
+        "rw",
+        "nosuid",
+        "nodev",
+        "noexec",
+        "relatime"
+      ]
+    },
+    "sysfs": {
+      "mount": "/sys",
+      "fs_type": "sysfs",
+      "mount_options": [
+        "rw",
+        "nosuid",
+        "nodev",
+        "noexec",
+        "relatime",
+        "seclabel"
+      ]
+    },
+    "securityfs": {
+      "mount": "/sys/kernel/security",
+      "fs_type": "securityfs",
+      "mount_options": [
+        "rw",
+        "nosuid",
+        "nodev",
+        "noexec",
+        "relatime"
+      ]
+    },
+    "devpts": {
+      "mount": "/dev/pts",
+      "fs_type": "devpts",
+      "mount_options": [
+        "rw",
+        "nosuid",
+        "noexec",
+        "relatime",
+        "seclabel",
+        "gid=5",
+        "mode=620",
+        "ptmxmode=000"
+      ]
+    },
+    "cgroup": {
+      "mount": "/sys/fs/cgroup/hugetlb",
+      "fs_type": "cgroup",
+      "mount_options": [
+        "rw",
+        "nosuid",
+        "nodev",
+        "noexec",
+        "relatime",
+        "hugetlb"
+      ]
+    },
+    "pstore": {
+      "mount": "/sys/fs/pstore",
+      "fs_type": "pstore",
+      "mount_options": [
+        "rw",
+        "nosuid",
+        "nodev",
+        "noexec",
+        "relatime"
+      ]
+    },
+    "configfs": {
+      "mount": "/sys/kernel/config",
+      "fs_type": "configfs",
+      "mount_options": [
+        "rw",
+        "relatime"
+      ]
+    },
+    "selinuxfs": {
+      "mount": "/sys/fs/selinux",
+      "fs_type": "selinuxfs",
+      "mount_options": [
+        "rw",
+        "relatime"
+      ]
+    },
+    "systemd-1": {
+      "mount": "/proc/sys/fs/binfmt_misc",
+      "fs_type": "autofs",
+      "mount_options": [
+        "rw",
+        "relatime",
+        "fd=32",
+        "pgrp=1",
+        "timeout=300",
+        "minproto=5",
+        "maxproto=5",
+        "direct"
+      ]
+    },
+    "debugfs": {
+      "mount": "/sys/kernel/debug",
+      "fs_type": "debugfs",
+      "mount_options": [
+        "rw",
+        "relatime"
+      ]
+    },
+    "mqueue": {
+      "mount": "/dev/mqueue",
+      "fs_type": "mqueue",
+      "mount_options": [
+        "rw",
+        "relatime",
+        "seclabel"
+      ]
+    },
+    "hugetlbfs": {
+      "mount": "/dev/hugepages",
+      "fs_type": "hugetlbfs",
+      "mount_options": [
+        "rw",
+        "relatime",
+        "seclabel"
+      ]
+    },
+    "sunrpc": {
+      "mount": "/proc/fs/nfsd",
+      "fs_type": "nfsd",
+      "mount_options": [
+        "rw",
+        "relatime"
+      ]
+    },
+    "fusectl": {
+      "mount": "/sys/fs/fuse/connections",
+      "fs_type": "fusectl",
+      "mount_options": [
+        "rw",
+        "relatime"
+      ]
+    },
+    "gvfsd-fuse": {
+      "mount": "/run/user/1000/gvfs",
+      "fs_type": "fuse.gvfsd-fuse",
+      "mount_options": [
+        "rw",
+        "nosuid",
+        "nodev",
+        "relatime",
+        "user_id=1000",
+        "group_id=1000"
+      ]
+    },
+    "/dev/block/8:2": {
+      "fs_type": "LVM2_member"
+    },
+    "/dev/block/253:0": {
+      "fs_type": "xfs"
+    },
+    "/dev/block/8:1": {
+      "fs_type": "xfs"
+    },
+    "/dev/block/253:1": {
+      "fs_type": "swap"
+    },
+    "/dev/sda2": {
+      "uuid": "BM82d2-iJ6i-wC2t-QWS1-r1y4-QDUj-GnTnYe"
+    },
+    "/dev/mapper/rhel-swap": {
+      "uuid": "67ef1bbe-921e-4d4d-9625-19bd9060cb6c"
+    },
+    "rootfs": {
+      "mount": "/",
+      "fs_type": "rootfs",
+      "mount_options": [
+        "rw"
+      ]
+    }
+  },
+  "kernel": {
+    "name": "Linux",
+    "release": "3.10.0-123.1.2.el7.x86_64",
+    "version": "#1 SMP Wed Jun 4 15:22:01 EDT 2014",
+    "machine": "x86_64",
+    "os": "GNU/Linux",
+    "modules": {
+      "tcp_lp": {
+        "size": "12663",
+        "refcount": "0"
+      },
+      "bnep": {
+        "size": "19704",
+        "refcount": "2"
+      },
+      "bluetooth": {
+        "size": "372662",
+        "refcount": "7"
+      },
+      "rfkill": {
+        "size": "26536",
+        "refcount": "3"
+      },
+      "fuse": {
+        "size": "87661",
+        "refcount": "3"
+      },
+      "ip6t_rpfilter": {
+        "size": "12546",
+        "refcount": "1"
+      },
+      "ip6t_REJECT": {
+        "size": "12939",
+        "refcount": "2"
+      },
+      "ipt_REJECT": {
+        "size": "12541",
+        "refcount": "2"
+      },
+      "xt_conntrack": {
+        "size": "12760",
+        "refcount": "7"
+      },
+      "ebtable_nat": {
+        "size": "12807",
+        "refcount": "0"
+      },
+      "ebtable_broute": {
+        "size": "12731",
+        "refcount": "0"
+      },
+      "bridge": {
+        "size": "110196",
+        "refcount": "1"
+      },
+      "stp": {
+        "size": "12976",
+        "refcount": "1"
+      },
+      "llc": {
+        "size": "14552",
+        "refcount": "2"
+      },
+      "ebtable_filter": {
+        "size": "12827",
+        "refcount": "0"
+      },
+      "ebtables": {
+        "size": "30913",
+        "refcount": "3"
+      },
+      "ip6table_nat": {
+        "size": "13015",
+        "refcount": "1"
+      },
+      "nf_conntrack_ipv6": {
+        "size": "18738",
+        "refcount": "5"
+      },
+      "nf_defrag_ipv6": {
+        "size": "34651",
+        "refcount": "1"
+      },
+      "nf_nat_ipv6": {
+        "size": "13279",
+        "refcount": "1"
+      },
+      "ip6table_mangle": {
+        "size": "12700",
+        "refcount": "1"
+      },
+      "ip6table_security": {
+        "size": "12710",
+        "refcount": "1"
+      },
+      "ip6table_raw": {
+        "size": "12683",
+        "refcount": "1"
+      },
+      "ip6table_filter": {
+        "size": "12815",
+        "refcount": "1"
+      },
+      "ip6_tables": {
+        "size": "27025",
+        "refcount": "5"
+      },
+      "iptable_nat": {
+        "size": "13011",
+        "refcount": "1"
+      },
+      "nf_conntrack_ipv4": {
+        "size": "14862",
+        "refcount": "4"
+      },
+      "nf_defrag_ipv4": {
+        "size": "12729",
+        "refcount": "1"
+      },
+      "nf_nat_ipv4": {
+        "size": "13263",
+        "refcount": "1"
+      },
+      "nf_nat": {
+        "size": "21798",
+        "refcount": "4"
+      },
+      "nf_conntrack": {
+        "size": "101024",
+        "refcount": "8"
+      },
+      "iptable_mangle": {
+        "size": "12695",
+        "refcount": "1"
+      },
+      "iptable_security": {
+        "size": "12705",
+        "refcount": "1"
+      },
+      "iptable_raw": {
+        "size": "12678",
+        "refcount": "1"
+      },
+      "iptable_filter": {
+        "size": "12810",
+        "refcount": "1"
+      },
+      "ip_tables": {
+        "size": "27239",
+        "refcount": "5"
+      },
+      "sg": {
+        "size": "36533",
+        "refcount": "0"
+      },
+      "ppdev": {
+        "size": "17671",
+        "refcount": "0"
+      },
+      "snd_intel8x0": {
+        "size": "38153",
+        "refcount": "3"
+      },
+      "snd_ac97_codec": {
+        "size": "130236",
+        "refcount": "1"
+      },
+      "ac97_bus": {
+        "size": "12730",
+        "refcount": "1"
+      },
+      "snd_seq": {
+        "size": "61519",
+        "refcount": "0"
+      },
+      "snd_seq_device": {
+        "size": "14497",
+        "refcount": "1"
+      },
+      "snd_pcm": {
+        "size": "97511",
+        "refcount": "2"
+      },
+      "snd_page_alloc": {
+        "size": "18710",
+        "refcount": "2"
+      },
+      "snd_timer": {
+        "size": "29482",
+        "refcount": "2"
+      },
+      "parport_pc": {
+        "size": "28165",
+        "refcount": "0"
+      },
+      "pcspkr": {
+        "size": "12718",
+        "refcount": "0"
+      },
+      "serio_raw": {
+        "size": "13462",
+        "refcount": "0"
+      },
+      "parport": {
+        "size": "42348",
+        "refcount": "2"
+      },
+      "snd": {
+        "size": "74645",
+        "refcount": "12"
+      },
+      "i2c_piix4": {
+        "size": "22106",
+        "refcount": "0"
+      },
+      "soundcore": {
+        "size": "15047",
+        "refcount": "1"
+      },
+      "mperf": {
+        "size": "12667",
+        "refcount": "0"
+      },
+      "i2c_core": {
+        "size": "40325",
+        "refcount": "1"
+      },
+      "nfsd": {
+        "size": "284378",
+        "refcount": "1"
+      },
+      "auth_rpcgss": {
+        "size": "59368",
+        "refcount": "1"
+      },
+      "nfs_acl": {
+        "size": "12837",
+        "refcount": "1"
+      },
+      "lockd": {
+        "size": "93977",
+        "refcount": "1"
+      },
+      "sunrpc": {
+        "size": "293453",
+        "refcount": "5"
+      },
+      "uinput": {
+        "size": "17625",
+        "refcount": "0"
+      },
+      "xfs": {
+        "size": "914152",
+        "refcount": "2"
+      },
+      "libcrc32c": {
+        "size": "12644",
+        "refcount": "1"
+      },
+      "sd_mod": {
+        "size": "45373",
+        "refcount": "3"
+      },
+      "sr_mod": {
+        "size": "22416",
+        "refcount": "0"
+      },
+      "crc_t10dif": {
+        "size": "12714",
+        "refcount": "1"
+      },
+      "cdrom": {
+        "size": "42556",
+        "refcount": "1"
+      },
+      "crct10dif_common": {
+        "size": "12595",
+        "refcount": "1"
+      },
+      "ata_generic": {
+        "size": "12910",
+        "refcount": "0"
+      },
+      "pata_acpi": {
+        "size": "13038",
+        "refcount": "0"
+      },
+      "ahci": {
+        "size": "25819",
+        "refcount": "2"
+      },
+      "libahci": {
+        "size": "32009",
+        "refcount": "1"
+      },
+      "ata_piix": {
+        "size": "35038",
+        "refcount": "0"
+      },
+      "e1000": {
+        "size": "149270",
+        "refcount": "0"
+      },
+      "libata": {
+        "size": "219478",
+        "refcount": "5"
+      },
+      "dm_mirror": {
+        "size": "22135",
+        "refcount": "0"
+      },
+      "dm_region_hash": {
+        "size": "20862",
+        "refcount": "1"
+      },
+      "dm_log": {
+        "size": "18411",
+        "refcount": "2"
+      },
+      "dm_mod": {
+        "size": "102999",
+        "refcount": "8"
+      }
+    }
+  },
+  "lsb": {
+  },
+  "os": "linux",
+  "os_version": "3.10.0-123.1.2.el7.x86_64",
+  "platform": "redhat",
+  "platform_version": "7.0",
+  "platform_family": "rhel",
+  "command": {
+    "ps": "ps -ef"
+  },
+  "dmi": {
+    "dmidecode_version": "2.12",
+    "smbios_version": "2.5",
+    "structures": {
+      "count": "10",
+      "size": "449"
+    },
+    "table_location": "0x000E1000",
+    "bios": {
+      "all_records": [
+        {
+          "record_id": "0x0000",
+          "size": "0",
+          "application_identifier": "BIOS Information",
+          "Vendor": "innotek GmbH",
+          "Version": "VirtualBox",
+          "Release Date": "12/01/2006",
+          "Address": "0xE0000",
+          "Runtime Size": "128 kB",
+          "ROM Size": "128 kB",
+          "Characteristics": {
+            "ISA is supported": null,
+            "PCI is supported": null,
+            "Boot from CD is supported": null,
+            "Selectable boot is supported": null,
+            "8042 keyboard services are supported (int 9h)": null,
+            "CGA/mono video services are supported (int 10h)": null,
+            "ACPI is supported": null
+          }
+        }
+      ],
+      "vendor": "innotek GmbH",
+      "version": "VirtualBox",
+      "release_date": "12/01/2006",
+      "address": "0xE0000",
+      "runtime_size": "128 kB",
+      "rom_size": "128 kB"
+    },
+    "system": {
+      "all_records": [
+        {
+          "record_id": "0x0001",
+          "size": "1",
+          "application_identifier": "System Information",
+          "Manufacturer": "innotek GmbH",
+          "Product Name": "VirtualBox",
+          "Version": "1.2",
+          "Serial Number": "0",
+          "UUID": "7B977F78-E586-482B-8FFC-F19612B3B4DB",
+          "Wake-up Type": "Power Switch",
+          "SKU Number": "Not Specified",
+          "Family": "Virtual Machine"
+        }
+      ],
+      "manufacturer": "innotek GmbH",
+      "product_name": "VirtualBox",
+      "version": "1.2",
+      "serial_number": "0",
+      "uuid": "7B977F78-E586-482B-8FFC-F19612B3B4DB",
+      "wake_up_type": "Power Switch",
+      "sku_number": "Not Specified",
+      "family": "Virtual Machine"
+    },
+    "base_board": {
+      "all_records": [
+        {
+          "record_id": "0x0008",
+          "size": "2",
+          "application_identifier": "Base Board Information",
+          "Manufacturer": "Oracle Corporation",
+          "Product Name": "VirtualBox",
+          "Version": "1.2",
+          "Serial Number": "0",
+          "Asset Tag": "Not Specified",
+          "Features": {
+            "Board is a hosting board": null
+          },
+          "Location In Chassis": "Not Specified",
+          "Chassis Handle": "0x0003",
+          "Type": "Motherboard",
+          "Contained Object Handles": "0"
+        }
+      ],
+      "manufacturer": "Oracle Corporation",
+      "product_name": "VirtualBox",
+      "version": "1.2",
+      "serial_number": "0",
+      "asset_tag": "Not Specified",
+      "location_in_chassis": "Not Specified",
+      "chassis_handle": "0x0003",
+      "type": "Motherboard",
+      "contained_object_handles": "0"
+    },
+    "chassis": {
+      "all_records": [
+        {
+          "record_id": "0x0003",
+          "size": "3",
+          "application_identifier": "Inactive",
+          "Manufacturer": "Oracle Corporation",
+          "Type": "Other",
+          "Lock": "Not Present",
+          "Version": "Not Specified",
+          "Serial Number": "Not Specified",
+          "Asset Tag": "Not Specified",
+          "Boot-up State": "Safe",
+          "Power Supply State": "Safe",
+          "Thermal State": "Safe",
+          "Security Status": "None"
+        }
+      ],
+      "manufacturer": "Oracle Corporation",
+      "type": "Other",
+      "lock": "Not Present",
+      "version": "Not Specified",
+      "serial_number": "Not Specified",
+      "asset_tag": "Not Specified",
+      "boot_up_state": "Safe",
+      "power_supply_state": "Safe",
+      "thermal_state": "Safe",
+      "security_status": "None"
+    },
+    "oem_strings": {
+      "all_records": [
+        {
+          "record_id": "0x0002",
+          "size": "11",
+          "application_identifier": "End Of Table",
+          "String 1": "vboxVer_4.3.12",
+          "String 2": "vboxRev_93733",
+          "Header and Data": {
+            "80 08 08 00 07 3B 27 00": null
+          }
+        }
+      ],
+      "string_1": "vboxVer_4.3.12",
+      "string_2": "vboxRev_93733"
+    }
+  },
+  "ohai_time": 1404768299.0252879,
+  "languages": {
+    "ruby": {
+      "bin_dir": "/usr/local/bin",
+      "gem_bin": "/usr/local/bin/gem",
+      "gems_dir": "/usr/local/gems",
+      "ruby_bin": "/usr/local/bin/ruby"
+    }
+  },
+  "chef_packages": {
+    "chef": {
+      "version": "11.12.8",
+      "chef_root": "/usr/local/gems/chef-11.12.8/lib"
+    },
+    "ohai": {
+      "version": "7.0.4",
+      "ohai_root": "/usr/local/gems/ohai-7.0.4/lib/ohai"
+    }
+  },
+  "counters": {
+    "network": {
+      "interfaces": {
+        "eth0": {
+          "rx": {
+            "bytes": "0",
+            "packets": "0",
+            "errors": "0",
+            "drop": 0,
+            "overrun": 0,
+            "frame": 0,
+            "compressed": 0,
+            "multicast": 0
+          },
+          "tx": {
+            "bytes": "342",
+            "packets": "0",
+            "errors": "0",
+            "drop": 0,
+            "overrun": 0,
+            "collisions": "0",
+            "carrier": 0,
+            "compressed": 0
+          }
+        }
+      }
+    }
+  },
+  "current_user": "fauxhai",
+  "domain": "local",
+  "etc": {
+    "passwd": {
+      "fauxhai": {
+        "dir": "/home/fauxhai",
+        "gid": 0,
+        "uid": 0,
+        "shell": "/bin/bash",
+        "gecos": "Fauxhai"
+      }
+    },
+    "group": {
+      "fauxhai": {
+        "gid": 0,
+        "members": [
+          "fauxhai"
+        ]
+      }
+    }
+  },
+  "hostname": "Fauxhai",
+  "fqdn": "fauxhai.local",
+  "ipaddress": "10.0.0.2",
+  "keys": {
+    "ssh": {
+      "host_dsa_public": "ssh-dss AAAAB3NzaC1kc3MAAACBAJFo9BLAw4WKEs5hgipk5m423FzBsDXCZSMcC9ca/om/1VYzMqImixGe3uICDzNFUWxFoLJTQAOccyzo6MXZiQqwWJDLFi5qOSr6w2XcMyE+zd4wOyMoDiVM5fizmG8K3FzrqvGjwBcHcBdOQnavSijoj38DN25J9zhrid5BY4WlAAAAFQDxXrCyG52XCzn3FV4ej38wJBkomQAAAIBovGPJ4mP2P6BK8lHl0PPbktwQbWlpJ13oz6REJFDVcUi7vV26bX/BjQX+ohzZQzljdz1SpUbPc/8nuA4darYkVh91eBi307EN8IdxRHj2eBgp/ZG4yshIebG3WHrwJD/xUjjZ1MRfyDT1ermVi4LvjjPgWDxLZnPpMaR6S1nzgQAAAIEAj0Vd6DCWslvlsZ8+N53HWsqPi3gnx35JoLPz9Z2epkKIKqmEHav+93G3hdfztVa4I4t3phoPniQchYryF5+RNg8hqxKzjNtrIqUYCeuf2NJrksNsH7OZygPHZpqt4kTuwAGZxjxEGfAI0y8DhkU2ntp2LnzRnWH106BQBCmcXwo= fauxhai.local",
+      "host_rsa_public": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCtLCeqtqr/HbnORckw1ukdLhpfGoOPFi5/esKEokzTqq1gsgQ2V8emmyjfq1i6XXfRtSBxkdlHv/GWdP5wBTuE2G85MzBkVSQPvmwQN8lX/JMPEEtKXkeOo0o92/PiSmvY4eRsdF0mw40Uvg7jtE3f3fxj497kzh5fKtkrHnF4x9gXCbVdr3FqXJfggR5IJwAxToerbK7x/uRS+7YuZI9Pip3tt14nv9ezwXcuGb/tvjWOZINiFl8izVIFKi7sxfTX09p4NgamxRS7TD2Yd0jT8nEoF9UZTsgXcJ1kDSx7N7NxFfNfP6rCdOGRRz4gUhXtsUjG/XkxPeCwZ7A9VnOD fauxhai.local"
+    }
+  },
+  "macaddress": "11:11:11:11:11:11",
+  "network": {
+    "default_gateway": "10.0.0.1",
+    "default_interface": "eth0",
+    "settings": {
+    },
+    "interfaces": {
+      "eth0": {
+        "addresses": {
+          "10.0.0.2": {
+            "broadcast": "10.0.0.255",
+            "family": "inet",
+            "netmask": "255.255.255.0",
+            "prefixlen": "23",
+            "scope": "Global"
+          }
+        },
+        "arp": {
+          "10.0.0.1": "fe:ff:ff:ff:ff:ff"
+        },
+        "encapsulation": "Ethernet",
+        "flags": [
+          "BROADCAST",
+          "MULTICAST",
+          "UP",
+          "LOWER_UP"
+        ],
+        "mtu": "1500",
+        "number": "0",
+        "routes": {
+          "10.0.0.0/255": {
+            "scope": "link",
+            "src": "10.0.0.2"
+          }
+        },
+        "state": "up",
+        "type": "eth"
+      }
+    }
+  },
+  "uptime": "30 days 15 hours 07 minutes 30 seconds",
+  "uptime_seconds": 2646450,
+  "cpu": {
+    "real": 1,
+    "total": 1
+  }
+}


### PR DESCRIPTION
This PR adds support for Redhat 7.0. The bundle console test with "Fauxhai.mock(platform: 'ubuntu', version: '12.04')" does not return any errors. 
