### PR TITLE
Deprecate slackware 14.1

### DIFF
--- a/PLATFORMS.md
+++ b/PLATFORMS.md
@@ -117,10 +117,6 @@ This file lists each platform known to Fauxhai and the available versions for ea
   - 7.2
   - 7.3
 
-### slackware
-
-  - 14.1
-
 ### smartos
 
   - 5.11

--- a/Rakefile
+++ b/Rakefile
@@ -28,12 +28,19 @@ namespace :documentation do
     f = File.new('PLATFORMS.md', 'w')
     f.write "## Fauxhai Platforms\n\nThis file lists each platform known to Fauxhai and the available versions for each of those platforms. See the ChefSpec documentation for mocking out platforms and platform versions within ChefSpec.\n"
     Dir.glob('./lib/fauxhai/platforms/**') do |platform_path|
-      f.write "\n### #{platform_path.split('/')[-1]}\n\n"
+      versions = []
       Dir.glob(File.join(platform_path, '**.json')).each do |version_path|
         # skip anything marked as deprecated
         data = JSON.parse(File.read(version_path))
         unless data['deprecated']
-          f.write "  - #{version_path.split('/')[-1].chomp('.json')}\n"
+          versions << version_path.split('/')[-1].chomp('.json')
+        end
+      end
+      # make sure there are any non-deprecated platforms before writing out the header
+      unless versions.empty?
+        f.write "\n### #{platform_path.split('/')[-1]}\n\n"
+        versions.each do |v|
+          f.write "  - #{v}\n"
         end
       end
     end

--- a/lib/fauxhai/platforms/slackware/14.1.json
+++ b/lib/fauxhai/platforms/slackware/14.1.json
@@ -1,4 +1,5 @@
 {
+  "deprecated": true,
   "filesystem": {
     "/dev/sda1": {
       "kb_size": "8023972",


### PR DESCRIPTION
This was never updated for Chef 12

Signed-off-by: Tim Smith <tsmith@chef.io>