### PR TITLE
Populate dmi attribute hash for Oracle 6.10 Fauxhai platform data

### DIFF
--- a/lib/fauxhai/platforms/oracle/6.10.json
+++ b/lib/fauxhai/platforms/oracle/6.10.json
@@ -241,7 +241,140 @@
     "total": 1
   },
   "current_user": "fauxhai",
-  "dmi": {},
+  "dmi": {
+    "bios": {
+      "address": "0xE8000",
+      "all_records": [
+        {
+          "Address": "0xE8000",
+          "BIOS Revision": "4.2",
+          "Characteristics": {
+            "EDD is supported": null,
+            "PCI is supported": null,
+            "Targeted content distribution is supported": null
+          },
+          "ROM Size": "64 kB",
+          "Release Date": "08/24/2006",
+          "Runtime Size": "96 kB",
+          "Vendor": "Xen",
+          "Version": "4.2.amazon",
+          "application_identifier": "BIOS Information",
+          "record_id": "0x0000",
+          "size": "0"
+        }
+      ],
+      "bios_revision": "4.2",
+      "release_date": "08/24/2006",
+      "rom_size": "64 kB",
+      "runtime_size": "96 kB",
+      "vendor": "Xen",
+      "version": "4.2.amazon"
+    },
+    "chassis": {
+      "all_records": [
+        {
+          "Asset Tag": "Not Specified",
+          "Boot-up State": "Safe",
+          "Lock": "Not Present",
+          "Manufacturer": "Xen",
+          "Power Supply State": "Safe",
+          "Security Status": "Unknown",
+          "Serial Number": "Not Specified",
+          "Thermal State": "Safe",
+          "Type": "Other",
+          "Version": "Not Specified",
+          "application_identifier": "Chassis Information",
+          "record_id": "0x0300",
+          "size": "3"
+        }
+      ],
+      "asset_tag": "Not Specified",
+      "boot_up_state": "Safe",
+      "lock": "Not Present",
+      "manufacturer": "Xen",
+      "power_supply_state": "Safe",
+      "security_status": "Unknown",
+      "serial_number": "Not Specified",
+      "thermal_state": "Safe",
+      "type": "Other",
+      "version": "Not Specified"
+    },
+    "dmidecode_version": "2.12",
+    "oem_strings": {
+      "all_records": [
+        {
+          "String 1": "Xen",
+          "application_identifier": "OEM Strings",
+          "record_id": "0x0B00",
+          "size": "11"
+        }
+      ],
+      "string_1": "Xen"
+    },
+    "processor": {
+      "all_records": [
+        {
+          "Current Speed": "2400 MHz",
+          "External Clock": "Unknown",
+          "Family": "Other",
+          "ID": "F2 06 03 00 FF FB 89 17",
+          "Manufacturer": "Intel",
+          "Max Speed": "2400 MHz",
+          "Socket Designation": "CPU 1",
+          "Status": "Populated, Enabled",
+          "Type": "Central Processor",
+          "Upgrade": "Other",
+          "Version": "Not Specified",
+          "Voltage": "Unknown",
+          "application_identifier": "Processor Information",
+          "record_id": "0x0401",
+          "size": "4"
+        }
+      ],
+      "current_speed": "2400 MHz",
+      "external_clock": "Unknown",
+      "family": "Other",
+      "id": "F2 06 03 00 FF FB 89 17",
+      "manufacturer": "Intel",
+      "max_speed": "2400 MHz",
+      "socket_designation": "CPU 1",
+      "status": "Populated, Enabled",
+      "type": "Central Processor",
+      "upgrade": "Other",
+      "version": "Not Specified",
+      "voltage": "Unknown"
+    },
+    "smbios_version": "2.7",
+    "structures": {
+      "count": "11",
+      "size": "359"
+    },
+    "system": {
+      "all_records": [
+        {
+          "Family": "Not Specified",
+          "Manufacturer": "Xen",
+          "Product Name": "HVM domU",
+          "SKU Number": "Not Specified",
+          "Serial Number": "ec246e3a-d27d-83c1-95ca-9ac49d076e97",
+          "UUID": "EC246E3A-D27D-83C1-95CA-9AC49D076E97",
+          "Version": "4.2.amazon",
+          "Wake-up Type": "Power Switch",
+          "application_identifier": "System Information",
+          "record_id": "0x0100",
+          "size": "1"
+        }
+      ],
+      "family": "Not Specified",
+      "manufacturer": "Xen",
+      "product_name": "HVM domU",
+      "serial_number": "ec246e3a-d27d-83c1-95ca-9ac49d076e97",
+      "sku_number": "Not Specified",
+      "uuid": "EC246E3A-D27D-83C1-95CA-9AC49D076E97",
+      "version": "4.2.amazon",
+      "wake_up_type": "Power Switch"
+    }
+  },
   "domain": "local",
   "filesystem": {
     "by_device": {


### PR DESCRIPTION
Signed-off-by: Matthew Newell <matthew.newell@cerner.com>

This change populates the dmi attribute key within the Oracle 6.10 platform. This brings the 6.10 Fauxhai platform in line with the other Oracle OS versions.