### PR TITLE
Whitelist languages/powershell which allows cookbooks that use dsc_scri...

### DIFF
--- a/lib/fauxhai/runner.rb
+++ b/lib/fauxhai/runner.rb
@@ -157,7 +157,8 @@ module Fauxhai
           'gem_bin' => gem_bin,
           'gems_dir' => gems_dir,
           'ruby_bin' => ruby_bin,
-        })
+        }),
+        'powershell' => @system.data['languages']['powershell']
       }
     end
 


### PR DESCRIPTION
This whitelists 'powershell' under 'languages'.

Without information about powershell, ChefSpec testing of anything using the new dsc_script resource in Chef 11.16.0+ fails because the provider insists on there being ohai data about Powershell v4.0:

https://github.com/opscode/chef/blob/11.16.4/lib/chef/platform/query_helpers.rb#L49-52
