### PR TITLE
Add dragonfly 4.8 dump and deprecate the 4.2 dump

### DIFF
--- a/PLATFORMS.md
+++ b/PLATFORMS.md
@@ -50,7 +50,7 @@ This file lists each platform known to Fauxhai and the available versions for ea
 
 ### dragonfly4
 
-  - 4.2-RELEASE
+  - 4.8-RELEASE
 
 ### fedora
 

--- a/lib/fauxhai/platforms/dragonfly4/4.2-RELEASE.json
+++ b/lib/fauxhai/platforms/dragonfly4/4.2-RELEASE.json
@@ -1,4 +1,5 @@
 {
+  "deprecated": true,
   "kernel": {
     "name": "DragonFly",
     "release": "4.2-RELEASE",

--- a/lib/fauxhai/platforms/dragonfly4/4.8-RELEASE.json
+++ b/lib/fauxhai/platforms/dragonfly4/4.8-RELEASE.json
@@ -1,0 +1,394 @@
+{
+  "chef_packages": {
+    "ohai": {
+      "version": "13.1.0",
+      "ohai_root": "/usr/local/lib/ruby/gems/2.3/gems/ohai-13.1.0/lib/ohai"
+    },
+    "chef": {
+      "version": "13.1.31",
+      "chef_root": "/usr/local/lib/ruby/gems/2.3/gems/chef-13.1.31/lib"
+    }
+  },
+  "command": {
+    "ps": "ps -axww"
+  },
+  "counters": {
+    "network": {
+      "interfaces": {
+        "lo": {
+          "tx": {
+            "queuelen": "1",
+            "bytes": 0,
+            "packets": 0,
+            "errors": 0,
+            "drop": 0,
+            "carrier": 0,
+            "collisions": 0
+          },
+          "rx": {
+            "bytes": 0,
+            "packets": 0,
+            "errors": 0,
+            "drop": 0,
+            "overrun": 0
+          }
+        },
+        "em0": {
+          "rx": {
+            "bytes": 0,
+            "packets": 0,
+            "errors": 0,
+            "drop": 0,
+            "overrun": 0,
+            "frame": 0,
+            "compressed": 0,
+            "multicast": 0
+          },
+          "tx": {
+            "bytes": 0,
+            "packets": 0,
+            "errors": 0,
+            "drop": 0,
+            "overrun": 0,
+            "collisions": 0,
+            "carrier": 0,
+            "compressed": 0
+          }
+        }
+      }
+    }
+  },
+  "cpu": {
+    "real": 1,
+    "total": 1,
+    "cores": 1
+  },
+  "current_user": "fauxhai",
+  "dmi": {
+  },
+  "domain": "local",
+  "etc": {
+    "passwd": {
+      "fauxhai": {
+        "dir": "/home/fauxhai",
+        "gid": 0,
+        "uid": 0,
+        "shell": "/bin/bash",
+        "gecos": "Fauxhai"
+      }
+    },
+    "group": {
+      "fauxhai": {
+        "gid": 0,
+        "members": [
+          "fauxhai"
+        ]
+      }
+    }
+  },
+  "filesystem": {
+    "ROOT": {
+      "kb_size": "13500416",
+      "kb_used": "1879072",
+      "kb_available": "11621344",
+      "percent_used": "14%",
+      "mount": "/",
+      "inodes_used": "99363",
+      "inodes_available": "0",
+      "total_inodes": "99363",
+      "inodes_percent_used": "100"
+    },
+    "devfs": {
+      "kb_size": "1",
+      "kb_used": "1",
+      "kb_available": "0",
+      "percent_used": "100%",
+      "mount": "/dev",
+      "inodes_used": "671",
+      "inodes_available": "0",
+      "total_inodes": "671",
+      "inodes_percent_used": "100"
+    },
+    "/dev/serno/VB479f1e2c-4509c5c9.s1a": {
+      "kb_size": "1046318",
+      "kb_used": "155616",
+      "kb_available": "806998",
+      "percent_used": "16%",
+      "mount": "/boot",
+      "inodes_used": "691",
+      "inodes_available": "15947",
+      "total_inodes": "16638",
+      "inodes_percent_used": "4"
+    },
+    "/build/usr.obj": {
+      "kb_size": "13500416",
+      "kb_used": "1879072",
+      "kb_available": "11621344",
+      "percent_used": "14%",
+      "mount": "/usr/obj",
+      "inodes_used": "99363",
+      "inodes_available": "0",
+      "total_inodes": "99363",
+      "inodes_percent_used": "100"
+    },
+    "/build/var.crash": {
+      "kb_size": "13500416",
+      "kb_used": "1879072",
+      "kb_available": "11621344",
+      "percent_used": "14%",
+      "mount": "/var/crash",
+      "inodes_used": "99363",
+      "inodes_available": "0",
+      "total_inodes": "99363",
+      "inodes_percent_used": "100"
+    },
+    "/build/var.cache": {
+      "kb_size": "13500416",
+      "kb_used": "1879072",
+      "kb_available": "11621344",
+      "percent_used": "14%",
+      "mount": "/var/cache",
+      "inodes_used": "99363",
+      "inodes_available": "0",
+      "total_inodes": "99363",
+      "inodes_percent_used": "100"
+    },
+    "/build/var.spool": {
+      "kb_size": "13500416",
+      "kb_used": "1879072",
+      "kb_available": "11621344",
+      "percent_used": "14%",
+      "mount": "/var/spool",
+      "inodes_used": "99363",
+      "inodes_available": "0",
+      "total_inodes": "99363",
+      "inodes_percent_used": "100"
+    },
+    "/build/var.log": {
+      "kb_size": "13500416",
+      "kb_used": "1879072",
+      "kb_available": "11621344",
+      "percent_used": "14%",
+      "mount": "/var/log",
+      "inodes_used": "99363",
+      "inodes_available": "0",
+      "total_inodes": "99363",
+      "inodes_percent_used": "100"
+    },
+    "/build/var.tmp": {
+      "kb_size": "13500416",
+      "kb_used": "1879072",
+      "kb_available": "11621344",
+      "percent_used": "14%",
+      "mount": "/var/tmp",
+      "inodes_used": "99363",
+      "inodes_available": "0",
+      "total_inodes": "99363",
+      "inodes_percent_used": "100"
+    },
+    "tmpfs": {
+      "kb_size": "243512",
+      "kb_used": "0",
+      "kb_available": "243512",
+      "percent_used": "0%",
+      "mount": "/tmp",
+      "inodes_used": "1",
+      "inodes_available": "243514",
+      "total_inodes": "243515",
+      "inodes_percent_used": "0"
+    },
+    "procfs": {
+      "kb_size": "4",
+      "kb_used": "4",
+      "kb_available": "0",
+      "percent_used": "100%",
+      "mount": "/proc",
+      "inodes_used": "20",
+      "inodes_available": "1952",
+      "total_inodes": "1972",
+      "inodes_percent_used": "1"
+    }
+  },
+  "fqdn": "fauxhai.local",
+  "hostname": "Fauxhai",
+  "idle": "30 days 15 hours 07 minutes 30 seconds",
+  "idletime_seconds": 2646450,
+  "ipaddress": "10.0.0.2",
+  "kernel": {
+    "name": "DragonFly",
+    "release": "4.8-RELEASE",
+    "version": "DragonFly v4.8.0-RELEASE #4: Sun Mar 26 20:55:22 EDT 2017     root@www.shiningsilence.com:/usr/obj/home/justin/release/4_8/sys/X86_64_GENERIC ",
+    "machine": "x86_64",
+    "processor": "x86_64",
+    "os": "DragonFly",
+    "ident": "X86_64_GENERIC",
+    "securelevel": [
+      "kern.securelevel: -1"
+    ],
+    "modules": {
+      "kernel": {
+        "size": "1eeb980",
+        "refcount": "7"
+      },
+      "acpi": {
+        "size": "debb0",
+        "refcount": "1"
+      },
+      "ehci": {
+        "size": "cff0",
+        "refcount": "1"
+      },
+      "xhci": {
+        "size": "d350",
+        "refcount": "1"
+      }
+    }
+  },
+  "keys": {
+    "ssh": {
+      "host_dsa_public": "ssh-dss AAAAB3NzaC1kc3MAAACBAJFo9BLAw4WKEs5hgipk5m423FzBsDXCZSMcC9ca/om/1VYzMqImixGe3uICDzNFUWxFoLJTQAOccyzo6MXZiQqwWJDLFi5qOSr6w2XcMyE+zd4wOyMoDiVM5fizmG8K3FzrqvGjwBcHcBdOQnavSijoj38DN25J9zhrid5BY4WlAAAAFQDxXrCyG52XCzn3FV4ej38wJBkomQAAAIBovGPJ4mP2P6BK8lHl0PPbktwQbWlpJ13oz6REJFDVcUi7vV26bX/BjQX+ohzZQzljdz1SpUbPc/8nuA4darYkVh91eBi307EN8IdxRHj2eBgp/ZG4yshIebG3WHrwJD/xUjjZ1MRfyDT1ermVi4LvjjPgWDxLZnPpMaR6S1nzgQAAAIEAj0Vd6DCWslvlsZ8+N53HWsqPi3gnx35JoLPz9Z2epkKIKqmEHav+93G3hdfztVa4I4t3phoPniQchYryF5+RNg8hqxKzjNtrIqUYCeuf2NJrksNsH7OZygPHZpqt4kTuwAGZxjxEGfAI0y8DhkU2ntp2LnzRnWH106BQBCmcXwo= fauxhai.local",
+      "host_rsa_public": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCtLCeqtqr/HbnORckw1ukdLhpfGoOPFi5/esKEokzTqq1gsgQ2V8emmyjfq1i6XXfRtSBxkdlHv/GWdP5wBTuE2G85MzBkVSQPvmwQN8lX/JMPEEtKXkeOo0o92/PiSmvY4eRsdF0mw40Uvg7jtE3f3fxj497kzh5fKtkrHnF4x9gXCbVdr3FqXJfggR5IJwAxToerbK7x/uRS+7YuZI9Pip3tt14nv9ezwXcuGb/tvjWOZINiFl8izVIFKi7sxfTX09p4NgamxRS7TD2Yd0jT8nEoF9UZTsgXcJ1kDSx7N7NxFfNfP6rCdOGRRz4gUhXtsUjG/XkxPeCwZ7A9VnOD fauxhai.local"
+    }
+  },
+  "languages": {
+    "ruby": {
+      "platform": "x86_64-dragonfly4",
+      "version": "2.3.4",
+      "release_date": "2017-03-30",
+      "target": "x86_64-portbld-dragonfly4",
+      "target_cpu": "x86_64",
+      "target_vendor": "portbld",
+      "target_os": "dragonfly4",
+      "host": "x86_64-portbld-dragonfly4",
+      "host_cpu": "x86_64",
+      "host_os": "dragonfly4",
+      "host_vendor": "portbld",
+      "bin_dir": "/usr/local/bin",
+      "ruby_bin": "/usr/local/bin/ruby",
+      "gems_dir": "/usr/local/gems",
+      "gem_bin": "/usr/local/bin/gem"
+    },
+    "powershell": null
+  },
+  "macaddress": "11:11:11:11:11:11",
+  "machinename": "Fauxhai",
+  "memory": {
+    "total": "1048576kB"
+  },
+  "network": {
+    "interfaces": {
+      "lo": {
+        "mtu": "65536",
+        "flags": [
+          "LOOPBACK",
+          "UP",
+          "LOWER_UP"
+        ],
+        "encapsulation": "Loopback",
+        "addresses": {
+          "127.0.0.1": {
+            "family": "inet",
+            "prefixlen": "8",
+            "netmask": "255.0.0.0",
+            "scope": "Node",
+            "ip_scope": "LOOPBACK"
+          },
+          "::1": {
+            "family": "inet6",
+            "prefixlen": "128",
+            "scope": "Node",
+            "tags": [
+
+            ],
+            "ip_scope": "LINK LOCAL LOOPBACK"
+          }
+        },
+        "state": "unknown"
+      },
+      "em0": {
+        "type": "em",
+        "number": "0",
+        "mtu": "1500",
+        "flags": [
+          "BROADCAST",
+          "MULTICAST",
+          "UP",
+          "LOWER_UP"
+        ],
+        "encapsulation": "Ethernet",
+        "addresses": {
+          "11:11:11:11:11:11": {
+            "family": "lladdr"
+          },
+          "10.0.0.2": {
+            "family": "inet",
+            "prefixlen": "24",
+            "netmask": "255.255.255.0",
+            "broadcast": "10.0.0.255",
+            "scope": "Global",
+            "ip_scope": "RFC1918 PRIVATE"
+          },
+          "fe80::11:1111:1111:1111": {
+            "family": "inet6",
+            "prefixlen": "64",
+            "scope": "Link",
+            "tags": [
+
+            ],
+            "ip_scope": "LINK LOCAL UNICAST"
+          }
+        },
+        "state": "up",
+        "arp": {
+          "10.0.0.1": "fe:ff:ff:ff:ff:ff"
+        },
+        "routes": [
+          {
+            "destination": "default",
+            "family": "inet",
+            "via": "10.0.0.1"
+          },
+          {
+            "destination": "10.0.0.0/24",
+            "family": "inet",
+            "scope": "link",
+            "proto": "kernel",
+            "src": "10.0.0.2"
+          },
+          {
+            "destination": "fe80::/64",
+            "family": "inet6",
+            "metric": "256",
+            "proto": "kernel"
+          }
+        ],
+        "ring_params": {
+        }
+      }
+    },
+    "default_interface": "em0",
+    "default_gateway": "10.0.0.1"
+  },
+  "ohai_time": 1497441132.986166,
+  "os": "dragonflybsd",
+  "os_version": "400800",
+  "platform": "dragonfly",
+  "platform_family": "dragonflybsd",
+  "platform_version": "4.8-RELEASE",
+  "root_group": "wheel",
+  "shells": [
+    "/bin/sh",
+    "/bin/csh",
+    "/bin/tcsh",
+    "/usr/local/libexec/git-core/git-shell"
+  ],
+  "time": {
+    "timezone": "GMT"
+  },
+  "uptime": "30 days 15 hours 07 minutes 30 seconds",
+  "uptime_seconds": 2646450,
+  "virtualization": {
+    "systems": {
+    }
+  }
+}


### PR DESCRIPTION
Signed-off-by: Tim Smith <tsmith@chef.io>