### PR TITLE
Resolve warning about usage of URI.open

### DIFF
--- a/lib/fauxhai/mocker.rb
+++ b/lib/fauxhai/mocker.rb
@@ -47,7 +47,7 @@ module Fauxhai
           # Try loading from github (in case someone submitted a PR with a new file, but we haven't
           # yet updated the gem version). Cache the response locally so it's faster next time.
           begin
-            response = open("#{RAW_BASE}/lib/fauxhai/platforms/#{platform}/#{version}.json")
+            response = URI.open("#{RAW_BASE}/lib/fauxhai/platforms/#{platform}/#{version}.json")
           rescue OpenURI::HTTPError
             raise Fauxhai::Exception::InvalidPlatform.new("Could not find platform '#{platform}/#{version}' on the local disk and an HTTP error was encountered when fetching from Github. #{PLATFORM_LIST_MESSAGE}")
           end


### PR DESCRIPTION
Use URI.open not open

Signed-off-by: Tim Smith <tsmith@chef.io>