### PR TITLE
Don't mock out chef_packages

### DIFF
--- a/lib/fauxhai/runner.rb
+++ b/lib/fauxhai/runner.rb
@@ -18,7 +18,6 @@ module Fauxhai
 
       result = @system.data.dup.delete_if { |k, v| !whitelist_attributes.include?(k) }.merge(
         'languages' => languages,
-        'chef_packages' => chef_packages,
         'counters' => counters,
         'current_user' => current_user,
         'domain' => domain,

--- a/lib/fauxhai/runner/default.rb
+++ b/lib/fauxhai/runner/default.rb
@@ -5,24 +5,6 @@ module Fauxhai
         '/usr/local/bin'
       end
 
-      def chef_packages
-        return {} if @system.data['chef_packages'].nil?
-
-        chef_version = @system.data['chef_packages']['chef']['version']
-        ohai_version = @system.data['chef_packages']['ohai']['version']
-
-        {
-          'chef' => {
-            'version' => chef_version,
-            'chef_root' => ['/opt/chef/embedded/lib/ruby/gems/2.4.0/gems', "chef-#{chef_version}", 'lib'].join('/'),
-          },
-          'ohai' => {
-            'version' => ohai_version,
-            'ohai_root' => ['/opt/chef/embedded/lib/ruby/gems/2.4.0/gems', "ohai-#{ohai_version}", 'lib', 'ohai'].join('/'),
-          },
-        }
-      end
-
       def counters
         {
           'network' => {
@@ -298,6 +280,7 @@ module Fauxhai
       def whitelist_attributes
         %w(
           block_device
+          chef_packages
           command
           dmi
           filesystem


### PR DESCRIPTION
Why? Just use the actual data instead of trying to fake it out.

Signed-off-by: Tim Smith <tsmith@chef.io>