### PR TITLE
Include filesystem2 in attributes.

### DIFF
--- a/lib/fauxhai/runner/default.rb
+++ b/lib/fauxhai/runner/default.rb
@@ -301,6 +301,7 @@ module Fauxhai
           command
           dmi
           filesystem
+          filesystem2
           fips
           init_package
           kernel


### PR DESCRIPTION
`filesystem2` allows for visibility of filesystems "by_device",
"by_mountpoint", and "by_pair".  The default filesystem module makes it
difficult to mock multiple filesystems that use virtual devices like
`tmpfs`.