### PR TITLE
Drop support for Ruby 2.2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,13 +1,12 @@
 language: ruby
 cache: bundler
-sudo: false
-dist: trusty
+dist: xenial
 
 rvm:
- - 2.2.10
- - 2.3.7
- - 2.4.4
- - 2.5.1
+ - 2.3.8
+ - 2.4.5
+ - 2.5.3
+ - 2.6.0
 
 branches:
   only:

--- a/fauxhai.gemspec
+++ b/fauxhai.gemspec
@@ -12,7 +12,7 @@ Gem::Specification.new do |spec|
   spec.homepage      = 'https://github.com/chefspec/fauxhai'
   spec.license       = 'MIT'
 
-  spec.required_ruby_version = '>= 2.2.2'
+  spec.required_ruby_version = '>= 2.3'
 
   spec.files         = %w{LICENSE} + Dir.glob("{lib,bin}/**/*", File::FNM_DOTMATCH).reject { |f| File.directory?(f) }
   spec.executables   = 'fauxhai'
@@ -20,8 +20,8 @@ Gem::Specification.new do |spec|
 
   spec.add_runtime_dependency 'net-ssh'
 
-  spec.add_development_dependency 'chef', '>= 12.0'
-  spec.add_development_dependency 'ohai', '>= 8.5'
+  spec.add_development_dependency 'chef', '>= 13.0'
+  spec.add_development_dependency 'ohai', '>= 13.0'
   spec.add_development_dependency 'rake'
   spec.add_development_dependency 'rspec', '~> 3.7'
   spec.add_development_dependency 'rspec-its', '~> 1.2'


### PR DESCRIPTION
Also cleanup travis testing a bit and require Chef 13+ as a dev dep

Signed-off-by: Tim Smith <tsmith@chef.io>