### PR TITLE
Deprecate Windows 7 and Windows 2008 R2 dumps

### DIFF
--- a/PLATFORMS.md
+++ b/PLATFORMS.md
@@ -136,9 +136,7 @@ This file lists each platform known to Fauxhai and the available versions for ea
 ### windows
 
   - 10
-  - 2008R2
   - 2012
   - 2012R2
   - 2016
-  - 7
   - 8.1

--- a/lib/fauxhai/platforms/windows/2008R2.json
+++ b/lib/fauxhai/platforms/windows/2008R2.json
@@ -62,6 +62,7 @@
     "total": 1
   },
   "current_user": "fauxhai",
+  "deprecated": true,
   "dmi": {},
   "domain": "local",
   "etc": {

--- a/lib/fauxhai/platforms/windows/7.json
+++ b/lib/fauxhai/platforms/windows/7.json
@@ -62,6 +62,7 @@
     "total": 1
   },
   "current_user": "fauxhai",
+  "deprecated": true,
   "dmi": {},
   "domain": "local",
   "etc": {


### PR DESCRIPTION
Chef no longer supports Windows 7 or Windows 2008 R2