### PR TITLE
Repair AIX 6.1 fauxhai data.

### DIFF
--- a/lib/fauxhai/platforms/aix/6.1.json
+++ b/lib/fauxhai/platforms/aix/6.1.json
@@ -1,19 +1,553 @@
 {
+  "filesystem": {
+    "/dev/hd4": {
+      "kb_size": "786432",
+      "kb_used": "494912",
+      "kb_available": "291520",
+      "percent_used": "63%",
+      "mount": "/",
+      "fs_type": "jfs2",
+      "mount_options": "rw,log=/dev/hd8"
+    },
+    "/dev/hd2": {
+      "kb_size": "12320768",
+      "kb_used": "9411384",
+      "kb_available": "2909384",
+      "percent_used": "77%",
+      "mount": "/usr",
+      "fs_type": "jfs2",
+      "mount_options": "rw,log=/dev/hd8"
+    },
+    "/dev/hd9var": {
+      "kb_size": "2621440",
+      "kb_used": "259688",
+      "kb_available": "2361752",
+      "percent_used": "10%",
+      "mount": "/var",
+      "fs_type": "jfs2",
+      "mount_options": "rw,log=/dev/hd8"
+    },
+    "/dev/hd3": {
+      "kb_size": "2621440",
+      "kb_used": "17304",
+      "kb_available": "2604136",
+      "percent_used": "1%",
+      "mount": "/tmp",
+      "fs_type": "jfs2",
+      "mount_options": "rw,log=/dev/hd8"
+    },
+    "/dev/hd1": {
+      "kb_size": "2359296",
+      "kb_used": "229168",
+      "kb_available": "2130128",
+      "percent_used": "10%",
+      "mount": "/home",
+      "fs_type": "jfs2",
+      "mount_options": "rw,log=/dev/hd8"
+    },
+    "/dev/hd11admin": {
+      "kb_size": "262144",
+      "kb_used": "760",
+      "kb_available": "261384",
+      "percent_used": "1%",
+      "mount": "/admin",
+      "fs_type": "jfs2",
+      "mount_options": "rw,log=/dev/hd8"
+    },
+    "/dev/hd10opt": {
+      "kb_size": "3407872",
+      "kb_used": "1417400",
+      "kb_available": "1990472",
+      "percent_used": "42%",
+      "mount": "/opt",
+      "fs_type": "jfs2",
+      "mount_options": "rw,log=/dev/hd8"
+    },
+    "192.168.1.11:/stage/middleware": {
+      "kb_size": "314572800",
+      "kb_used": "225814136",
+      "kb_available": "88758664",
+      "percent_used": "72%",
+      "mount": "/stage/middleware",
+      "fs_type": "nfs3",
+      "mount_options": "ro,bg,hard,intr,sec=sys"
+    },
+    "/proc": {
+      "mount": "/proc",
+      "fs_type": "procfs",
+      "mount_options": "rw"
+    }
+  },
   "kernel": {
-
+    "name": "aix",
+    "release": "1",
+    "version": "6",
+    "machine": "powerpc",
+    "modules": {
+      "/usr/lib/drivers/if_en": {
+        "text": {
+          "address": "4b50000",
+          "size": "20000"
+        },
+        "data": {
+          "address": "4b60000",
+          "size": "bd8"
+        }
+      },
+      "/usr/lib/drivers/random": {
+        "text": {
+          "address": "f1000000c028c000",
+          "size": "20000"
+        },
+        "data": {
+          "address": "f1000000c0294000",
+          "size": "17148"
+        }
+      },
+      "/usr/lib/drivers/nfs.ext": {
+        "text": {
+          "address": "4920000",
+          "size": "220000"
+        },
+        "data": {
+          "address": "4ad0000",
+          "size": "65700"
+        }
+      },
+      "/usr/lib/drivers/krpc.ext": {
+        "text": {
+          "address": "48c0000",
+          "size": "60000"
+        },
+        "data": {
+          "address": "4910000",
+          "size": "dbe8"
+        }
+      },
+      "/usr/lib/drivers/nfs_kdes.ext": {
+        "text": {
+          "address": "f1000000c028a000",
+          "size": "2000"
+        },
+        "data": {
+          "address": "f1000000c028b000",
+          "size": "d0"
+        }
+      },
+      "/usr/lib/drivers/posix_aiopin": {
+        "text": {
+          "address": "4890000",
+          "size": "20000"
+        },
+        "data": {
+          "address": "48a0000",
+          "size": "8990"
+        }
+      },
+      "/usr/lib/drivers/posix_aio.ext": {
+        "text": {
+          "address": "4870000",
+          "size": "20000"
+        },
+        "data": {
+          "address": "4880000",
+          "size": "e80"
+        }
+      },
+      "/usr/lib/drivers/aiopin": {
+        "text": {
+          "address": "4850000",
+          "size": "20000"
+        },
+        "data": {
+          "address": "4860000",
+          "size": "8910"
+        }
+      },
+      "/usr/lib/drivers/aio.ext": {
+        "text": {
+          "address": "4830000",
+          "size": "20000"
+        },
+        "data": {
+          "address": "4840000",
+          "size": "1198"
+        }
+      },
+      "/usr/lib/drivers/smt_loadpin": {
+        "text": {
+          "address": "f1000000c0288000",
+          "size": "2000"
+        },
+        "data": {
+          "address": "f1000000c0289000",
+          "size": "78"
+        }
+      },
+      "/usr/lib/drivers/smt_load": {
+        "text": {
+          "address": "f1000000c0280000",
+          "size": "6000"
+        },
+        "data": {
+          "address": "f1000000c0285000",
+          "size": "698"
+        }
+      },
+      "/usr/pmapi/etc/pmsvcs": {
+        "text": {
+          "address": "47e0000",
+          "size": "40000"
+        },
+        "data": {
+          "address": "4810000",
+          "size": "334c"
+        }
+      },
+      "/usr/lib/drivers/perfvmmstat": {
+        "text": {
+          "address": "47b0000",
+          "size": "20000"
+        },
+        "data": {
+          "address": "47c0000",
+          "size": "9f0"
+        }
+      },
+      "/usr/lib/drivers/ptydd": {
+        "text": {
+          "address": "f1000000c0264000",
+          "size": "1c000"
+        },
+        "data": {
+          "address": "f1000000c027d000",
+          "size": "2154"
+        }
+      },
+      "/usr/lib/perf/perfstat": {
+        "text": {
+          "address": "4780000",
+          "size": "30000"
+        },
+        "data": {
+          "address": "47a0000",
+          "size": "f14"
+        }
+      },
+      "/usr/lib/drivers/netinet": {
+        "text": {
+          "address": "4540000",
+          "size": "240000"
+        },
+        "data": {
+          "address": "4630000",
+          "size": "14b8c0"
+        }
+      },
+      "/usr/lib/drivers/crypto/clickext": {
+        "text": {
+          "address": "f1000000c0214000",
+          "size": "50000"
+        },
+        "data": {
+          "address": "f1000000c0257000",
+          "size": "b148"
+        }
+      },
+      "/usr/lib/drivers/ldterm": {
+        "text": {
+          "address": "f1000000c01f9000",
+          "size": "1b000"
+        },
+        "data": {
+          "address": "f1000000c0212000",
+          "size": "16d8"
+        }
+      },
+      "/usr/lib/drivers/vconsdd": {
+        "text": {
+          "address": "f1000000c01f0000",
+          "size": "9000"
+        },
+        "data": {
+          "address": "f1000000c01f8000",
+          "size": "788"
+        }
+      },
+      "/usr/lib/drivers/sfwcomdd": {
+        "text": {
+          "address": "44f0000",
+          "size": "40000"
+        },
+        "data": {
+          "address": "4520000",
+          "size": "9350"
+        }
+      },
+      "/usr/lib/drivers/storfwork": {
+        "text": {
+          "address": "44b0000",
+          "size": "40000"
+        },
+        "data": {
+          "address": "44e0000",
+          "size": "4028"
+        }
+      },
+      "/etc/drivers/coreprobe.ext": {
+        "text": {
+          "address": "f1000000c01e8000",
+          "size": "5000"
+        },
+        "data": {
+          "address": "f1000000c01ec000",
+          "size": "2b0"
+        }
+      },
+      "/usr/lib/drivers/syscalls64.ext": {
+        "text": {
+          "address": "f1000000c01e6000",
+          "size": "2000"
+        },
+        "data": {
+          "address": "f1000000c01e7000",
+          "size": "98"
+        }
+      },
+      "/usr/lib/drivers/pse/tirdwr": {
+        "text": {
+          "address": "f1000000c01e2000",
+          "size": "4000"
+        },
+        "data": {
+          "address": "f1000000c01e5000",
+          "size": "498"
+        }
+      },
+      "/usr/lib/drivers/pse/timod": {
+        "text": {
+          "address": "f1000000c01de000",
+          "size": "4000"
+        },
+        "data": {
+          "address": "f1000000c01e1000",
+          "size": "580"
+        }
+      },
+      "/usr/lib/drivers/pse/xtiso": {
+        "text": {
+          "address": "f1000000c01c1000",
+          "size": "1d000"
+        },
+        "data": {
+          "address": "f1000000c01dc000",
+          "size": "10f8"
+        }
+      },
+      "/usr/lib/drivers/pse/stdmod": {
+        "text": {
+          "address": "f1000000c01bf000",
+          "size": "2000"
+        },
+        "data": {
+          "address": "f1000000c01c0000",
+          "size": "9d0"
+        }
+      },
+      "/usr/lib/drivers/pse/sc": {
+        "text": {
+          "address": "f1000000c01bb000",
+          "size": "3000"
+        },
+        "data": {
+          "address": "f1000000c01bd000",
+          "size": "610"
+        }
+      },
+      "/usr/lib/drivers/pse/spx": {
+        "text": {
+          "address": "f1000000c01b7000",
+          "size": "3000"
+        },
+        "data": {
+          "address": "f1000000c01b9000",
+          "size": "2b0"
+        }
+      },
+      "/usr/lib/drivers/pse/stddev": {
+        "text": {
+          "address": "f1000000c01b3000",
+          "size": "3000"
+        },
+        "data": {
+          "address": "f1000000c01b5000",
+          "size": "940"
+        }
+      },
+      "/usr/lib/drivers/ttydbg": {
+        "text": {
+          "address": "f1000000c01b1000",
+          "size": "2000"
+        },
+        "data": {
+          "address": "f1000000c01b2000",
+          "size": "4d0"
+        }
+      },
+      "/usr/lib/drivers/ttydbg_pinned": {
+        "text": {
+          "address": "f1000000c01ad000",
+          "size": "4000"
+        },
+        "data": {
+          "address": "f1000000c01b0000",
+          "size": "440"
+        }
+      },
+      "/usr/lib/drivers/pse/pse": {
+        "text": {
+          "address": "f1000000c0154000",
+          "size": "59000"
+        },
+        "data": {
+          "address": "f1000000c01a4000",
+          "size": "7f88"
+        }
+      },
+      "/usr/lib/drivers/iscsidd": {
+        "text": {
+          "address": "4450000",
+          "size": "50000"
+        },
+        "data": {
+          "address": "4490000",
+          "size": "7ea8"
+        }
+      },
+      "/usr/lib/drivers/hd_pin_bot": {
+        "text": {
+          "address": "43e0000",
+          "size": "70000"
+        },
+        "data": {
+          "address": "4420000",
+          "size": "20d10"
+        }
+      },
+      "/usr/lib/drivers/hd_pin": {
+        "text": {
+          "address": "43a0000",
+          "size": "40000"
+        },
+        "data": {
+          "address": "43d0000",
+          "size": "1f90"
+        }
+      },
+      "/usr/lib/drivers/aixdiskpcmke": {
+        "text": {
+          "address": "4350000",
+          "size": "50000"
+        },
+        "data": {
+          "address": "4390000",
+          "size": "8310"
+        }
+      },
+      "/etc/drivers/scsidiskpin": {
+        "text": {
+          "address": "42f0000",
+          "size": "60000"
+        },
+        "data": {
+          "address": "4340000",
+          "size": "ad50"
+        }
+      },
+      "/usr/lib/drivers/scsidisk": {
+        "text": {
+          "address": "42c0000",
+          "size": "30000"
+        },
+        "data": {
+          "address": "42e0000",
+          "size": "c98"
+        }
+      },
+      "/usr/lib/drivers/vscsi_initdd": {
+        "text": {
+          "address": "f1000000c0130000",
+          "size": "24000"
+        },
+        "data": {
+          "address": "f1000000c0151000",
+          "size": "2783"
+        }
+      },
+      "/usr/lib/drivers/eth_demux": {
+        "text": {
+          "address": "4290000",
+          "size": "20000"
+        },
+        "data": {
+          "address": "42a0000",
+          "size": "410"
+        }
+      },
+      "/usr/lib/drivers/vioentdd": {
+        "text": {
+          "address": "4260000",
+          "size": "30000"
+        },
+        "data": {
+          "address": "4280000",
+          "size": "fe60"
+        }
+      },
+      "/usr/lib/drivers/vdev_busdd": {
+        "text": {
+          "address": "4230000",
+          "size": "30000"
+        },
+        "data": {
+          "address": "4250000",
+          "size": "2a34"
+        }
+      },
+      "/usr/lib/drivers/planar_pal_chrp": {
+        "text": {
+          "address": "41f0000",
+          "size": "40000"
+        },
+        "data": {
+          "address": "4220000",
+          "size": "cbd8"
+        }
+      },
+      "/unix": {
+        "text": {
+          "address": "28b6e50",
+          "size": "0"
+        },
+        "data": {
+          "address": "0",
+          "size": "2c0def0"
+        }
+      }
+    }
   },
   "os": "aix",
-  "os_version": null,
-  "platform": null,
-  "platform_version": ".",
-  "platform_family": null,
+  "os_version": "1",
+  "platform": "aix",
+  "platform_version": "6.1",
+  "platform_family": "aix",
   "command": {
     "ps": "ps -ef"
   },
   "dmi": {
 
   },
-  "ohai_time": 1407455425.26451,
+  "ohai_time": 1411621630.957907,
   "languages": {
     "ruby": {
       "bin_dir": "/usr/local/bin",
@@ -23,6 +557,10 @@
     }
   },
   "chef_packages": {
+    "chef": {
+      "version": "12.0.0.alpha.0",
+      "chef_root": "/usr/local/gems/chef-12.0.0.alpha.0/lib"
+    },
     "ohai": {
       "version": "7.2.0",
       "ohai_root": "/usr/local/gems/ohai-7.2.0/lib/ohai"


### PR DESCRIPTION
Some of the Fauxhai data was incorrect for AIX 6.1 due to bugs that we have now fixed. In particular, the most important attributes like `platform`, `platform_version` and so on were broken.

There is extra gravy in this data now for filesystems, kernel modules, etc.
