### PR TITLE
Deprecate SmartOS definition

### DIFF
--- a/PLATFORMS.md
+++ b/PLATFORMS.md
@@ -88,7 +88,7 @@ This file lists each platform known to Fauxhai and the available versions for ea
 
 ### smartos
 
-- 5.11
+- 5.11 (deprecated)
 
 ### solaris2
 

--- a/lib/fauxhai/platforms/smartos/5.11.json
+++ b/lib/fauxhai/platforms/smartos/5.11.json
@@ -9,6 +9,7 @@
       "version": "6.20.0"
     }
   },
+  "deprecated": true,
   "command": {
     "ps": "ps -ef"
   },

--- a/platforms.json
+++ b/platforms.json
@@ -167,7 +167,7 @@
   },
   "smartos": {
     "5.11": {
-      "deprecated": false,
+      "deprecated": true,
       "path": "lib/fauxhai/platforms/smartos/5.11.json"
     }
   },


### PR DESCRIPTION
This is a super old definition for old OS release and Chef release.

Signed-off-by: Tim Smith <tsmith@chef.io>