### PR TITLE
Strip out a few build only files from the rubygems

### DIFF
--- a/fauxhai.gemspec
+++ b/fauxhai.gemspec
@@ -14,7 +14,7 @@ Gem::Specification.new do |spec|
 
   spec.required_ruby_version = '>= 2.2.2'
 
-  spec.files         = `git ls-files`.split($\)
+  spec.files         = `git ls-files -z`.split("\x0").reject { |f| f.match(%r{^(\..*|Gemfile|Rakefile)}) }
   spec.executables   = spec.files.grep(%r{^bin/}).map { |f| File.basename(f) }
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ['lib']


### PR DESCRIPTION
Rakefile and Gemfile. Pretty simple stuff. Slims down the gem a tiny bit

Signed-off-by: Tim Smith <tsmith@chef.io>