### PR TITLE
add hardware for mac_os_x 10.13

### DIFF
--- a/lib/fauxhai/platforms/mac_os_x/10.13.json
+++ b/lib/fauxhai/platforms/mac_os_x/10.13.json
@@ -367,6 +367,40 @@
     }
   },
   "fqdn": "fauxhai.local",
+  "hardware": {
+    "Lightshow_version": "1.4a6",
+    "SMC_version_system": "2.20f18",
+    "boot_rom_version": "MP61.0123.B00",
+    "cpu_type": "12-Core Intel Xeon E5",
+    "current_processor_speed": "2.7 GHz",
+    "l2_cache_core": "256 KB",
+    "l3_cache": "30 MB",
+    "machine_model": "MacPro6,1",
+    "machine_name": "Mac Pro",
+    "number_processors": 12,
+    "packages": 1,
+    "physical_memory": "32 GB",
+    "platform_UUID": "1EADE98D-2235-5D99-B419-F386B45067AA",
+    "serial_number": "F5KM30GKF694",
+    "operating_system": "Mac OS X",
+    "operating_system_version": "10.13.4",
+    "build_version": "17E199",
+    "architecture": "x86_64",
+    "storage": [{
+        "name": "Macintosh HD",
+        "bsd_name": "disk1s1",
+        "capacity": 1000345825280
+      },
+      {
+        "name": "External HD",
+        "bsd_name": "disk2s2",
+        "capacity": 5999654821888
+      }
+    ],
+    "battery": {
+
+    }
+  },
   "hostname": "Fauxhai",
   "idle": "30 days 15 hours 07 minutes 30 seconds",
   "idletime_seconds": 2646450,
@@ -1266,8 +1300,7 @@
         "mtu": "1500",
         "number": "0",
         "ring_params": {},
-        "routes": [
-          {
+        "routes": [{
             "destination": "default",
             "family": "inet",
             "via": "10.0.0.1"


### PR DESCRIPTION
This PR adds a node attribute `hardware` dictionary for runs on `mac_os_x` `10.13`. 

This resolves an issue we worked around here: https://github.com/Microsoft/macos-cookbook/pull/105, where the `node['hardware']` is `nil`. Our current workaround is to delay lookups against `node['hardware']` until our library class, but it'd be nice to be able to do it in a recipe and not have to stub `node['hardware']` to pass converge tests. 