### PR TITLE
Lazy require open-uri and net/ssh

### DIFF
--- a/lib/fauxhai/fetcher.rb
+++ b/lib/fauxhai/fetcher.rb
@@ -1,6 +1,5 @@
 require "digest/sha1"
 require "json" unless defined?(JSON)
-require "net/ssh" unless defined?(Net::SSH)
 
 module Fauxhai
   class Fetcher
@@ -10,6 +9,7 @@ module Fauxhai
       if !force_cache_miss? && cached?
         @data = cache
       else
+        require "net/ssh" unless defined?(Net::SSH)
         Net::SSH.start(host, user, @options) do |ssh|
           @data = JSON.parse(ssh.exec!("ohai"))
         end

--- a/lib/fauxhai/mocker.rb
+++ b/lib/fauxhai/mocker.rb
@@ -1,6 +1,5 @@
 require "json" unless defined?(JSON)
 require "pathname" unless defined?(Pathname)
-require "open-uri"
 
 module Fauxhai
   class Mocker
@@ -46,6 +45,7 @@ module Fauxhai
         elsif @options[:github_fetching]
           # Try loading from github (in case someone submitted a PR with a new file, but we haven't
           # yet updated the gem version). Cache the response locally so it's faster next time.
+          require "open-uri" unless defined?(OpenURI)
           begin
             response = URI.open("#{RAW_BASE}/lib/fauxhai/platforms/#{platform}/#{version}.json")
           rescue OpenURI::HTTPError


### PR DESCRIPTION
We require all of fauxhai in chefspec, but 99.9999999% of the time we
don't do GitHub fetch or mock out data using SSH. There's no need to
load these libraries

Signed-off-by: Tim Smith <tsmith@chef.io>