### PR TITLE
CentOS Stream 8 & 9 data

### DIFF
--- a/PLATFORMS.md
+++ b/PLATFORMS.md
@@ -27,6 +27,10 @@ This file lists each platform known to Fauxhai and the available versions for ea
 - 7.8.2003
 - 8
 
+### centos-stream
+
+- 8
+
 ### clearos
 
 - 7.4

--- a/lib/fauxhai/platforms/centos-stream/8.json
+++ b/lib/fauxhai/platforms/centos-stream/8.json
@@ -16,13 +16,13 @@
   },
   "chef_packages": {
     "chef": {
-      "version": "17.9.26",
-      "chef_root": "/opt/chef/embedded/lib/ruby/gems/3.0.0/gems/chef-17.9.26/lib",
+      "version": "18.1.0",
+      "chef_root": "/opt/chef/embedded/lib/ruby/gems/3.1.0/gems/chef-18.1.0/lib",
       "chef_effortless": null
     },
     "ohai": {
-      "version": "17.9.1",
-      "ohai_root": "/opt/chef/embedded/lib/ruby/gems/3.0.0/gems/ohai-17.9.1/lib/ohai"
+      "version": "18.0.26",
+      "ohai_root": "/opt/chef/embedded/lib/ruby/gems/3.1.0/gems/ohai-18.0.26/lib/ohai"
     }
   },
   "command": {
@@ -122,7 +122,7 @@
           "Product Name": "VirtualBox",
           "Version": "1.2",
           "Serial Number": "0",
-          "UUID": "da8a21f1-856a-2e46-95f6-78c789ce0179",
+          "UUID": "ba2dcf84-dfa6-b74d-91e0-0c4890823590",
           "Wake-up Type": "Power Switch",
           "SKU Number": "Not Specified",
           "Family": "Virtual Machine"
@@ -132,7 +132,7 @@
       "product_name": "VirtualBox",
       "version": "1.2",
       "serial_number": "0",
-      "uuid": "da8a21f1-856a-2e46-95f6-78c789ce0179",
+      "uuid": "ba2dcf84-dfa6-b74d-91e0-0c4890823590",
       "wake_up_type": "Power Switch",
       "sku_number": "Not Specified",
       "family": "Virtual Machine"
@@ -202,33 +202,33 @@
           "record_id": "0x0002",
           "size": "11",
           "application_identifier": "OEM Strings",
-          "String 1": "vboxVer_6.1.32",
-          "String 2": "vboxRev_149290"
+          "String 1": "vboxVer_6.1.42",
+          "String 2": "vboxRev_155177"
         }
       ],
-      "string_1": "vboxVer_6.1.32",
-      "string_2": "vboxRev_149290"
+      "string_1": "vboxVer_6.1.42",
+      "string_2": "vboxRev_155177"
     }
   },
   "domain": "local",
   "filesystem": {
     "by_device": {
       "devtmpfs": {
-        "kb_size": "913212",
+        "kb_size": "1892916",
         "kb_used": "0",
-        "kb_available": "913212",
+        "kb_available": "1892916",
         "percent_used": "0%",
-        "total_inodes": "228303",
+        "total_inodes": "473229",
         "inodes_used": "326",
-        "inodes_available": "227977",
+        "inodes_available": "472903",
         "inodes_percent_used": "1%",
         "fs_type": "devtmpfs",
         "mount_options": [
           "rw",
           "nosuid",
           "seclabel",
-          "size=913212k",
-          "nr_inodes=228303",
+          "size=1892916k",
+          "nr_inodes=473229",
           "mode=755"
         ],
         "mounts": [
@@ -236,13 +236,13 @@
         ]
       },
       "tmpfs": {
-        "kb_size": "186056",
+        "kb_size": "382136",
         "kb_used": "0",
-        "kb_available": "186056",
+        "kb_available": "382136",
         "percent_used": "0%",
-        "total_inodes": "232570",
+        "total_inodes": "477673",
         "inodes_used": "5",
-        "inodes_available": "232565",
+        "inodes_available": "477668",
         "inodes_percent_used": "1%",
         "fs_type": "tmpfs",
         "mount_options": [
@@ -251,25 +251,26 @@
           "nodev",
           "relatime",
           "seclabel",
-          "size=186056k",
-          "mode=700"
+          "size=382136k",
+          "mode=700",
+          "uid=1000",
+          "gid=1000"
         ],
         "mounts": [
           "/dev/shm",
           "/run",
           "/sys/fs/cgroup",
-          "/run/user/1000",
-          "/run/user/0"
+          "/run/user/1000"
         ]
       },
       "/dev/sda2": {
-        "kb_size": "64829516",
-        "kb_used": "2689348",
-        "kb_available": "62140168",
-        "percent_used": "5%",
-        "total_inodes": "32430592",
-        "inodes_used": "47361",
-        "inodes_available": "32383231",
+        "kb_size": "64837704",
+        "kb_used": "1873192",
+        "kb_available": "62964512",
+        "percent_used": "3%",
+        "total_inodes": "32434688",
+        "inodes_used": "43242",
+        "inodes_available": "32391446",
         "inodes_percent_used": "1%",
         "fs_type": "xfs",
         "mount_options": [
@@ -282,16 +283,16 @@
           "logbsize=32k",
           "noquota"
         ],
-        "uuid": "63ee0043-c7c5-4fcd-a3e1-b87d4b320bc4",
+        "uuid": "c7a12ab8-69a7-4fc3-8af2-9bca350a92cc",
         "mounts": [
           "/"
         ]
       },
       "vagrant": {
-        "kb_size": "495333060",
-        "kb_used": "456844832",
-        "kb_available": "38488228",
-        "percent_used": "93%",
+        "kb_size": "492054648",
+        "kb_used": "396776644",
+        "kb_available": "95278004",
+        "percent_used": "81%",
         "fs_type": "vboxsf",
         "mount_options": [
           "rw",
@@ -371,21 +372,21 @@
           "noexec",
           "relatime",
           "seclabel",
-          "devices"
+          "rdma"
         ],
         "mounts": [
           "/sys/fs/cgroup/systemd",
-          "/sys/fs/cgroup/blkio",
-          "/sys/fs/cgroup/memory",
-          "/sys/fs/cgroup/pids",
           "/sys/fs/cgroup/cpu,cpuacct",
           "/sys/fs/cgroup/net_cls,net_prio",
+          "/sys/fs/cgroup/blkio",
+          "/sys/fs/cgroup/devices",
+          "/sys/fs/cgroup/hugetlb",
           "/sys/fs/cgroup/perf_event",
           "/sys/fs/cgroup/cpuset",
-          "/sys/fs/cgroup/rdma",
           "/sys/fs/cgroup/freezer",
-          "/sys/fs/cgroup/hugetlb",
-          "/sys/fs/cgroup/devices"
+          "/sys/fs/cgroup/pids",
+          "/sys/fs/cgroup/memory",
+          "/sys/fs/cgroup/rdma"
         ]
       },
       "pstore": {
@@ -452,27 +453,16 @@
         "mount_options": [
           "rw",
           "relatime",
-          "fd=35",
+          "fd=31",
           "pgrp=1",
           "timeout=0",
           "minproto=5",
           "maxproto=5",
           "direct",
-          "pipe_ino=18053"
+          "pipe_ino=13755"
         ],
         "mounts": [
           "/proc/sys/fs/binfmt_misc"
-        ]
-      },
-      "mqueue": {
-        "fs_type": "mqueue",
-        "mount_options": [
-          "rw",
-          "relatime",
-          "seclabel"
-        ],
-        "mounts": [
-          "/dev/mqueue"
         ]
       },
       "hugetlbfs": {
@@ -485,6 +475,17 @@
         ],
         "mounts": [
           "/dev/hugepages"
+        ]
+      },
+      "mqueue": {
+        "fs_type": "mqueue",
+        "mount_options": [
+          "rw",
+          "relatime",
+          "seclabel"
+        ],
+        "mounts": [
+          "/dev/mqueue"
         ]
       },
       "debugfs": {
@@ -515,7 +516,7 @@
       },
       "/dev/sda1": {
         "fs_type": "swap",
-        "uuid": "0d01112d-3db9-4c8b-9b6b-9db9416fb74d",
+        "uuid": "37d4a022-8ce6-48a4-9adc-a7c490916194",
         "mounts": [
 
         ]
@@ -523,21 +524,21 @@
     },
     "by_mountpoint": {
       "/dev": {
-        "kb_size": "913212",
+        "kb_size": "1892916",
         "kb_used": "0",
-        "kb_available": "913212",
+        "kb_available": "1892916",
         "percent_used": "0%",
-        "total_inodes": "228303",
+        "total_inodes": "473229",
         "inodes_used": "326",
-        "inodes_available": "227977",
+        "inodes_available": "472903",
         "inodes_percent_used": "1%",
         "fs_type": "devtmpfs",
         "mount_options": [
           "rw",
           "nosuid",
           "seclabel",
-          "size=913212k",
-          "nr_inodes=228303",
+          "size=1892916k",
+          "nr_inodes=473229",
           "mode=755"
         ],
         "devices": [
@@ -545,13 +546,13 @@
         ]
       },
       "/dev/shm": {
-        "kb_size": "930280",
+        "kb_size": "1910692",
         "kb_used": "0",
-        "kb_available": "930280",
+        "kb_available": "1910692",
         "percent_used": "0%",
-        "total_inodes": "232570",
+        "total_inodes": "477673",
         "inodes_used": "1",
-        "inodes_available": "232569",
+        "inodes_available": "477672",
         "inodes_percent_used": "1%",
         "fs_type": "tmpfs",
         "mount_options": [
@@ -565,13 +566,13 @@
         ]
       },
       "/run": {
-        "kb_size": "930280",
-        "kb_used": "16804",
-        "kb_available": "913476",
-        "percent_used": "2%",
-        "total_inodes": "232570",
-        "inodes_used": "461",
-        "inodes_available": "232109",
+        "kb_size": "1910692",
+        "kb_used": "16772",
+        "kb_available": "1893920",
+        "percent_used": "1%",
+        "total_inodes": "477673",
+        "inodes_used": "446",
+        "inodes_available": "477227",
         "inodes_percent_used": "1%",
         "fs_type": "tmpfs",
         "mount_options": [
@@ -586,13 +587,13 @@
         ]
       },
       "/sys/fs/cgroup": {
-        "kb_size": "930280",
+        "kb_size": "1910692",
         "kb_used": "0",
-        "kb_available": "930280",
+        "kb_available": "1910692",
         "percent_used": "0%",
-        "total_inodes": "232570",
+        "total_inodes": "477673",
         "inodes_used": "17",
-        "inodes_available": "232553",
+        "inodes_available": "477656",
         "inodes_percent_used": "1%",
         "fs_type": "tmpfs",
         "mount_options": [
@@ -608,13 +609,13 @@
         ]
       },
       "/": {
-        "kb_size": "64829516",
-        "kb_used": "2689348",
-        "kb_available": "62140168",
-        "percent_used": "5%",
-        "total_inodes": "32430592",
-        "inodes_used": "47361",
-        "inodes_available": "32383231",
+        "kb_size": "64837704",
+        "kb_used": "1873192",
+        "kb_available": "62964512",
+        "percent_used": "3%",
+        "total_inodes": "32434688",
+        "inodes_used": "43242",
+        "inodes_available": "32391446",
         "inodes_percent_used": "1%",
         "fs_type": "xfs",
         "mount_options": [
@@ -627,16 +628,16 @@
           "logbsize=32k",
           "noquota"
         ],
-        "uuid": "63ee0043-c7c5-4fcd-a3e1-b87d4b320bc4",
+        "uuid": "c7a12ab8-69a7-4fc3-8af2-9bca350a92cc",
         "devices": [
           "/dev/sda2"
         ]
       },
       "/vagrant": {
-        "kb_size": "495333060",
-        "kb_used": "456844832",
-        "kb_available": "38488228",
-        "percent_used": "93%",
+        "kb_size": "492054648",
+        "kb_used": "396776644",
+        "kb_available": "95278004",
+        "percent_used": "81%",
         "fs_type": "vboxsf",
         "mount_options": [
           "rw",
@@ -652,13 +653,13 @@
         ]
       },
       "/run/user/1000": {
-        "kb_size": "186056",
+        "kb_size": "382136",
         "kb_used": "0",
-        "kb_available": "186056",
+        "kb_available": "382136",
         "percent_used": "0%",
-        "total_inodes": "232570",
+        "total_inodes": "477673",
         "inodes_used": "5",
-        "inodes_available": "232565",
+        "inodes_available": "477668",
         "inodes_percent_used": "1%",
         "fs_type": "tmpfs",
         "mount_options": [
@@ -667,33 +668,10 @@
           "nodev",
           "relatime",
           "seclabel",
-          "size=186056k",
+          "size=382136k",
           "mode=700",
           "uid=1000",
           "gid=1000"
-        ],
-        "devices": [
-          "tmpfs"
-        ]
-      },
-      "/run/user/0": {
-        "kb_size": "186056",
-        "kb_used": "0",
-        "kb_available": "186056",
-        "percent_used": "0%",
-        "total_inodes": "232570",
-        "inodes_used": "5",
-        "inodes_available": "232565",
-        "inodes_percent_used": "1%",
-        "fs_type": "tmpfs",
-        "mount_options": [
-          "rw",
-          "nosuid",
-          "nodev",
-          "relatime",
-          "seclabel",
-          "size=186056k",
-          "mode=700"
         ],
         "devices": [
           "tmpfs"
@@ -800,51 +778,6 @@
           "bpf"
         ]
       },
-      "/sys/fs/cgroup/blkio": {
-        "fs_type": "cgroup",
-        "mount_options": [
-          "rw",
-          "nosuid",
-          "nodev",
-          "noexec",
-          "relatime",
-          "seclabel",
-          "blkio"
-        ],
-        "devices": [
-          "cgroup"
-        ]
-      },
-      "/sys/fs/cgroup/memory": {
-        "fs_type": "cgroup",
-        "mount_options": [
-          "rw",
-          "nosuid",
-          "nodev",
-          "noexec",
-          "relatime",
-          "seclabel",
-          "memory"
-        ],
-        "devices": [
-          "cgroup"
-        ]
-      },
-      "/sys/fs/cgroup/pids": {
-        "fs_type": "cgroup",
-        "mount_options": [
-          "rw",
-          "nosuid",
-          "nodev",
-          "noexec",
-          "relatime",
-          "seclabel",
-          "pids"
-        ],
-        "devices": [
-          "cgroup"
-        ]
-      },
       "/sys/fs/cgroup/cpu,cpuacct": {
         "fs_type": "cgroup",
         "mount_options": [
@@ -872,6 +805,51 @@
           "seclabel",
           "net_cls",
           "net_prio"
+        ],
+        "devices": [
+          "cgroup"
+        ]
+      },
+      "/sys/fs/cgroup/blkio": {
+        "fs_type": "cgroup",
+        "mount_options": [
+          "rw",
+          "nosuid",
+          "nodev",
+          "noexec",
+          "relatime",
+          "seclabel",
+          "blkio"
+        ],
+        "devices": [
+          "cgroup"
+        ]
+      },
+      "/sys/fs/cgroup/devices": {
+        "fs_type": "cgroup",
+        "mount_options": [
+          "rw",
+          "nosuid",
+          "nodev",
+          "noexec",
+          "relatime",
+          "seclabel",
+          "devices"
+        ],
+        "devices": [
+          "cgroup"
+        ]
+      },
+      "/sys/fs/cgroup/hugetlb": {
+        "fs_type": "cgroup",
+        "mount_options": [
+          "rw",
+          "nosuid",
+          "nodev",
+          "noexec",
+          "relatime",
+          "seclabel",
+          "hugetlb"
         ],
         "devices": [
           "cgroup"
@@ -907,21 +885,6 @@
           "cgroup"
         ]
       },
-      "/sys/fs/cgroup/rdma": {
-        "fs_type": "cgroup",
-        "mount_options": [
-          "rw",
-          "nosuid",
-          "nodev",
-          "noexec",
-          "relatime",
-          "seclabel",
-          "rdma"
-        ],
-        "devices": [
-          "cgroup"
-        ]
-      },
       "/sys/fs/cgroup/freezer": {
         "fs_type": "cgroup",
         "mount_options": [
@@ -937,7 +900,7 @@
           "cgroup"
         ]
       },
-      "/sys/fs/cgroup/hugetlb": {
+      "/sys/fs/cgroup/pids": {
         "fs_type": "cgroup",
         "mount_options": [
           "rw",
@@ -946,13 +909,13 @@
           "noexec",
           "relatime",
           "seclabel",
-          "hugetlb"
+          "pids"
         ],
         "devices": [
           "cgroup"
         ]
       },
-      "/sys/fs/cgroup/devices": {
+      "/sys/fs/cgroup/memory": {
         "fs_type": "cgroup",
         "mount_options": [
           "rw",
@@ -961,7 +924,22 @@
           "noexec",
           "relatime",
           "seclabel",
-          "devices"
+          "memory"
+        ],
+        "devices": [
+          "cgroup"
+        ]
+      },
+      "/sys/fs/cgroup/rdma": {
+        "fs_type": "cgroup",
+        "mount_options": [
+          "rw",
+          "nosuid",
+          "nodev",
+          "noexec",
+          "relatime",
+          "seclabel",
+          "rdma"
         ],
         "devices": [
           "cgroup"
@@ -1003,27 +981,16 @@
         "mount_options": [
           "rw",
           "relatime",
-          "fd=35",
+          "fd=31",
           "pgrp=1",
           "timeout=0",
           "minproto=5",
           "maxproto=5",
           "direct",
-          "pipe_ino=18053"
+          "pipe_ino=13755"
         ],
         "devices": [
           "systemd-1"
-        ]
-      },
-      "/dev/mqueue": {
-        "fs_type": "mqueue",
-        "mount_options": [
-          "rw",
-          "relatime",
-          "seclabel"
-        ],
-        "devices": [
-          "mqueue"
         ]
       },
       "/dev/hugepages": {
@@ -1036,6 +1003,17 @@
         ],
         "devices": [
           "hugetlbfs"
+        ]
+      },
+      "/dev/mqueue": {
+        "fs_type": "mqueue",
+        "mount_options": [
+          "rw",
+          "relatime",
+          "seclabel"
+        ],
+        "devices": [
+          "mqueue"
         ]
       },
       "/sys/kernel/debug": {
@@ -1063,35 +1041,35 @@
     "by_pair": {
       "devtmpfs,/dev": {
         "device": "devtmpfs",
-        "kb_size": "913212",
+        "kb_size": "1892916",
         "kb_used": "0",
-        "kb_available": "913212",
+        "kb_available": "1892916",
         "percent_used": "0%",
         "mount": "/dev",
-        "total_inodes": "228303",
+        "total_inodes": "473229",
         "inodes_used": "326",
-        "inodes_available": "227977",
+        "inodes_available": "472903",
         "inodes_percent_used": "1%",
         "fs_type": "devtmpfs",
         "mount_options": [
           "rw",
           "nosuid",
           "seclabel",
-          "size=913212k",
-          "nr_inodes=228303",
+          "size=1892916k",
+          "nr_inodes=473229",
           "mode=755"
         ]
       },
       "tmpfs,/dev/shm": {
         "device": "tmpfs",
-        "kb_size": "930280",
+        "kb_size": "1910692",
         "kb_used": "0",
-        "kb_available": "930280",
+        "kb_available": "1910692",
         "percent_used": "0%",
         "mount": "/dev/shm",
-        "total_inodes": "232570",
+        "total_inodes": "477673",
         "inodes_used": "1",
-        "inodes_available": "232569",
+        "inodes_available": "477672",
         "inodes_percent_used": "1%",
         "fs_type": "tmpfs",
         "mount_options": [
@@ -1103,14 +1081,14 @@
       },
       "tmpfs,/run": {
         "device": "tmpfs",
-        "kb_size": "930280",
-        "kb_used": "16804",
-        "kb_available": "913476",
-        "percent_used": "2%",
+        "kb_size": "1910692",
+        "kb_used": "16772",
+        "kb_available": "1893920",
+        "percent_used": "1%",
         "mount": "/run",
-        "total_inodes": "232570",
-        "inodes_used": "461",
-        "inodes_available": "232109",
+        "total_inodes": "477673",
+        "inodes_used": "446",
+        "inodes_available": "477227",
         "inodes_percent_used": "1%",
         "fs_type": "tmpfs",
         "mount_options": [
@@ -1123,14 +1101,14 @@
       },
       "tmpfs,/sys/fs/cgroup": {
         "device": "tmpfs",
-        "kb_size": "930280",
+        "kb_size": "1910692",
         "kb_used": "0",
-        "kb_available": "930280",
+        "kb_available": "1910692",
         "percent_used": "0%",
         "mount": "/sys/fs/cgroup",
-        "total_inodes": "232570",
+        "total_inodes": "477673",
         "inodes_used": "17",
-        "inodes_available": "232553",
+        "inodes_available": "477656",
         "inodes_percent_used": "1%",
         "fs_type": "tmpfs",
         "mount_options": [
@@ -1144,14 +1122,14 @@
       },
       "/dev/sda2,/": {
         "device": "/dev/sda2",
-        "kb_size": "64829516",
-        "kb_used": "2689348",
-        "kb_available": "62140168",
-        "percent_used": "5%",
+        "kb_size": "64837704",
+        "kb_used": "1873192",
+        "kb_available": "62964512",
+        "percent_used": "3%",
         "mount": "/",
-        "total_inodes": "32430592",
-        "inodes_used": "47361",
-        "inodes_available": "32383231",
+        "total_inodes": "32434688",
+        "inodes_used": "43242",
+        "inodes_available": "32391446",
         "inodes_percent_used": "1%",
         "fs_type": "xfs",
         "mount_options": [
@@ -1164,14 +1142,14 @@
           "logbsize=32k",
           "noquota"
         ],
-        "uuid": "63ee0043-c7c5-4fcd-a3e1-b87d4b320bc4"
+        "uuid": "c7a12ab8-69a7-4fc3-8af2-9bca350a92cc"
       },
       "vagrant,/vagrant": {
         "device": "vagrant",
-        "kb_size": "495333060",
-        "kb_used": "456844832",
-        "kb_available": "38488228",
-        "percent_used": "93%",
+        "kb_size": "492054648",
+        "kb_used": "396776644",
+        "kb_available": "95278004",
+        "percent_used": "81%",
         "mount": "/vagrant",
         "fs_type": "vboxsf",
         "mount_options": [
@@ -1186,14 +1164,14 @@
       },
       "tmpfs,/run/user/1000": {
         "device": "tmpfs",
-        "kb_size": "186056",
+        "kb_size": "382136",
         "kb_used": "0",
-        "kb_available": "186056",
+        "kb_available": "382136",
         "percent_used": "0%",
         "mount": "/run/user/1000",
-        "total_inodes": "232570",
+        "total_inodes": "477673",
         "inodes_used": "5",
-        "inodes_available": "232565",
+        "inodes_available": "477668",
         "inodes_percent_used": "1%",
         "fs_type": "tmpfs",
         "mount_options": [
@@ -1202,32 +1180,10 @@
           "nodev",
           "relatime",
           "seclabel",
-          "size=186056k",
+          "size=382136k",
           "mode=700",
           "uid=1000",
           "gid=1000"
-        ]
-      },
-      "tmpfs,/run/user/0": {
-        "device": "tmpfs",
-        "kb_size": "186056",
-        "kb_used": "0",
-        "kb_available": "186056",
-        "percent_used": "0%",
-        "mount": "/run/user/0",
-        "total_inodes": "232570",
-        "inodes_used": "5",
-        "inodes_available": "232565",
-        "inodes_percent_used": "1%",
-        "fs_type": "tmpfs",
-        "mount_options": [
-          "rw",
-          "nosuid",
-          "nodev",
-          "relatime",
-          "seclabel",
-          "size=186056k",
-          "mode=700"
         ]
       },
       "sysfs,/sys": {
@@ -1324,48 +1280,6 @@
           "mode=700"
         ]
       },
-      "cgroup,/sys/fs/cgroup/blkio": {
-        "device": "cgroup",
-        "mount": "/sys/fs/cgroup/blkio",
-        "fs_type": "cgroup",
-        "mount_options": [
-          "rw",
-          "nosuid",
-          "nodev",
-          "noexec",
-          "relatime",
-          "seclabel",
-          "blkio"
-        ]
-      },
-      "cgroup,/sys/fs/cgroup/memory": {
-        "device": "cgroup",
-        "mount": "/sys/fs/cgroup/memory",
-        "fs_type": "cgroup",
-        "mount_options": [
-          "rw",
-          "nosuid",
-          "nodev",
-          "noexec",
-          "relatime",
-          "seclabel",
-          "memory"
-        ]
-      },
-      "cgroup,/sys/fs/cgroup/pids": {
-        "device": "cgroup",
-        "mount": "/sys/fs/cgroup/pids",
-        "fs_type": "cgroup",
-        "mount_options": [
-          "rw",
-          "nosuid",
-          "nodev",
-          "noexec",
-          "relatime",
-          "seclabel",
-          "pids"
-        ]
-      },
       "cgroup,/sys/fs/cgroup/cpu,cpuacct": {
         "device": "cgroup",
         "mount": "/sys/fs/cgroup/cpu,cpuacct",
@@ -1396,6 +1310,48 @@
           "net_prio"
         ]
       },
+      "cgroup,/sys/fs/cgroup/blkio": {
+        "device": "cgroup",
+        "mount": "/sys/fs/cgroup/blkio",
+        "fs_type": "cgroup",
+        "mount_options": [
+          "rw",
+          "nosuid",
+          "nodev",
+          "noexec",
+          "relatime",
+          "seclabel",
+          "blkio"
+        ]
+      },
+      "cgroup,/sys/fs/cgroup/devices": {
+        "device": "cgroup",
+        "mount": "/sys/fs/cgroup/devices",
+        "fs_type": "cgroup",
+        "mount_options": [
+          "rw",
+          "nosuid",
+          "nodev",
+          "noexec",
+          "relatime",
+          "seclabel",
+          "devices"
+        ]
+      },
+      "cgroup,/sys/fs/cgroup/hugetlb": {
+        "device": "cgroup",
+        "mount": "/sys/fs/cgroup/hugetlb",
+        "fs_type": "cgroup",
+        "mount_options": [
+          "rw",
+          "nosuid",
+          "nodev",
+          "noexec",
+          "relatime",
+          "seclabel",
+          "hugetlb"
+        ]
+      },
       "cgroup,/sys/fs/cgroup/perf_event": {
         "device": "cgroup",
         "mount": "/sys/fs/cgroup/perf_event",
@@ -1424,20 +1380,6 @@
           "cpuset"
         ]
       },
-      "cgroup,/sys/fs/cgroup/rdma": {
-        "device": "cgroup",
-        "mount": "/sys/fs/cgroup/rdma",
-        "fs_type": "cgroup",
-        "mount_options": [
-          "rw",
-          "nosuid",
-          "nodev",
-          "noexec",
-          "relatime",
-          "seclabel",
-          "rdma"
-        ]
-      },
       "cgroup,/sys/fs/cgroup/freezer": {
         "device": "cgroup",
         "mount": "/sys/fs/cgroup/freezer",
@@ -1452,9 +1394,9 @@
           "freezer"
         ]
       },
-      "cgroup,/sys/fs/cgroup/hugetlb": {
+      "cgroup,/sys/fs/cgroup/pids": {
         "device": "cgroup",
-        "mount": "/sys/fs/cgroup/hugetlb",
+        "mount": "/sys/fs/cgroup/pids",
         "fs_type": "cgroup",
         "mount_options": [
           "rw",
@@ -1463,12 +1405,12 @@
           "noexec",
           "relatime",
           "seclabel",
-          "hugetlb"
+          "pids"
         ]
       },
-      "cgroup,/sys/fs/cgroup/devices": {
+      "cgroup,/sys/fs/cgroup/memory": {
         "device": "cgroup",
-        "mount": "/sys/fs/cgroup/devices",
+        "mount": "/sys/fs/cgroup/memory",
         "fs_type": "cgroup",
         "mount_options": [
           "rw",
@@ -1477,7 +1419,21 @@
           "noexec",
           "relatime",
           "seclabel",
-          "devices"
+          "memory"
+        ]
+      },
+      "cgroup,/sys/fs/cgroup/rdma": {
+        "device": "cgroup",
+        "mount": "/sys/fs/cgroup/rdma",
+        "fs_type": "cgroup",
+        "mount_options": [
+          "rw",
+          "nosuid",
+          "nodev",
+          "noexec",
+          "relatime",
+          "seclabel",
+          "rdma"
         ]
       },
       "none,/sys/kernel/tracing": {
@@ -1515,23 +1471,13 @@
         "mount_options": [
           "rw",
           "relatime",
-          "fd=35",
+          "fd=31",
           "pgrp=1",
           "timeout=0",
           "minproto=5",
           "maxproto=5",
           "direct",
-          "pipe_ino=18053"
-        ]
-      },
-      "mqueue,/dev/mqueue": {
-        "device": "mqueue",
-        "mount": "/dev/mqueue",
-        "fs_type": "mqueue",
-        "mount_options": [
-          "rw",
-          "relatime",
-          "seclabel"
+          "pipe_ino=13755"
         ]
       },
       "hugetlbfs,/dev/hugepages": {
@@ -1543,6 +1489,16 @@
           "relatime",
           "seclabel",
           "pagesize=2M"
+        ]
+      },
+      "mqueue,/dev/mqueue": {
+        "device": "mqueue",
+        "mount": "/dev/mqueue",
+        "fs_type": "mqueue",
+        "mount_options": [
+          "rw",
+          "relatime",
+          "seclabel"
         ]
       },
       "debugfs,/sys/kernel/debug": {
@@ -1570,13 +1526,13 @@
       "/dev/sda1,": {
         "device": "/dev/sda1",
         "fs_type": "swap",
-        "uuid": "0d01112d-3db9-4c8b-9b6b-9db9416fb74d"
+        "uuid": "37d4a022-8ce6-48a4-9adc-a7c490916194"
       }
     }
   },
   "fips": {
     "kernel": {
-      "enabled": true
+      "enabled": false
     }
   },
   "fqdn": "fauxhai.local",
@@ -1587,8 +1543,8 @@
   "ipaddress": "10.0.0.2",
   "kernel": {
     "name": "Linux",
-    "release": "4.18.0-348.2.1.el8_5.x86_64",
-    "version": "#1 SMP Tue Nov 16 14:42:35 UTC 2021",
+    "release": "4.18.0-383.el8.x86_64",
+    "version": "#1 SMP Wed Apr 20 15:38:08 UTC 2022",
     "machine": "x86_64",
     "processor": "x86_64",
     "os": "GNU/Linux",
@@ -1596,7 +1552,7 @@
       "vboxsf": {
         "size": "90112",
         "refcount": "1",
-        "version": "6.1.30 r148432"
+        "version": "6.1.32 r149290"
       },
       "intel_rapl_msr": {
         "size": "16384",
@@ -1605,6 +1561,14 @@
       "intel_rapl_common": {
         "size": "24576",
         "refcount": "1"
+      },
+      "intel_pmc_core_pltdrv": {
+        "size": "16384",
+        "refcount": "0"
+      },
+      "intel_pmc_core": {
+        "size": "49152",
+        "refcount": "0"
       },
       "crct10dif_pclmul": {
         "size": "16384",
@@ -1622,6 +1586,10 @@
         "size": "20480",
         "refcount": "0"
       },
+      "i2c_piix4": {
+        "size": "24576",
+        "refcount": "0"
+      },
       "pcspkr": {
         "size": "16384",
         "refcount": "0"
@@ -1630,20 +1598,16 @@
         "size": "24576",
         "refcount": "0"
       },
-      "i2c_piix4": {
-        "size": "24576",
-        "refcount": "0"
-      },
       "video": {
         "size": "49152",
         "refcount": "0"
       },
       "sunrpc": {
-        "size": "557056",
+        "size": "565248",
         "refcount": "1"
       },
       "xfs": {
-        "size": "1544192",
+        "size": "1556480",
         "refcount": "1"
       },
       "libcrc32c": {
@@ -1669,62 +1633,16 @@
         "version": "0.2.15"
       },
       "vboxvideo": {
-        "size": "45056",
-        "refcount": "1",
-        "version": "6.1.30 r148432"
-      },
-      "drm_ttm_helper": {
-        "size": "16384",
-        "refcount": "1"
-      },
-      "ttm": {
-        "size": "77824",
-        "refcount": "2"
-      },
-      "drm_kms_helper": {
-        "size": "253952",
-        "refcount": "1"
-      },
-      "drm": {
-        "size": "573440",
-        "refcount": "5"
-      },
-      "ahci": {
-        "size": "40960",
-        "refcount": "2",
-        "version": "3.0"
-      },
-      "libahci": {
-        "size": "40960",
-        "refcount": "1"
-      },
-      "ata_piix": {
-        "size": "36864",
-        "refcount": "0",
-        "version": "2.13"
-      },
-      "libata": {
-        "size": "270336",
-        "refcount": "4",
-        "version": "3.00"
-      },
-      "crc32c_intel": {
-        "size": "24576",
-        "refcount": "1"
-      },
-      "e1000": {
-        "size": "151552",
-        "refcount": "0",
-        "version": "7.3.21-k8-NAPI"
-      },
-      "serio_raw": {
-        "size": "16384",
+        "size": "32768",
         "refcount": "0"
       },
-      "vboxguest": {
-        "size": "385024",
-        "refcount": "2",
-        "version": "6.1.30 r148432"
+      "drm_vram_helper": {
+        "size": "20480",
+        "refcount": "1"
+      },
+      "drm_kms_helper": {
+        "size": "266240",
+        "refcount": "4"
       },
       "syscopyarea": {
         "size": "16384",
@@ -1741,6 +1659,55 @@
       "fb_sys_fops": {
         "size": "16384",
         "refcount": "1"
+      },
+      "drm_ttm_helper": {
+        "size": "16384",
+        "refcount": "2"
+      },
+      "ttm": {
+        "size": "73728",
+        "refcount": "2"
+      },
+      "ahci": {
+        "size": "40960",
+        "refcount": "2",
+        "version": "3.0"
+      },
+      "libahci": {
+        "size": "40960",
+        "refcount": "1"
+      },
+      "ata_piix": {
+        "size": "36864",
+        "refcount": "0",
+        "version": "2.13"
+      },
+      "drm": {
+        "size": "585728",
+        "refcount": "6"
+      },
+      "e1000": {
+        "size": "151552",
+        "refcount": "0",
+        "version": "7.3.21-k8-NAPI"
+      },
+      "crc32c_intel": {
+        "size": "24576",
+        "refcount": "1"
+      },
+      "vboxguest": {
+        "size": "385024",
+        "refcount": "2",
+        "version": "6.1.32 r149290"
+      },
+      "serio_raw": {
+        "size": "16384",
+        "refcount": "0"
+      },
+      "libata": {
+        "size": "262144",
+        "refcount": "4",
+        "version": "3.00"
       }
     }
   },
@@ -1753,8 +1720,8 @@
   "languages": {
     "ruby": {
       "platform": "x86_64-linux",
-      "version": "3.0.3",
-      "release_date": "2021-11-24",
+      "version": "3.1.2",
+      "release_date": "2022-04-12",
       "target": "x86_64-pc-linux-gnu",
       "target_cpu": "x86_64",
       "target_vendor": "pc",
@@ -1875,7 +1842,7 @@
     "default_interface": "eth0",
     "default_gateway": "10.0.0.1"
   },
-  "ohai_time": 1643239257.2132964,
+  "ohai_time": 1675120120.157616,
   "os": "linux",
   "os_release": {
     "name": "CentOS Stream",
@@ -1895,3967 +1862,3905 @@
     "redhat_support_product": "Red Hat Enterprise Linux 8",
     "redhat_support_product_version": "CentOS Stream"
   },
-  "os_version": "4.18.0-348.2.1.el8_5.x86_64",
+  "os_version": "4.18.0-383.el8.x86_64",
   "packages": {
-    "perl-Module-Loaded": {
-      "epoch": "1",
-      "version": "0.08",
-      "release": "421.el8",
-      "installdate": "1640302878",
-      "arch": "noarch"
-    },
-    "tzdata": {
-      "epoch": "0",
-      "version": "2021e",
-      "release": "1.el8",
-      "installdate": "1640302504",
-      "arch": "noarch"
-    },
-    "perl-Pod-Parser": {
-      "epoch": "0",
-      "version": "1.63",
-      "release": "396.el8",
-      "installdate": "1640302878",
-      "arch": "noarch"
-    },
-    "libmodulemd": {
-      "epoch": "0",
-      "version": "2.13.0",
-      "release": "1.el8",
-      "installdate": "1640302537",
-      "arch": "x86_64"
-    },
-    "xkeyboard-config": {
-      "epoch": "0",
-      "version": "2.28",
-      "release": "1.el8",
-      "installdate": "1640302504",
-      "arch": "noarch"
-    },
-    "perl-Test-Simple": {
-      "epoch": "1",
-      "version": "1.302135",
-      "release": "1.el8",
-      "installdate": "1640302878",
-      "arch": "noarch"
-    },
-    "crontabs": {
-      "epoch": "0",
-      "version": "1.11",
-      "release": "17.20190603git.el8",
-      "installdate": "1640302537",
-      "arch": "noarch"
-    },
-    "perl-Unicode-Collate": {
-      "epoch": "0",
-      "version": "1.25",
-      "release": "2.el8",
-      "installdate": "1640302879",
-      "arch": "x86_64"
-    },
-    "kbd-misc": {
-      "epoch": "0",
-      "version": "2.0.4",
-      "release": "10.el8",
-      "installdate": "1640302519",
-      "arch": "noarch"
-    },
-    "perl-Text-Diff": {
-      "epoch": "0",
-      "version": "1.45",
-      "release": "2.el8",
-      "installdate": "1640302879",
-      "arch": "noarch"
-    },
-    "initscripts": {
-      "epoch": "0",
-      "version": "10.00.15",
-      "release": "1.el8",
-      "installdate": "1640302542",
-      "arch": "x86_64"
-    },
-    "perl-File-HomeDir": {
-      "epoch": "0",
-      "version": "1.002",
-      "release": "4.el8",
-      "installdate": "1640302879",
-      "arch": "noarch"
-    },
-    "polkit-libs": {
-      "epoch": "0",
-      "version": "0.115",
-      "release": "12.el8",
-      "installdate": "1640302542",
-      "arch": "x86_64"
-    },
-    "filesystem": {
-      "epoch": "0",
-      "version": "3.8",
-      "release": "6.el8",
-      "installdate": "1640302520",
-      "arch": "x86_64"
-    },
-    "perl-Software-License": {
-      "epoch": "0",
-      "version": "0.103013",
-      "release": "2.el8",
-      "installdate": "1640302879",
-      "arch": "noarch"
-    },
-    "iproute": {
-      "epoch": "0",
-      "version": "5.15.0",
-      "release": "1.el8",
-      "installdate": "1640302543",
-      "arch": "x86_64"
-    },
-    "ncurses-libs": {
-      "epoch": "0",
-      "version": "6.1",
-      "release": "9.20180224.el8",
-      "installdate": "1640302520",
-      "arch": "x86_64"
-    },
-    "zip": {
-      "epoch": "0",
-      "version": "3.0",
-      "release": "23.el8",
-      "installdate": "1640302879",
-      "arch": "x86_64"
-    },
-    "python3-decorator": {
-      "epoch": "0",
-      "version": "4.2.1",
-      "release": "2.el8",
-      "installdate": "1640302543",
-      "arch": "noarch"
-    },
-    "cups-client": {
-      "epoch": "1",
-      "version": "2.2.6",
-      "release": "41.el8",
-      "installdate": "1640302543",
-      "arch": "x86_64"
-    },
-    "info": {
-      "epoch": "0",
-      "version": "6.5",
-      "release": "6.el8",
-      "installdate": "1640302521",
-      "arch": "x86_64"
-    },
-    "qt5-srpm-macros": {
-      "epoch": "0",
-      "version": "5.15.2",
-      "release": "1.el8",
-      "installdate": "1640302881",
-      "arch": "noarch"
-    },
-    "timedatex": {
-      "epoch": "0",
-      "version": "0.5",
-      "release": "3.el8",
-      "installdate": "1640302543",
-      "arch": "x86_64"
-    },
-    "bzip2-libs": {
-      "epoch": "0",
-      "version": "1.0.6",
-      "release": "26.el8",
-      "installdate": "1640302521",
-      "arch": "x86_64"
-    },
-    "python3-libsemanage": {
-      "epoch": "0",
-      "version": "2.9",
-      "release": "6.el8",
-      "installdate": "1640302552",
-      "arch": "x86_64"
-    },
-    "libgpg-error": {
-      "epoch": "0",
-      "version": "1.31",
-      "release": "1.el8",
-      "installdate": "1640302522",
-      "arch": "x86_64"
-    },
-    "ghc-srpm-macros": {
-      "epoch": "0",
-      "version": "1.4.2",
-      "release": "7.el8",
-      "installdate": "1640302883",
-      "arch": "noarch"
-    },
-    "libuuid": {
-      "epoch": "0",
-      "version": "2.32.1",
-      "release": "28.el8",
-      "installdate": "1640302522",
-      "arch": "x86_64"
-    },
-    "perl-ExtUtils-Install": {
-      "epoch": "0",
-      "version": "2.14",
-      "release": "4.el8",
-      "installdate": "1640302883",
-      "arch": "noarch"
-    },
-    "python3-configobj": {
-      "epoch": "0",
-      "version": "5.0.6",
-      "release": "11.el8",
-      "installdate": "1640302552",
-      "arch": "noarch"
-    },
-    "libzstd": {
-      "epoch": "0",
-      "version": "1.4.4",
-      "release": "1.el8",
-      "installdate": "1640302522",
-      "arch": "x86_64"
-    },
-    "perl-ExtUtils-Embed": {
-      "epoch": "0",
-      "version": "1.34",
-      "release": "421.el8",
-      "installdate": "1640302883",
-      "arch": "noarch"
-    },
-    "at": {
-      "epoch": "0",
-      "version": "3.1.20",
-      "release": "11.el8",
-      "installdate": "1640302553",
-      "arch": "x86_64"
-    },
-    "sed": {
-      "epoch": "0",
-      "version": "4.5",
-      "release": "5.el8",
-      "installdate": "1640302522",
-      "arch": "x86_64"
-    },
-    "perl-inc-latest": {
-      "epoch": "2",
-      "version": "0.500",
-      "release": "9.el8",
-      "installdate": "1640302883",
-      "arch": "noarch"
-    },
-    "libcap-ng": {
-      "epoch": "0",
-      "version": "0.7.11",
-      "release": "1.el8",
-      "installdate": "1640302522",
-      "arch": "x86_64"
-    },
-    "gobject-introspection": {
-      "epoch": "0",
-      "version": "1.56.1",
-      "release": "1.el8",
-      "installdate": "1640302554",
-      "arch": "x86_64"
-    },
-    "libgcrypt": {
-      "epoch": "0",
-      "version": "1.8.5",
-      "release": "6.el8",
-      "installdate": "1640302522",
-      "arch": "x86_64"
-    },
-    "glibc": {
-      "epoch": "0",
-      "version": "2.28",
-      "release": "184.el8",
-      "installdate": "1643238283",
-      "arch": "x86_64"
-    },
-    "grub2-tools-extra": {
-      "epoch": "1",
-      "version": "2.02",
-      "release": "106.el8",
-      "installdate": "1640302554",
-      "arch": "x86_64"
-    },
-    "libffi": {
-      "epoch": "0",
-      "version": "3.1",
-      "release": "23.el8",
-      "installdate": "1640302522",
-      "arch": "x86_64"
-    },
-    "systemd-libs": {
-      "epoch": "0",
-      "version": "239",
-      "release": "55.el8",
-      "installdate": "1643238290",
-      "arch": "x86_64"
-    },
-    "nss-util": {
-      "epoch": "0",
-      "version": "3.67.0",
-      "release": "7.el8_5",
-      "installdate": "1640302522",
-      "arch": "x86_64"
-    },
-    "rpm-libs": {
-      "epoch": "0",
-      "version": "4.14.3",
-      "release": "21.el8",
-      "installdate": "1643238293",
-      "arch": "x86_64"
-    },
-    "tpm2-tss": {
-      "epoch": "0",
-      "version": "2.3.2",
-      "release": "4.el8",
-      "installdate": "1640302555",
-      "arch": "x86_64"
-    },
-    "file-libs": {
-      "epoch": "0",
-      "version": "5.33",
-      "release": "20.el8",
-      "installdate": "1640302523",
-      "arch": "x86_64"
-    },
-    "selinux-policy-targeted": {
-      "epoch": "0",
-      "version": "3.14.3",
-      "release": "86.el8",
-      "installdate": "1643238336",
-      "arch": "noarch"
-    },
-    "gnupg2": {
-      "epoch": "0",
-      "version": "2.2.20",
-      "release": "2.el8",
-      "installdate": "1640302555",
-      "arch": "x86_64"
-    },
-    "libbasicobjects": {
-      "epoch": "0",
-      "version": "0.1.1",
-      "release": "39.el8",
-      "installdate": "1640302523",
-      "arch": "x86_64"
-    },
-    "libsss_idmap": {
-      "epoch": "0",
-      "version": "2.6.1",
-      "release": "2.el8",
-      "installdate": "1643238375",
-      "arch": "x86_64"
-    },
-    "python3-libdnf": {
-      "epoch": "0",
-      "version": "0.63.0",
-      "release": "5.el8",
-      "installdate": "1640302555",
-      "arch": "x86_64"
-    },
-    "lz4-libs": {
-      "epoch": "0",
-      "version": "1.8.3",
-      "release": "3.el8_4",
-      "installdate": "1640302523",
-      "arch": "x86_64"
-    },
-    "selinux-policy-devel": {
-      "epoch": "0",
-      "version": "3.14.3",
-      "release": "86.el8",
-      "installdate": "1643238377",
-      "arch": "noarch"
-    },
-    "hostname": {
-      "epoch": "0",
-      "version": "3.20",
-      "release": "7.el8.0.1",
-      "installdate": "1640302523",
-      "arch": "x86_64"
-    },
-    "python3-dnf-plugins-core": {
-      "epoch": "0",
-      "version": "4.0.21",
-      "release": "8.el8",
-      "installdate": "1643238391",
-      "arch": "noarch"
-    },
-    "libverto": {
-      "epoch": "0",
-      "version": "0.3.0",
-      "release": "5.el8",
-      "installdate": "1640302523",
-      "arch": "x86_64"
-    },
-    "libsss_autofs": {
-      "epoch": "0",
-      "version": "2.6.1",
-      "release": "2.el8",
-      "installdate": "1643238391",
-      "arch": "x86_64"
-    },
-    "redhat-lsb-submod-security": {
-      "epoch": "0",
-      "version": "4.1",
-      "release": "47.el8",
-      "installdate": "1640302556",
-      "arch": "x86_64"
-    },
-    "libnftnl": {
-      "epoch": "0",
-      "version": "1.1.5",
-      "release": "4.el8",
-      "installdate": "1640302523",
-      "arch": "x86_64"
-    },
-    "libsss_sudo": {
-      "epoch": "0",
-      "version": "2.6.1",
-      "release": "2.el8",
-      "installdate": "1643238392",
-      "arch": "x86_64"
-    },
-    "centos-gpg-keys": {
-      "epoch": "1",
-      "version": "8",
-      "release": "4.el8",
-      "installdate": "1643238393",
-      "arch": "noarch"
-    },
-    "dnf": {
-      "epoch": "0",
-      "version": "4.7.0",
-      "release": "5.el8",
-      "installdate": "1640302557",
-      "arch": "noarch"
-    },
-    "libdhash": {
-      "epoch": "0",
-      "version": "0.5.0",
-      "release": "39.el8",
-      "installdate": "1640302523",
-      "arch": "x86_64"
-    },
-    "kernel": {
-      "epoch": "0",
-      "version": "4.18.0",
-      "release": "348.2.1.el8_5",
-      "installdate": "1640302566",
-      "arch": "x86_64",
-      "versions": [
-        {
-          "epoch": "0",
-          "version": "4.18.0",
-          "release": "358.el8",
-          "installdate": "1643238446",
-          "arch": "x86_64"
-        },
-        {
-          "epoch": "0",
-          "version": "4.18.0",
-          "release": "348.2.1.el8_5",
-          "installdate": "1640302566",
-          "arch": "x86_64"
-        }
-      ]
-    },
-    "kernel-tools": {
-      "epoch": "0",
-      "version": "4.18.0",
-      "release": "358.el8",
-      "installdate": "1643238449",
-      "arch": "x86_64"
-    },
-    "python3-pyyaml": {
-      "epoch": "0",
-      "version": "3.12",
-      "release": "12.el8",
-      "installdate": "1640302565",
-      "arch": "x86_64"
-    },
-    "lzo": {
-      "epoch": "0",
-      "version": "2.08",
-      "release": "14.el8",
-      "installdate": "1640302523",
-      "arch": "x86_64"
-    },
-    "NetworkManager-team": {
-      "epoch": "1",
-      "version": "1.36.0",
-      "release": "0.4.el8",
-      "installdate": "1643238449",
-      "arch": "x86_64"
-    },
-    "firewalld": {
-      "epoch": "0",
-      "version": "0.9.3",
-      "release": "11.el8",
-      "installdate": "1640302566",
-      "arch": "noarch"
-    },
-    "grep": {
-      "epoch": "0",
-      "version": "3.1",
-      "release": "6.el8",
-      "installdate": "1640302524",
-      "arch": "x86_64"
-    },
-    "rsyslog": {
-      "epoch": "0",
-      "version": "8.2102.0",
-      "release": "7.el8",
-      "installdate": "1643238450",
-      "arch": "x86_64"
-    },
-    "wget": {
-      "epoch": "0",
-      "version": "1.19.5",
-      "release": "10.el8",
-      "installdate": "1640302566",
-      "arch": "x86_64"
-    },
-    "libnetfilter_conntrack": {
-      "epoch": "0",
-      "version": "1.0.6",
-      "release": "5.el8",
-      "installdate": "1640302524",
-      "arch": "x86_64"
-    },
-    "postfix": {
-      "epoch": "2",
-      "version": "3.5.8",
-      "release": "3.el8",
-      "installdate": "1643238452",
-      "arch": "x86_64"
-    },
-    "authselect": {
-      "epoch": "0",
-      "version": "1.2.2",
-      "release": "3.el8",
-      "installdate": "1640302566",
-      "arch": "x86_64"
-    },
-    "nss-softokn": {
-      "epoch": "0",
-      "version": "3.67.0",
-      "release": "7.el8_5",
-      "installdate": "1640302524",
-      "arch": "x86_64"
-    },
-    "libgomp": {
-      "epoch": "0",
-      "version": "8.5.0",
-      "release": "7.el8",
-      "installdate": "1643238456",
-      "arch": "x86_64"
-    },
-    "iptables": {
-      "epoch": "0",
-      "version": "1.8.4",
-      "release": "22.el8",
-      "installdate": "1640302524",
-      "arch": "x86_64"
-    },
-    "chef": {
-      "epoch": "0",
-      "version": "17.9.26",
-      "release": "1.el8",
-      "installdate": "1643239069",
-      "arch": "x86_64"
-    },
-    "audit": {
-      "epoch": "0",
-      "version": "3.0",
-      "release": "0.17.20191104git1c2f876.el8",
-      "installdate": "1640302567",
-      "arch": "x86_64"
-    },
-    "keyutils": {
-      "epoch": "0",
-      "version": "1.5.10",
-      "release": "9.el8",
-      "installdate": "1640302524",
-      "arch": "x86_64"
-    },
-    "sudo": {
-      "epoch": "0",
-      "version": "1.8.29",
-      "release": "8.el8",
-      "installdate": "1640302567",
-      "arch": "x86_64"
-    },
-    "groff-base": {
-      "epoch": "0",
-      "version": "1.22.3",
-      "release": "18.el8",
-      "installdate": "1640302525",
-      "arch": "x86_64"
-    },
-    "prefixdevname": {
-      "epoch": "0",
-      "version": "0.1.0",
-      "release": "6.el8",
-      "installdate": "1640302568",
-      "arch": "x86_64"
-    },
-    "rsync": {
-      "epoch": "0",
-      "version": "3.1.3",
-      "release": "14.el8",
-      "installdate": "1640302568",
-      "arch": "x86_64"
-    },
-    "libicu": {
-      "epoch": "0",
-      "version": "60.3",
-      "release": "2.el8_1",
-      "installdate": "1640302526",
-      "arch": "x86_64"
-    },
-    "libsysfs": {
-      "epoch": "0",
-      "version": "2.1.0",
-      "release": "24.el8",
-      "installdate": "1640302568",
-      "arch": "x86_64"
-    },
-    "libbpf": {
-      "epoch": "0",
-      "version": "0.4.0",
-      "release": "2.el8",
-      "installdate": "1640302527",
-      "arch": "x86_64"
-    },
-    "gpg-pubkey": {
-      "epoch": "0",
-      "version": "8483c65d",
-      "release": "5ccc5b19",
-      "installdate": "1640302866",
-      "arch": "(none)"
-    },
-    "time": {
-      "epoch": "0",
-      "version": "1.9",
-      "release": "3.el8",
-      "installdate": "1640302527",
-      "arch": "x86_64"
-    },
-    "perl-libnet": {
-      "epoch": "0",
-      "version": "3.11",
-      "release": "3.el8",
-      "installdate": "1640302871",
-      "arch": "noarch"
-    },
-    "libselinux-utils": {
-      "epoch": "0",
-      "version": "2.9",
-      "release": "5.el8",
-      "installdate": "1640302527",
-      "arch": "x86_64"
-    },
-    "perl-Mozilla-CA": {
-      "epoch": "0",
-      "version": "20160104",
-      "release": "7.module_el8.3.0+416+dee7bcef",
-      "installdate": "1640302871",
-      "arch": "noarch"
-    },
-    "c-ares": {
-      "epoch": "0",
-      "version": "1.13.0",
-      "release": "6.el8",
-      "installdate": "1640302527",
-      "arch": "x86_64"
-    },
-    "perl-Term-ANSIColor": {
-      "epoch": "0",
-      "version": "4.06",
-      "release": "396.el8",
-      "installdate": "1640302871",
-      "arch": "noarch"
-    },
-    "libdaemon": {
-      "epoch": "0",
-      "version": "0.14",
-      "release": "15.el8",
-      "installdate": "1640302527",
-      "arch": "x86_64"
-    },
-    "perl-HTTP-Tiny": {
-      "epoch": "0",
-      "version": "0.074",
-      "release": "1.el8",
-      "installdate": "1640302872",
-      "arch": "noarch"
-    },
-    "libini_config": {
-      "epoch": "0",
-      "version": "1.3.1",
-      "release": "39.el8",
-      "installdate": "1640302527",
-      "arch": "x86_64"
-    },
-    "perl-Pod-Usage": {
-      "epoch": "4",
-      "version": "1.69",
-      "release": "395.el8",
-      "installdate": "1640302872",
-      "arch": "noarch"
-    },
-    "perl-Errno": {
-      "epoch": "0",
-      "version": "1.28",
-      "release": "421.el8",
-      "installdate": "1640302872",
-      "arch": "x86_64"
-    },
-    "perl-Exporter": {
-      "epoch": "0",
-      "version": "5.72",
-      "release": "396.el8",
-      "installdate": "1640302872",
-      "arch": "noarch"
-    },
-    "memstrack": {
-      "epoch": "0",
-      "version": "0.1.11",
-      "release": "1.el8",
-      "installdate": "1640302527",
-      "arch": "x86_64"
-    },
-    "perl-macros": {
-      "epoch": "4",
-      "version": "5.26.3",
-      "release": "421.el8",
-      "installdate": "1640302873",
-      "arch": "x86_64"
-    },
-    "slang": {
-      "epoch": "0",
-      "version": "2.3.2",
-      "release": "3.el8",
-      "installdate": "1640302528",
-      "arch": "x86_64"
-    },
-    "perl-IO": {
-      "epoch": "0",
-      "version": "1.38",
-      "release": "421.el8",
-      "installdate": "1640302873",
-      "arch": "x86_64"
-    },
-    "libmaxminddb": {
-      "epoch": "0",
-      "version": "1.2.0",
-      "release": "10.el8",
-      "installdate": "1640302528",
-      "arch": "x86_64"
-    },
-    "perl-threads-shared": {
-      "epoch": "0",
-      "version": "1.58",
-      "release": "2.el8",
-      "installdate": "1640302873",
-      "arch": "x86_64"
-    },
-    "platform-python-pip": {
-      "epoch": "0",
-      "version": "9.0.3",
-      "release": "22.el8",
-      "installdate": "1640302528",
-      "arch": "noarch"
-    },
-    "perl-CPAN-Meta-Requirements": {
-      "epoch": "0",
-      "version": "2.140",
-      "release": "396.el8",
-      "installdate": "1640302874",
-      "arch": "noarch"
-    },
-    "libssh": {
-      "epoch": "0",
-      "version": "0.9.6",
-      "release": "3.el8",
-      "installdate": "1640302531",
-      "arch": "x86_64"
-    },
-    "perl-Module-CoreList": {
-      "epoch": "1",
-      "version": "5.20181130",
-      "release": "1.el8",
-      "installdate": "1640302875",
-      "arch": "noarch"
-    },
-    "libkcapi": {
-      "epoch": "0",
-      "version": "1.2.0",
-      "release": "2.el8",
-      "installdate": "1640302531",
-      "arch": "x86_64"
-    },
-    "perl-Compress-Raw-Zlib": {
-      "epoch": "0",
-      "version": "2.081",
-      "release": "1.el8",
-      "installdate": "1640302875",
-      "arch": "x86_64"
-    },
-    "curl": {
-      "epoch": "0",
-      "version": "7.61.1",
-      "release": "22.el8",
-      "installdate": "1640302531",
-      "arch": "x86_64"
-    },
-    "perl-encoding": {
-      "epoch": "4",
-      "version": "2.22",
-      "release": "3.el8",
-      "installdate": "1640302875",
-      "arch": "x86_64"
-    },
-    "crypto-policies": {
-      "epoch": "0",
-      "version": "20211116",
-      "release": "1.gitae470d6.el8",
-      "installdate": "1640302531",
-      "arch": "noarch"
-    },
-    "perl-ExtUtils-Command": {
-      "epoch": "1",
-      "version": "7.34",
-      "release": "1.el8",
-      "installdate": "1640302875",
-      "arch": "noarch"
-    },
-    "cracklib-dicts": {
-      "epoch": "0",
-      "version": "2.9.6",
-      "release": "15.el8",
-      "installdate": "1640302532",
-      "arch": "x86_64"
-    },
-    "perl-Module-Load-Conditional": {
-      "epoch": "0",
-      "version": "0.68",
-      "release": "395.el8",
-      "installdate": "1640302875",
-      "arch": "noarch"
-    },
-    "libnsl2": {
-      "epoch": "0",
-      "version": "1.2.0",
-      "release": "2.20180605git4a062cf.el8",
-      "installdate": "1640302532",
-      "arch": "x86_64"
-    },
-    "perl-Compress-Raw-Bzip2": {
-      "epoch": "0",
-      "version": "2.081",
-      "release": "1.el8",
-      "installdate": "1640302875",
-      "arch": "x86_64"
-    },
-    "elfutils-libs": {
-      "epoch": "0",
-      "version": "0.186",
-      "release": "1.el8",
-      "installdate": "1640302532",
-      "arch": "x86_64"
-    },
-    "perl-Math-BigInt": {
-      "epoch": "1",
-      "version": "1.9998.11",
-      "release": "7.el8",
-      "installdate": "1640302875",
-      "arch": "noarch"
-    },
-    "libcroco": {
-      "epoch": "0",
-      "version": "0.6.12",
-      "release": "4.el8_2.1",
-      "installdate": "1640302532",
-      "arch": "x86_64"
-    },
-    "python-srpm-macros": {
-      "epoch": "0",
-      "version": "3",
-      "release": "41.el8",
-      "installdate": "1640302876",
-      "arch": "noarch"
-    },
-    "dbus-libs": {
-      "epoch": "1",
-      "version": "1.12.8",
-      "release": "18.el8",
-      "installdate": "1640302532",
-      "arch": "x86_64"
-    },
-    "python3-rpm-macros": {
-      "epoch": "0",
-      "version": "3",
-      "release": "41.el8",
-      "installdate": "1640302877",
-      "arch": "noarch"
-    },
-    "perl-open": {
-      "epoch": "0",
-      "version": "1.11",
-      "release": "421.el8",
-      "installdate": "1640302877",
-      "arch": "noarch"
-    },
-    "ca-certificates": {
-      "epoch": "0",
-      "version": "2021.2.50",
-      "release": "82.el8",
-      "installdate": "1640302533",
-      "arch": "noarch"
-    },
-    "perl-Module-CoreList-tools": {
-      "epoch": "1",
-      "version": "5.20181130",
-      "release": "1.el8",
-      "installdate": "1640302877",
-      "arch": "noarch"
-    },
-    "kmod": {
-      "epoch": "0",
-      "version": "25",
-      "release": "19.el8",
-      "installdate": "1640302533",
-      "arch": "x86_64"
-    },
-    "perl-Compress-Bzip2": {
-      "epoch": "0",
-      "version": "2.26",
-      "release": "6.el8",
-      "installdate": "1640302877",
-      "arch": "x86_64"
-    },
-    "dbus-daemon": {
-      "epoch": "1",
-      "version": "1.12.8",
-      "release": "18.el8",
-      "installdate": "1640302534",
-      "arch": "x86_64"
-    },
-    "perl-Devel-Size": {
-      "epoch": "0",
-      "version": "0.81",
-      "release": "2.el8",
-      "installdate": "1640302877",
-      "arch": "x86_64"
-    },
-    "pam": {
-      "epoch": "0",
-      "version": "1.3.1",
-      "release": "15.el8",
-      "installdate": "1640302534",
-      "arch": "x86_64"
-    },
-    "perl-IPC-Cmd": {
-      "epoch": "2",
-      "version": "1.02",
-      "release": "1.el8",
-      "installdate": "1640302877",
-      "arch": "noarch"
-    },
-    "os-prober": {
-      "epoch": "0",
-      "version": "1.74",
-      "release": "9.el8",
-      "installdate": "1640302535",
-      "arch": "x86_64"
-    },
-    "perl-autodie": {
-      "epoch": "0",
-      "version": "2.29",
-      "release": "396.el8",
-      "installdate": "1640302878",
-      "arch": "noarch"
-    },
-    "shared-mime-info": {
-      "epoch": "0",
-      "version": "1.9",
-      "release": "3.el8",
-      "installdate": "1640302535",
-      "arch": "x86_64"
-    },
-    "dbus": {
-      "epoch": "1",
-      "version": "1.12.8",
-      "release": "18.el8",
-      "installdate": "1640302535",
-      "arch": "x86_64"
-    },
-    "geolite2-city": {
-      "epoch": "0",
-      "version": "20180605",
-      "release": "1.el8",
-      "installdate": "1640302503",
-      "arch": "noarch"
-    },
-    "python3-setuptools-wheel": {
-      "epoch": "0",
-      "version": "39.2.0",
-      "release": "6.el8",
-      "installdate": "1640302504",
-      "arch": "noarch"
-    },
-    "python3-six": {
-      "epoch": "0",
-      "version": "1.11.0",
-      "release": "8.el8",
-      "installdate": "1640302537",
-      "arch": "noarch"
-    },
-    "ncurses-base": {
-      "epoch": "0",
-      "version": "6.1",
-      "release": "9.20180224.el8",
-      "installdate": "1640302504",
-      "arch": "noarch"
-    },
-    "quota-nls": {
-      "epoch": "1",
-      "version": "4.04",
-      "release": "14.el8",
-      "installdate": "1640302504",
-      "arch": "noarch"
-    },
-    "python3-libselinux": {
-      "epoch": "0",
-      "version": "2.9",
-      "release": "5.el8",
-      "installdate": "1640302537",
-      "arch": "x86_64"
-    },
-    "cronie": {
-      "epoch": "0",
-      "version": "1.5.2",
-      "release": "6.el8",
-      "installdate": "1640302537",
-      "arch": "x86_64"
-    },
-    "libssh-config": {
-      "epoch": "0",
-      "version": "0.9.6",
-      "release": "3.el8",
-      "installdate": "1640302519",
-      "arch": "noarch"
-    },
-    "libsolv": {
-      "epoch": "0",
-      "version": "0.7.20",
-      "release": "1.el8",
-      "installdate": "1640302537",
-      "arch": "x86_64"
-    },
-    "dnf-data": {
-      "epoch": "0",
-      "version": "4.7.0",
-      "release": "5.el8",
-      "installdate": "1640302519",
-      "arch": "noarch"
-    },
-    "kbd-legacy": {
-      "epoch": "0",
-      "version": "2.0.4",
-      "release": "10.el8",
-      "installdate": "1640302519",
-      "arch": "noarch"
-    },
-    "kernel-core": {
-      "epoch": "0",
-      "version": "4.18.0",
-      "release": "358.el8",
-      "installdate": "1643238434",
-      "arch": "x86_64",
-      "versions": [
-        {
-          "epoch": "0",
-          "version": "4.18.0",
-          "release": "348.2.1.el8_5",
-          "installdate": "1640302542",
-          "arch": "x86_64"
-        },
-        {
-          "epoch": "0",
-          "version": "4.18.0",
-          "release": "358.el8",
-          "installdate": "1643238434",
-          "arch": "x86_64"
-        }
-      ]
-    },
-    "firewalld-filesystem": {
-      "epoch": "0",
-      "version": "0.9.3",
-      "release": "11.el8",
-      "installdate": "1640302520",
-      "arch": "noarch"
-    },
-    "centos-stream-release": {
-      "epoch": "0",
-      "version": "8.6",
-      "release": "1.el8",
-      "installdate": "1640302520",
-      "arch": "noarch"
-    },
-    "libuser": {
-      "epoch": "0",
-      "version": "0.62",
-      "release": "24.el8",
-      "installdate": "1640302542",
-      "arch": "x86_64"
-    },
-    "setup": {
-      "epoch": "0",
-      "version": "2.12.2",
-      "release": "6.el8",
-      "installdate": "1640302520",
-      "arch": "noarch"
-    },
-    "polkit": {
-      "epoch": "0",
-      "version": "0.115",
-      "release": "12.el8",
-      "installdate": "1640302543",
-      "arch": "x86_64"
-    },
-    "basesystem": {
-      "epoch": "0",
-      "version": "11",
-      "release": "5.el8",
-      "installdate": "1640302520",
-      "arch": "noarch"
-    },
-    "openssh": {
-      "epoch": "0",
-      "version": "8.0p1",
-      "release": "12.el8",
-      "installdate": "1640302543",
-      "arch": "x86_64"
-    },
-    "libselinux": {
-      "epoch": "0",
-      "version": "2.9",
-      "release": "5.el8",
-      "installdate": "1640302520",
-      "arch": "x86_64"
-    },
-    "logrotate": {
-      "epoch": "0",
-      "version": "3.14.0",
-      "release": "4.el8",
-      "installdate": "1640302543",
-      "arch": "x86_64"
-    },
-    "libnfsidmap": {
-      "epoch": "1",
-      "version": "2.3.3",
-      "release": "47.el8",
-      "installdate": "1640302543",
-      "arch": "x86_64"
-    },
-    "libldb": {
-      "epoch": "0",
-      "version": "2.4.1",
-      "release": "1.el8",
-      "installdate": "1640302543",
-      "arch": "x86_64"
-    },
-    "bash": {
-      "epoch": "0",
-      "version": "4.4.20",
-      "release": "3.el8",
-      "installdate": "1640302521",
-      "arch": "x86_64"
-    },
-    "cups-libs": {
-      "epoch": "1",
-      "version": "2.2.6",
-      "release": "41.el8",
-      "installdate": "1640302543",
-      "arch": "x86_64"
-    },
-    "zlib": {
-      "epoch": "0",
-      "version": "1.2.11",
-      "release": "17.el8",
-      "installdate": "1640302521",
-      "arch": "x86_64"
-    },
-    "network-scripts": {
-      "epoch": "0",
-      "version": "10.00.15",
-      "release": "1.el8",
-      "installdate": "1640302543",
-      "arch": "x86_64"
-    },
-    "xz-libs": {
-      "epoch": "0",
-      "version": "5.2.4",
-      "release": "3.el8",
-      "installdate": "1640302521",
-      "arch": "x86_64"
-    },
-    "teamd": {
-      "epoch": "0",
-      "version": "1.31",
-      "release": "2.el8",
-      "installdate": "1640302543",
-      "arch": "x86_64"
-    },
-    "popt": {
-      "epoch": "0",
-      "version": "1.18",
-      "release": "1.el8",
-      "installdate": "1640302521",
-      "arch": "x86_64"
-    },
-    "passwd": {
-      "epoch": "0",
-      "version": "0.80",
-      "release": "3.el8",
-      "installdate": "1640302543",
-      "arch": "x86_64"
-    },
-    "libcap": {
-      "epoch": "0",
-      "version": "2.26",
-      "release": "5.el8",
-      "installdate": "1640302521",
-      "arch": "x86_64"
-    },
-    "kernel-modules": {
-      "epoch": "0",
-      "version": "4.18.0",
-      "release": "358.el8",
-      "installdate": "1643238439",
-      "arch": "x86_64",
-      "versions": [
-        {
-          "epoch": "0",
-          "version": "4.18.0",
-          "release": "348.2.1.el8_5",
-          "installdate": "1640302544",
-          "arch": "x86_64"
-        },
-        {
-          "epoch": "0",
-          "version": "4.18.0",
-          "release": "358.el8",
-          "installdate": "1643238439",
-          "arch": "x86_64"
-        }
-      ]
-    },
-    "elfutils-libelf": {
-      "epoch": "0",
-      "version": "0.186",
-      "release": "1.el8",
-      "installdate": "1640302521",
-      "arch": "x86_64"
-    },
-    "python3-setools": {
-      "epoch": "0",
-      "version": "4.3.0",
-      "release": "3.el8",
-      "installdate": "1640302552",
-      "arch": "x86_64"
-    },
-    "libverto-libevent": {
-      "epoch": "0",
-      "version": "0.3.0",
-      "release": "5.el8",
-      "installdate": "1640302552",
-      "arch": "x86_64"
-    },
-    "libxcrypt": {
-      "epoch": "0",
-      "version": "4.1.1",
-      "release": "6.el8",
-      "installdate": "1640302522",
-      "arch": "x86_64"
-    },
-    "unbound-libs": {
-      "epoch": "0",
-      "version": "1.7.3",
-      "release": "17.el8",
-      "installdate": "1640302552",
-      "arch": "x86_64"
-    },
-    "libxml2": {
-      "epoch": "0",
-      "version": "2.9.7",
-      "release": "11.el8",
-      "installdate": "1640302522",
-      "arch": "x86_64"
-    },
-    "rpcbind": {
-      "epoch": "0",
-      "version": "1.2.5",
-      "release": "8.el8",
-      "installdate": "1640302552",
-      "arch": "x86_64"
-    },
-    "expat": {
-      "epoch": "0",
-      "version": "2.2.5",
-      "release": "4.el8",
-      "installdate": "1640302522",
-      "arch": "x86_64"
-    },
-    "python3-dateutil": {
-      "epoch": "1",
-      "version": "2.6.1",
-      "release": "6.el8",
-      "installdate": "1640302552",
-      "arch": "noarch"
-    },
-    "findutils": {
-      "epoch": "1",
-      "version": "4.6.0",
-      "release": "20.el8",
-      "installdate": "1640302522",
-      "arch": "x86_64"
-    },
-    "python3-pyudev": {
-      "epoch": "0",
-      "version": "0.21.0",
-      "release": "7.el8",
-      "installdate": "1640302552",
-      "arch": "noarch"
-    },
-    "libacl": {
-      "epoch": "0",
-      "version": "2.2.53",
-      "release": "1.el8",
-      "installdate": "1640302522",
-      "arch": "x86_64"
-    },
-    "authselect-libs": {
-      "epoch": "0",
-      "version": "1.2.2",
-      "release": "3.el8",
-      "installdate": "1640302553",
-      "arch": "x86_64"
-    },
-    "libmnl": {
-      "epoch": "0",
-      "version": "1.0.4",
-      "release": "6.el8",
-      "installdate": "1640302522",
-      "arch": "x86_64"
-    },
-    "dracut-network": {
-      "epoch": "0",
-      "version": "049",
-      "release": "191.git20210920.el8",
-      "installdate": "1640302553",
-      "arch": "x86_64"
-    },
-    "keyutils-libs": {
-      "epoch": "0",
-      "version": "1.5.10",
-      "release": "9.el8",
-      "installdate": "1640302522",
-      "arch": "x86_64"
-    },
-    "dbus-glib": {
-      "epoch": "0",
-      "version": "0.110",
-      "release": "2.el8",
-      "installdate": "1640302554",
-      "arch": "x86_64"
-    },
-    "audit-libs": {
-      "epoch": "0",
-      "version": "3.0",
-      "release": "0.17.20191104git1c2f876.el8",
-      "installdate": "1640302522",
-      "arch": "x86_64"
-    },
-    "python3-slip-dbus": {
-      "epoch": "0",
-      "version": "0.6.4",
-      "release": "11.el8",
-      "installdate": "1640302554",
-      "arch": "noarch"
-    },
-    "nspr": {
-      "epoch": "0",
-      "version": "4.32.0",
-      "release": "1.el8_4",
-      "installdate": "1640302522",
-      "arch": "x86_64"
-    },
-    "libgcc": {
-      "epoch": "0",
-      "version": "8.5.0",
-      "release": "7.el8",
-      "installdate": "1643238282",
-      "arch": "x86_64"
-    },
-    "python3-gobject-base": {
-      "epoch": "0",
-      "version": "3.28.3",
-      "release": "2.el8",
-      "installdate": "1640302554",
-      "arch": "x86_64"
-    },
-    "libunistring": {
-      "epoch": "0",
-      "version": "0.9.9",
-      "release": "3.el8",
-      "installdate": "1640302522",
-      "arch": "x86_64"
-    },
-    "glibc-langpack-en": {
-      "epoch": "0",
-      "version": "2.28",
-      "release": "184.el8",
-      "installdate": "1643238283",
-      "arch": "x86_64"
-    },
-    "pinentry": {
-      "epoch": "0",
-      "version": "1.1.0",
-      "release": "2.el8",
-      "installdate": "1640302554",
-      "arch": "x86_64"
-    },
-    "grub2-common": {
-      "epoch": "1",
-      "version": "2.02",
-      "release": "106.el8",
-      "installdate": "1640302522",
-      "arch": "noarch"
-    },
-    "glibc-gconv-extra": {
-      "epoch": "0",
-      "version": "2.28",
-      "release": "184.el8",
-      "installdate": "1643238284",
-      "arch": "x86_64"
-    },
-    "dracut-squash": {
-      "epoch": "0",
-      "version": "049",
-      "release": "191.git20210920.el8",
-      "installdate": "1640302554",
-      "arch": "x86_64"
-    },
-    "p11-kit": {
-      "epoch": "0",
-      "version": "0.23.22",
-      "release": "1.el8",
-      "installdate": "1640302522",
-      "arch": "x86_64"
-    },
-    "libtalloc": {
-      "epoch": "0",
-      "version": "2.3.3",
-      "release": "1.el8",
-      "installdate": "1640302522",
-      "arch": "x86_64"
-    },
-    "libsemanage": {
-      "epoch": "0",
-      "version": "2.9",
-      "release": "6.el8",
-      "installdate": "1640302522",
-      "arch": "x86_64"
-    },
-    "mailx": {
-      "epoch": "0",
-      "version": "12.5",
-      "release": "29.el8",
-      "installdate": "1640302555",
-      "arch": "x86_64"
-    },
-    "diffutils": {
-      "epoch": "0",
-      "version": "3.6",
-      "release": "6.el8",
-      "installdate": "1640302523",
-      "arch": "x86_64"
-    },
-    "ima-evm-utils": {
-      "epoch": "0",
-      "version": "1.3.2",
-      "release": "12.el8",
-      "installdate": "1640302555",
-      "arch": "x86_64"
-    },
-    "file": {
-      "epoch": "0",
-      "version": "5.33",
-      "release": "20.el8",
-      "installdate": "1640302523",
-      "arch": "x86_64"
-    },
-    "gnupg2-smime": {
-      "epoch": "0",
-      "version": "2.2.20",
-      "release": "2.el8",
-      "installdate": "1640302555",
-      "arch": "x86_64"
-    },
-    "json-c": {
-      "epoch": "0",
-      "version": "0.13.1",
-      "release": "3.el8",
-      "installdate": "1640302523",
-      "arch": "x86_64"
-    },
-    "gpgme": {
-      "epoch": "0",
-      "version": "1.13.1",
-      "release": "9.el8",
-      "installdate": "1640302555",
-      "arch": "x86_64"
-    },
-    "libcollection": {
-      "epoch": "0",
-      "version": "0.7.0",
-      "release": "39.el8",
-      "installdate": "1640302523",
-      "arch": "x86_64"
-    },
-    "libdnf": {
-      "epoch": "0",
-      "version": "0.63.0",
-      "release": "5.el8",
-      "installdate": "1640302555",
-      "arch": "x86_64"
-    },
-    "libsmartcols": {
-      "epoch": "0",
-      "version": "2.32.1",
-      "release": "28.el8",
-      "installdate": "1640302523",
-      "arch": "x86_64"
-    },
-    "python3-hawkey": {
-      "epoch": "0",
-      "version": "0.63.0",
-      "release": "5.el8",
-      "installdate": "1640302555",
-      "arch": "x86_64"
-    },
-    "libtevent": {
-      "epoch": "0",
-      "version": "0.11.0",
-      "release": "0.el8",
-      "installdate": "1640302523",
-      "arch": "x86_64"
-    },
-    "make": {
-      "epoch": "1",
-      "version": "4.2.1",
-      "release": "11.el8",
-      "installdate": "1640302523",
-      "arch": "x86_64"
-    },
-    "plymouth-core-libs": {
-      "epoch": "0",
-      "version": "0.9.4",
-      "release": "10.20200615git1e36e30.el8",
-      "installdate": "1640302555",
-      "arch": "x86_64"
-    },
-    "cpio": {
-      "epoch": "0",
-      "version": "2.12",
-      "release": "11.el8",
-      "installdate": "1640302523",
-      "arch": "x86_64"
-    },
-    "plymouth": {
-      "epoch": "0",
-      "version": "0.9.4",
-      "release": "10.20200615git1e36e30.el8",
-      "installdate": "1640302555",
-      "arch": "x86_64"
-    },
-    "libtdb": {
-      "epoch": "0",
-      "version": "1.4.4",
-      "release": "1.el8",
-      "installdate": "1640302523",
-      "arch": "x86_64"
-    },
-    "man-db": {
-      "epoch": "0",
-      "version": "2.7.6.1",
-      "release": "18.el8",
-      "installdate": "1640302556",
-      "arch": "x86_64"
-    },
-    "libnl3-cli": {
-      "epoch": "0",
-      "version": "3.5.0",
-      "release": "1.el8",
-      "installdate": "1640302523",
-      "arch": "x86_64"
-    },
-    "nss": {
-      "epoch": "0",
-      "version": "3.67.0",
-      "release": "7.el8_5",
-      "installdate": "1640302556",
-      "arch": "x86_64"
-    },
-    "ethtool": {
-      "epoch": "2",
-      "version": "5.13",
-      "release": "1.el8",
-      "installdate": "1640302523",
-      "arch": "x86_64"
-    },
-    "quota": {
-      "epoch": "1",
-      "version": "4.04",
-      "release": "14.el8",
-      "installdate": "1640302556",
-      "arch": "x86_64"
-    },
-    "bc": {
-      "epoch": "0",
-      "version": "1.07.1",
-      "release": "5.el8",
-      "installdate": "1640302523",
-      "arch": "x86_64"
-    },
-    "python3-audit": {
-      "epoch": "0",
-      "version": "3.0",
-      "release": "0.17.20191104git1c2f876.el8",
-      "installdate": "1640302556",
-      "arch": "x86_64"
-    },
-    "e2fsprogs-libs": {
-      "epoch": "0",
-      "version": "1.45.6",
-      "release": "2.el8",
-      "installdate": "1640302523",
-      "arch": "x86_64"
-    },
-    "m4": {
-      "epoch": "0",
-      "version": "1.4.18",
-      "release": "7.el8",
-      "installdate": "1640302523",
-      "arch": "x86_64"
-    },
-    "python3-dnf": {
-      "epoch": "0",
-      "version": "4.7.0",
-      "release": "5.el8",
-      "installdate": "1640302557",
-      "arch": "noarch"
-    },
-    "libedit": {
-      "epoch": "0",
-      "version": "3.1",
-      "release": "23.20170329cvs.el8",
-      "installdate": "1640302523",
-      "arch": "x86_64"
-    },
-    "libseccomp": {
-      "epoch": "0",
-      "version": "2.5.2",
-      "release": "1.el8",
-      "installdate": "1640302523",
-      "arch": "x86_64"
-    },
-    "python3-nftables": {
-      "epoch": "1",
-      "version": "0.9.3",
-      "release": "24.el8",
-      "installdate": "1640302565",
-      "arch": "x86_64"
-    },
-    "libtasn1": {
-      "epoch": "0",
-      "version": "4.13",
-      "release": "3.el8",
-      "installdate": "1640302523",
-      "arch": "x86_64"
-    },
-    "libyaml": {
-      "epoch": "0",
-      "version": "0.1.7",
-      "release": "5.el8",
-      "installdate": "1640302523",
-      "arch": "x86_64"
-    },
-    "numactl-libs": {
-      "epoch": "0",
-      "version": "2.0.12",
-      "release": "13.el8",
-      "installdate": "1640302523",
-      "arch": "x86_64"
-    },
-    "nfs-utils": {
-      "epoch": "1",
-      "version": "2.3.3",
-      "release": "47.el8",
-      "installdate": "1640302566",
-      "arch": "x86_64"
-    },
-    "pcre": {
-      "epoch": "0",
-      "version": "8.42",
-      "release": "6.el8",
-      "installdate": "1640302523",
-      "arch": "x86_64"
-    },
-    "psmisc": {
-      "epoch": "0",
-      "version": "23.1",
-      "release": "5.el8",
-      "installdate": "1640302524",
-      "arch": "x86_64"
-    },
-    "redhat-lsb-core": {
-      "epoch": "0",
-      "version": "4.1",
-      "release": "47.el8",
-      "installdate": "1640302566",
-      "arch": "x86_64"
-    },
-    "squashfs-tools": {
-      "epoch": "0",
-      "version": "4.3",
-      "release": "20.el8",
-      "installdate": "1640302524",
-      "arch": "x86_64"
-    },
-    "libteam": {
-      "epoch": "0",
-      "version": "1.31",
-      "release": "2.el8",
-      "installdate": "1640302524",
-      "arch": "x86_64"
-    },
-    "grub2-pc": {
-      "epoch": "1",
-      "version": "2.02",
-      "release": "106.el8",
-      "installdate": "1640302566",
-      "arch": "x86_64"
-    },
-    "nss-softokn-freebl": {
-      "epoch": "0",
-      "version": "3.67.0",
-      "release": "7.el8_5",
-      "installdate": "1640302524",
-      "arch": "x86_64"
-    },
-    "iptables-libs": {
-      "epoch": "0",
-      "version": "1.8.4",
-      "release": "22.el8",
-      "installdate": "1640302524",
-      "arch": "x86_64"
-    },
-    "openssh-clients": {
-      "epoch": "0",
-      "version": "8.0p1",
-      "release": "12.el8",
-      "installdate": "1640302567",
-      "arch": "x86_64"
-    },
-    "iptables-ebtables": {
-      "epoch": "0",
-      "version": "1.8.4",
-      "release": "22.el8",
-      "installdate": "1640302524",
-      "arch": "x86_64"
-    },
-    "grub2-pc-modules": {
-      "epoch": "1",
-      "version": "2.02",
-      "release": "106.el8",
-      "installdate": "1640302524",
-      "arch": "noarch"
-    },
-    "mpfr": {
-      "epoch": "0",
-      "version": "3.1.6",
-      "release": "1.el8",
-      "installdate": "1640302524",
-      "arch": "x86_64"
-    },
-    "ipset": {
-      "epoch": "0",
-      "version": "7.1",
-      "release": "1.el8",
-      "installdate": "1640302524",
-      "arch": "x86_64"
-    },
-    "acl": {
-      "epoch": "0",
-      "version": "2.2.53",
-      "release": "1.el8",
-      "installdate": "1640302525",
-      "arch": "x86_64"
-    },
-    "tar": {
-      "epoch": "2",
-      "version": "1.30",
-      "release": "5.el8",
-      "installdate": "1640302525",
-      "arch": "x86_64"
-    },
-    "patch": {
-      "epoch": "0",
-      "version": "2.7.6",
-      "release": "11.el8",
-      "installdate": "1640302525",
-      "arch": "x86_64"
-    },
-    "libmetalink": {
-      "epoch": "0",
-      "version": "0.1.3",
-      "release": "7.el8",
-      "installdate": "1640302525",
-      "arch": "x86_64"
-    },
-    "mozjs60": {
-      "epoch": "0",
-      "version": "60.9.0",
-      "release": "4.el8",
-      "installdate": "1640302526",
-      "arch": "x86_64"
-    },
-    "snappy": {
-      "epoch": "0",
-      "version": "1.1.8",
-      "release": "3.el8",
-      "installdate": "1640302527",
-      "arch": "x86_64"
-    },
-    "libss": {
-      "epoch": "0",
-      "version": "1.45.6",
-      "release": "2.el8",
-      "installdate": "1640302527",
-      "arch": "x86_64"
-    },
-    "ed": {
-      "epoch": "0",
-      "version": "1.14.2",
-      "release": "4.el8",
-      "installdate": "1640302527",
-      "arch": "x86_64"
-    },
-    "libpng": {
-      "epoch": "2",
-      "version": "1.6.34",
-      "release": "5.el8",
-      "installdate": "1640302527",
-      "arch": "x86_64"
-    },
-    "pigz": {
-      "epoch": "0",
-      "version": "2.4",
-      "release": "4.el8",
-      "installdate": "1640302527",
-      "arch": "x86_64"
-    },
-    "brotli": {
-      "epoch": "0",
-      "version": "1.0.6",
-      "release": "3.el8",
-      "installdate": "1640302527",
-      "arch": "x86_64"
-    },
-    "fuse-libs": {
-      "epoch": "0",
-      "version": "2.9.7",
-      "release": "12.el8",
-      "installdate": "1640302527",
-      "arch": "x86_64"
-    },
-    "hdparm": {
-      "epoch": "0",
-      "version": "9.54",
-      "release": "4.el8",
-      "installdate": "1640302527",
-      "arch": "x86_64"
-    },
-    "libndp": {
-      "epoch": "0",
-      "version": "1.7",
-      "release": "6.el8",
-      "installdate": "1640302527",
-      "arch": "x86_64"
-    },
-    "libpath_utils": {
-      "epoch": "0",
-      "version": "0.2.1",
-      "release": "39.el8",
-      "installdate": "1640302527",
-      "arch": "x86_64"
-    },
-    "libpipeline": {
-      "epoch": "0",
-      "version": "1.5.0",
-      "release": "2.el8",
-      "installdate": "1640302527",
-      "arch": "x86_64"
-    },
-    "gawk": {
-      "epoch": "0",
-      "version": "4.2.1",
-      "release": "2.el8",
-      "installdate": "1640302527",
-      "arch": "x86_64"
-    },
-    "lmdb-libs": {
-      "epoch": "0",
-      "version": "0.9.24",
-      "release": "1.el8",
-      "installdate": "1640302527",
-      "arch": "x86_64"
-    },
-    "ncurses": {
-      "epoch": "0",
-      "version": "6.1",
-      "release": "9.20180224.el8",
-      "installdate": "1640302528",
-      "arch": "x86_64"
-    },
-    "sg3_utils-libs": {
-      "epoch": "0",
-      "version": "1.44",
-      "release": "5.el8",
-      "installdate": "1640302528",
-      "arch": "x86_64"
-    },
-    "newt": {
-      "epoch": "0",
-      "version": "0.52.20",
-      "release": "11.el8",
-      "installdate": "1640302528",
-      "arch": "x86_64"
-    },
-    "libfastjson": {
-      "epoch": "0",
-      "version": "0.99.9",
-      "release": "1.el8",
-      "installdate": "1640302528",
-      "arch": "x86_64"
-    },
-    "ipcalc": {
-      "epoch": "0",
-      "version": "0.2.4",
-      "release": "4.el8",
-      "installdate": "1640302528",
-      "arch": "x86_64"
-    },
-    "cyrus-sasl-lib": {
-      "epoch": "0",
-      "version": "2.1.27",
-      "release": "5.el8",
-      "installdate": "1640302528",
-      "arch": "x86_64"
-    },
-    "platform-python-setuptools": {
-      "epoch": "0",
-      "version": "39.2.0",
-      "release": "6.el8",
-      "installdate": "1640302529",
-      "arch": "noarch"
-    },
-    "grub2-tools-minimal": {
-      "epoch": "1",
-      "version": "2.02",
-      "release": "106.el8",
-      "installdate": "1640302531",
-      "arch": "x86_64"
-    },
-    "openldap": {
-      "epoch": "0",
-      "version": "2.4.46",
-      "release": "18.el8",
-      "installdate": "1640302531",
-      "arch": "x86_64"
-    },
-    "grubby": {
-      "epoch": "0",
-      "version": "8.40",
-      "release": "42.el8",
-      "installdate": "1640302531",
-      "arch": "x86_64"
-    },
-    "libkcapi-hmaccalc": {
-      "epoch": "0",
-      "version": "1.2.0",
-      "release": "2.el8",
-      "installdate": "1640302531",
-      "arch": "x86_64"
-    },
-    "libdb-utils": {
-      "epoch": "0",
-      "version": "5.3.28",
-      "release": "42.el8_4",
-      "installdate": "1640302531",
-      "arch": "x86_64"
-    },
-    "libcurl": {
-      "epoch": "0",
-      "version": "7.61.1",
-      "release": "22.el8",
-      "installdate": "1640302531",
-      "arch": "x86_64"
-    },
-    "crypto-policies-scripts": {
-      "epoch": "0",
-      "version": "20211116",
-      "release": "1.gitae470d6.el8",
-      "installdate": "1640302531",
-      "arch": "noarch"
-    },
-    "elfutils-default-yama-scope": {
-      "epoch": "0",
-      "version": "0.186",
-      "release": "1.el8",
-      "installdate": "1640302531",
-      "arch": "noarch"
-    },
-    "cracklib": {
-      "epoch": "0",
-      "version": "2.9.6",
-      "release": "15.el8",
-      "installdate": "1640302531",
-      "arch": "x86_64"
-    },
-    "procps-ng": {
-      "epoch": "0",
-      "version": "3.3.15",
-      "release": "6.el8",
-      "installdate": "1640302532",
-      "arch": "x86_64"
-    },
-    "libtirpc": {
-      "epoch": "0",
-      "version": "1.1.4",
-      "release": "6.el8",
-      "installdate": "1640302532",
-      "arch": "x86_64"
-    },
-    "kpartx": {
-      "epoch": "0",
-      "version": "0.8.4",
-      "release": "20.el8",
-      "installdate": "1640302532",
-      "arch": "x86_64"
-    },
-    "elfutils-debuginfod-client": {
-      "epoch": "0",
-      "version": "0.186",
-      "release": "1.el8",
-      "installdate": "1640302532",
-      "arch": "x86_64"
-    },
-    "openssl-pkcs11": {
-      "epoch": "0",
-      "version": "0.4.10",
-      "release": "2.el8",
-      "installdate": "1640302532",
-      "arch": "x86_64"
-    },
-    "gettext-libs": {
-      "epoch": "0",
-      "version": "0.19.8.1",
-      "release": "17.el8",
-      "installdate": "1640302532",
-      "arch": "x86_64"
-    },
-    "dbus-common": {
-      "epoch": "1",
-      "version": "1.12.8",
-      "release": "18.el8",
-      "installdate": "1640302532",
-      "arch": "noarch"
-    },
-    "libmount": {
-      "epoch": "0",
-      "version": "2.32.1",
-      "release": "28.el8",
-      "installdate": "1640302532",
-      "arch": "x86_64"
-    },
-    "dbus-tools": {
-      "epoch": "1",
-      "version": "1.12.8",
-      "release": "18.el8",
-      "installdate": "1640302532",
-      "arch": "x86_64"
-    },
-    "coreutils": {
-      "epoch": "0",
-      "version": "8.30",
-      "release": "12.el8",
-      "installdate": "1640302533",
-      "arch": "x86_64"
-    },
-    "shadow-utils": {
-      "epoch": "2",
-      "version": "4.6",
-      "release": "16.el8",
-      "installdate": "1640302533",
-      "arch": "x86_64"
-    },
-    "openssl-libs": {
-      "epoch": "1",
-      "version": "1.1.1k",
-      "release": "5.el8_5",
-      "installdate": "1640302533",
-      "arch": "x86_64"
-    },
-    "kmod-libs": {
-      "epoch": "0",
-      "version": "25",
-      "release": "19.el8",
-      "installdate": "1640302533",
-      "arch": "x86_64"
-    },
-    "trousers-lib": {
-      "epoch": "0",
-      "version": "0.3.15",
-      "release": "1.el8",
-      "installdate": "1640302534",
-      "arch": "x86_64"
-    },
-    "libutempter": {
-      "epoch": "0",
-      "version": "1.1.6",
-      "release": "14.el8",
-      "installdate": "1640302534",
-      "arch": "x86_64"
-    },
-    "libpwquality": {
-      "epoch": "0",
-      "version": "1.4.4",
-      "release": "3.el8",
-      "installdate": "1640302534",
-      "arch": "x86_64"
-    },
-    "util-linux": {
-      "epoch": "0",
-      "version": "2.32.1",
-      "release": "28.el8",
-      "installdate": "1640302534",
-      "arch": "x86_64"
-    },
-    "dracut": {
-      "epoch": "0",
-      "version": "049",
-      "release": "191.git20210920.el8",
-      "installdate": "1640302535",
-      "arch": "x86_64"
-    },
-    "gettext": {
-      "epoch": "0",
-      "version": "0.19.8.1",
-      "release": "17.el8",
-      "installdate": "1640302535",
-      "arch": "x86_64"
-    },
-    "glib2": {
-      "epoch": "0",
-      "version": "2.56.4",
-      "release": "158.el8",
-      "installdate": "1640302535",
-      "arch": "x86_64"
-    },
-    "perl-Memoize": {
-      "epoch": "0",
-      "version": "1.03",
-      "release": "421.el8",
-      "installdate": "1640302878",
-      "arch": "noarch"
-    },
     "perl-Package-Generator": {
       "epoch": "0",
       "version": "1.106",
       "release": "11.el8",
-      "installdate": "1640302878",
+      "installdate": "1654278572",
       "arch": "noarch"
     },
-    "perl-Pod-Checker": {
-      "epoch": "4",
-      "version": "1.73",
-      "release": "395.el8",
-      "installdate": "1640302878",
+    "systemd": {
+      "epoch": "0",
+      "version": "239",
+      "release": "58.el8",
+      "installdate": "1654278214",
+      "arch": "x86_64"
+    },
+    "tzdata": {
+      "epoch": "0",
+      "version": "2022a",
+      "release": "2.el8",
+      "installdate": "1654278179",
       "arch": "noarch"
     },
     "perl-Sys-Syslog": {
       "epoch": "0",
       "version": "0.35",
       "release": "397.el8",
-      "installdate": "1640302878",
+      "installdate": "1654278572",
       "arch": "x86_64"
     },
-    "perl-Test": {
+    "libmodulemd": {
       "epoch": "0",
-      "version": "1.30",
-      "release": "421.el8",
-      "installdate": "1640302878",
+      "version": "2.13.0",
+      "release": "1.el8",
+      "installdate": "1654278215",
+      "arch": "x86_64"
+    },
+    "xkeyboard-config": {
+      "epoch": "0",
+      "version": "2.28",
+      "release": "1.el8",
+      "installdate": "1654278179",
       "arch": "noarch"
     },
     "perl-Text-Glob": {
       "epoch": "0",
       "version": "0.11",
       "release": "4.el8",
-      "installdate": "1640302878",
+      "installdate": "1654278572",
       "arch": "noarch"
     },
-    "perl-Time-Piece": {
+    "crontabs": {
       "epoch": "0",
-      "version": "1.31",
-      "release": "421.el8",
-      "installdate": "1640302878",
-      "arch": "x86_64"
+      "version": "1.11",
+      "release": "17.20190603git.el8",
+      "installdate": "1654278215",
+      "arch": "noarch"
     },
     "perl-local-lib": {
       "epoch": "0",
       "version": "2.000024",
       "release": "2.el8",
-      "installdate": "1640302879",
+      "installdate": "1654278573",
       "arch": "noarch"
     },
-    "perl-Algorithm-Diff": {
+    "iproute": {
       "epoch": "0",
-      "version": "1.1903",
-      "release": "9.el8",
-      "installdate": "1640302879",
+      "version": "5.15.0",
+      "release": "4.el8",
+      "installdate": "1654278215",
+      "arch": "x86_64"
+    },
+    "kbd-misc": {
+      "epoch": "0",
+      "version": "2.0.4",
+      "release": "10.el8",
+      "installdate": "1654278196",
       "arch": "noarch"
     },
     "perl-Archive-Tar": {
       "epoch": "0",
       "version": "2.30",
       "release": "1.el8",
-      "installdate": "1640302879",
+      "installdate": "1654278573",
       "arch": "noarch"
     },
-    "perl-File-Which": {
+    "kernel-core": {
       "epoch": "0",
-      "version": "1.22",
-      "release": "2.el8",
-      "installdate": "1640302879",
+      "version": "4.18.0",
+      "release": "383.el8",
+      "installdate": "1654278220",
+      "arch": "x86_64"
+    },
+    "centos-gpg-keys": {
+      "epoch": "1",
+      "version": "8",
+      "release": "6.el8",
+      "installdate": "1654278197",
       "arch": "noarch"
     },
     "perl-Devel-Peek": {
       "epoch": "0",
       "version": "1.26",
       "release": "421.el8",
-      "installdate": "1640302879",
+      "installdate": "1654278573",
       "arch": "x86_64"
     },
-    "perl-Data-Section": {
+    "libuser": {
       "epoch": "0",
-      "version": "0.200007",
-      "release": "3.el8",
-      "installdate": "1640302879",
-      "arch": "noarch"
+      "version": "0.62",
+      "release": "24.el8",
+      "installdate": "1654278221",
+      "arch": "x86_64"
+    },
+    "filesystem": {
+      "epoch": "0",
+      "version": "3.8",
+      "release": "6.el8",
+      "installdate": "1654278197",
+      "arch": "x86_64"
     },
     "perl-PerlIO-via-QuotedPrint": {
       "epoch": "0",
       "version": "0.08",
       "release": "395.el8",
-      "installdate": "1640302879",
+      "installdate": "1654278573",
       "arch": "noarch"
     },
-    "unzip": {
+    "openssh": {
       "epoch": "0",
-      "version": "6.0",
-      "release": "45.el8",
-      "installdate": "1640302879",
+      "version": "8.0p1",
+      "release": "12.el8",
+      "installdate": "1654278221",
+      "arch": "x86_64"
+    },
+    "ncurses-libs": {
+      "epoch": "0",
+      "version": "6.1",
+      "release": "9.20180224.el8",
+      "installdate": "1654278197",
       "arch": "x86_64"
     },
     "python3-pyparsing": {
       "epoch": "0",
       "version": "2.1.10",
       "release": "7.el8",
-      "installdate": "1640302879",
+      "installdate": "1654278573",
       "arch": "noarch"
     },
-    "rust-srpm-macros": {
+    "python3-decorator": {
       "epoch": "0",
-      "version": "5",
+      "version": "4.2.1",
       "release": "2.el8",
-      "installdate": "1640302881",
+      "installdate": "1654278221",
       "arch": "noarch"
+    },
+    "glibc": {
+      "epoch": "0",
+      "version": "2.28",
+      "release": "203.el8",
+      "installdate": "1654278198",
+      "arch": "x86_64"
+    },
+    "cups-client": {
+      "epoch": "1",
+      "version": "2.2.6",
+      "release": "46.el8",
+      "installdate": "1654278221",
+      "arch": "x86_64"
+    },
+    "info": {
+      "epoch": "0",
+      "version": "6.5",
+      "release": "7.el8_5",
+      "installdate": "1654278198",
+      "arch": "x86_64"
     },
     "perl-srpm-macros": {
       "epoch": "0",
       "version": "1",
       "release": "25.el8",
-      "installdate": "1640302881",
+      "installdate": "1654278574",
       "arch": "noarch"
     },
-    "ocaml-srpm-macros": {
+    "network-scripts": {
       "epoch": "0",
-      "version": "5",
-      "release": "4.el8",
-      "installdate": "1640302881",
-      "arch": "noarch"
-    },
-    "go-srpm-macros": {
-      "epoch": "0",
-      "version": "2",
-      "release": "17.el8",
-      "installdate": "1640302883",
-      "arch": "noarch"
-    },
-    "efi-srpm-macros": {
-      "epoch": "0",
-      "version": "3",
-      "release": "3.el8",
-      "installdate": "1640302883",
-      "arch": "noarch"
-    },
-    "perl-devel": {
-      "epoch": "4",
-      "version": "5.26.3",
-      "release": "421.el8",
-      "installdate": "1640302883",
+      "version": "10.00.17",
+      "release": "1.el8",
+      "installdate": "1654278221",
       "arch": "x86_64"
     },
-    "perl-ExtUtils-CBuilder": {
+    "bzip2-libs": {
+      "epoch": "0",
+      "version": "1.0.6",
+      "release": "26.el8",
+      "installdate": "1654278198",
+      "arch": "x86_64"
+    },
+    "python3-dateutil": {
       "epoch": "1",
-      "version": "0.280230",
-      "release": "2.el8",
-      "installdate": "1640302883",
-      "arch": "noarch"
-    },
-    "perl-ExtUtils-Miniperl": {
-      "epoch": "0",
-      "version": "1.06",
-      "release": "421.el8",
-      "installdate": "1640302883",
-      "arch": "noarch"
-    },
-    "perl-Encode-devel": {
-      "epoch": "4",
-      "version": "2.97",
-      "release": "3.el8",
-      "installdate": "1640302883",
-      "arch": "x86_64"
-    },
-    "perl-Module-Build": {
-      "epoch": "2",
-      "version": "0.42.24",
-      "release": "5.el8",
-      "installdate": "1640302883",
-      "arch": "noarch"
-    },
-    "perl": {
-      "epoch": "4",
-      "version": "5.26.3",
-      "release": "421.el8",
-      "installdate": "1640302883",
-      "arch": "x86_64"
-    },
-    "python3-libs": {
-      "epoch": "0",
-      "version": "3.6.8",
-      "release": "45.el8",
-      "installdate": "1643238290",
-      "arch": "x86_64"
-    },
-    "systemd": {
-      "epoch": "0",
-      "version": "239",
-      "release": "55.el8",
-      "installdate": "1643238292",
-      "arch": "x86_64"
-    },
-    "rpm": {
-      "epoch": "0",
-      "version": "4.14.3",
-      "release": "21.el8",
-      "installdate": "1643238293",
-      "arch": "x86_64"
-    },
-    "policycoreutils": {
-      "epoch": "0",
-      "version": "2.9",
-      "release": "18.el8",
-      "installdate": "1643238293",
-      "arch": "x86_64"
-    },
-    "selinux-policy": {
-      "epoch": "0",
-      "version": "3.14.3",
-      "release": "86.el8",
-      "installdate": "1643238293",
-      "arch": "noarch"
-    },
-    "systemd-udev": {
-      "epoch": "0",
-      "version": "239",
-      "release": "55.el8",
-      "installdate": "1643238372",
-      "arch": "x86_64"
-    },
-    "NetworkManager": {
-      "epoch": "1",
-      "version": "1.36.0",
-      "release": "0.4.el8",
-      "installdate": "1643238374",
-      "arch": "x86_64"
-    },
-    "python3-policycoreutils": {
-      "epoch": "0",
-      "version": "2.9",
-      "release": "18.el8",
-      "installdate": "1643238375",
-      "arch": "noarch"
-    },
-    "policycoreutils-devel": {
-      "epoch": "0",
-      "version": "2.9",
-      "release": "18.el8",
-      "installdate": "1643238376",
-      "arch": "x86_64"
-    },
-    "rpm-build-libs": {
-      "epoch": "0",
-      "version": "4.14.3",
-      "release": "21.el8",
-      "installdate": "1643238390",
-      "arch": "x86_64"
-    },
-    "device-mapper": {
-      "epoch": "8",
-      "version": "1.02.181",
-      "release": "2.el8",
-      "installdate": "1643238390",
-      "arch": "x86_64"
-    },
-    "dnf-plugins-core": {
-      "epoch": "0",
-      "version": "4.0.21",
-      "release": "8.el8",
-      "installdate": "1643238391",
-      "arch": "noarch"
-    },
-    "kernel-tools-libs": {
-      "epoch": "0",
-      "version": "4.18.0",
-      "release": "358.el8",
-      "installdate": "1643238391",
-      "arch": "x86_64"
-    },
-    "libsss_certmap": {
-      "epoch": "0",
       "version": "2.6.1",
-      "release": "2.el8",
-      "installdate": "1643238391",
-      "arch": "x86_64"
-    },
-    "sssd-client": {
-      "epoch": "0",
-      "version": "2.6.1",
-      "release": "2.el8",
-      "installdate": "1643238392",
-      "arch": "x86_64"
-    },
-    "libstdc++": {
-      "epoch": "0",
-      "version": "8.5.0",
-      "release": "7.el8",
-      "installdate": "1643238392",
-      "arch": "x86_64"
-    },
-    "sssd-common": {
-      "epoch": "0",
-      "version": "2.6.1",
-      "release": "2.el8",
-      "installdate": "1643238393",
-      "arch": "x86_64"
-    },
-    "linux-firmware": {
-      "epoch": "0",
-      "version": "20211119",
-      "release": "105.gitf5d51956.el8",
-      "installdate": "1643238428",
-      "arch": "noarch"
-    },
-    "centos-stream-repos": {
-      "epoch": "0",
-      "version": "8",
-      "release": "4.el8",
-      "installdate": "1643238446",
-      "arch": "noarch"
-    },
-    "binutils": {
-      "epoch": "0",
-      "version": "2.30",
-      "release": "112.el8",
-      "installdate": "1643238448",
-      "arch": "x86_64"
-    },
-    "virt-what": {
-      "epoch": "0",
-      "version": "1.18",
-      "release": "13.el8",
-      "installdate": "1643238449",
-      "arch": "x86_64"
-    },
-    "python3-rpm": {
-      "epoch": "0",
-      "version": "4.14.3",
-      "release": "21.el8",
-      "installdate": "1643238449",
-      "arch": "x86_64"
-    },
-    "NetworkManager-tui": {
-      "epoch": "1",
-      "version": "1.36.0",
-      "release": "0.4.el8",
-      "installdate": "1643238449",
-      "arch": "x86_64"
-    },
-    "redhat-rpm-config": {
-      "epoch": "0",
-      "version": "127",
-      "release": "1.el8",
-      "installdate": "1643238449",
-      "arch": "noarch"
-    },
-    "gssproxy": {
-      "epoch": "0",
-      "version": "0.8.0",
-      "release": "20.el8",
-      "installdate": "1643238450",
-      "arch": "x86_64"
-    },
-    "kexec-tools": {
-      "epoch": "0",
-      "version": "2.0.20",
-      "release": "67.el8",
-      "installdate": "1643238451",
-      "arch": "x86_64"
-    },
-    "python3-perf": {
-      "epoch": "0",
-      "version": "4.18.0",
-      "release": "358.el8",
-      "installdate": "1643238454",
-      "arch": "x86_64"
-    },
-    "python3-syspurpose": {
-      "epoch": "0",
-      "version": "1.28.24",
-      "release": "1.el8",
-      "installdate": "1643238456",
-      "arch": "x86_64"
-    },
-    "libibverbs": {
-      "epoch": "0",
-      "version": "37.2",
-      "release": "1.el8",
-      "installdate": "1643238456",
-      "arch": "x86_64"
-    },
-    "hwdata": {
-      "epoch": "0",
-      "version": "0.314",
-      "release": "8.11.el8",
-      "installdate": "1643238457",
-      "arch": "noarch"
-    },
-    "net-tools": {
-      "epoch": "0",
-      "version": "2.0",
-      "release": "0.52.20160912git.el8",
-      "installdate": "1640302567",
-      "arch": "x86_64"
-    },
-    "dracut-config-rescue": {
-      "epoch": "0",
-      "version": "049",
-      "release": "191.git20210920.el8",
-      "installdate": "1640302567",
-      "arch": "x86_64"
-    },
-    "parted": {
-      "epoch": "0",
-      "version": "3.2",
-      "release": "39.el8",
-      "installdate": "1640302567",
-      "arch": "x86_64"
-    },
-    "e2fsprogs": {
-      "epoch": "0",
-      "version": "1.45.6",
-      "release": "2.el8",
-      "installdate": "1640302568",
-      "arch": "x86_64"
-    },
-    "sg3_utils": {
-      "epoch": "0",
-      "version": "1.44",
-      "release": "5.el8",
-      "installdate": "1640302568",
-      "arch": "x86_64"
-    },
-    "biosdevname": {
-      "epoch": "0",
-      "version": "0.7.3",
-      "release": "2.el8",
-      "installdate": "1640302568",
-      "arch": "x86_64"
-    },
-    "lshw": {
-      "epoch": "0",
-      "version": "B.02.19.2",
       "release": "6.el8",
-      "installdate": "1640302568",
-      "arch": "x86_64"
-    },
-    "iprutils": {
-      "epoch": "0",
-      "version": "2.4.19",
-      "release": "1.el8",
-      "installdate": "1640302568",
-      "arch": "x86_64"
-    },
-    "lsscsi": {
-      "epoch": "0",
-      "version": "0.32",
-      "release": "3.el8",
-      "installdate": "1640302568",
-      "arch": "x86_64"
-    },
-    "rootfiles": {
-      "epoch": "0",
-      "version": "8.1",
-      "release": "22.el8",
-      "installdate": "1640302568",
+      "installdate": "1654278229",
       "arch": "noarch"
     },
-    "perl-Digest": {
-      "epoch": "0",
-      "version": "1.17",
-      "release": "395.el8",
-      "installdate": "1640302871",
-      "arch": "noarch"
-    },
-    "perl-Data-Dumper": {
-      "epoch": "0",
-      "version": "2.167",
-      "release": "399.el8",
-      "installdate": "1640302871",
-      "arch": "x86_64"
-    },
-    "perl-Net-SSLeay": {
-      "epoch": "0",
-      "version": "1.88",
-      "release": "1.module_el8.4.0+517+be1595ff",
-      "installdate": "1640302871",
-      "arch": "x86_64"
-    },
-    "perl-Pod-Escapes": {
-      "epoch": "1",
-      "version": "1.07",
-      "release": "395.el8",
-      "installdate": "1640302871",
-      "arch": "noarch"
-    },
-    "perl-IO-Socket-IP": {
-      "epoch": "0",
-      "version": "0.39",
-      "release": "5.el8",
-      "installdate": "1640302871",
-      "arch": "noarch"
-    },
-    "perl-IO-Socket-SSL": {
-      "epoch": "0",
-      "version": "2.066",
-      "release": "4.module_el8.4.0+517+be1595ff",
-      "installdate": "1640302871",
-      "arch": "noarch"
-    },
-    "perl-Term-Cap": {
-      "epoch": "0",
-      "version": "1.17",
-      "release": "395.el8",
-      "installdate": "1640302871",
-      "arch": "noarch"
-    },
-    "perl-Pod-Simple": {
-      "epoch": "1",
-      "version": "3.35",
-      "release": "395.el8",
-      "installdate": "1640302871",
-      "arch": "noarch"
-    },
-    "perl-podlators": {
-      "epoch": "0",
-      "version": "4.11",
-      "release": "1.el8",
-      "installdate": "1640302872",
-      "arch": "noarch"
-    },
-    "perl-Text-ParseWords": {
-      "epoch": "0",
-      "version": "3.30",
-      "release": "395.el8",
-      "installdate": "1640302872",
-      "arch": "noarch"
-    },
-    "perl-MIME-Base64": {
-      "epoch": "0",
-      "version": "3.15",
-      "release": "396.el8",
-      "installdate": "1640302872",
-      "arch": "x86_64"
-    },
-    "perl-Getopt-Long": {
-      "epoch": "1",
-      "version": "2.50",
-      "release": "4.el8",
-      "installdate": "1640302872",
-      "arch": "noarch"
-    },
-    "perl-Socket": {
-      "epoch": "4",
-      "version": "2.027",
-      "release": "3.el8",
-      "installdate": "1640302872",
-      "arch": "x86_64"
-    },
-    "perl-Carp": {
-      "epoch": "0",
-      "version": "1.42",
-      "release": "396.el8",
-      "installdate": "1640302872",
-      "arch": "noarch"
-    },
-    "perl-libs": {
-      "epoch": "4",
-      "version": "5.26.3",
-      "release": "421.el8",
-      "installdate": "1640302873",
-      "arch": "x86_64"
-    },
-    "perl-parent": {
-      "epoch": "1",
-      "version": "0.237",
-      "release": "1.el8",
-      "installdate": "1640302873",
-      "arch": "noarch"
-    },
-    "perl-Text-Tabs+Wrap": {
-      "epoch": "0",
-      "version": "2013.0523",
-      "release": "395.el8",
-      "installdate": "1640302873",
-      "arch": "noarch"
-    },
-    "perl-File-Path": {
-      "epoch": "0",
-      "version": "2.15",
-      "release": "2.el8",
-      "installdate": "1640302873",
-      "arch": "noarch"
-    },
-    "perl-PathTools": {
-      "epoch": "0",
-      "version": "3.74",
-      "release": "1.el8",
-      "installdate": "1640302873",
-      "arch": "x86_64"
-    },
-    "perl-threads": {
-      "epoch": "1",
-      "version": "2.21",
-      "release": "2.el8",
-      "installdate": "1640302873",
-      "arch": "x86_64"
-    },
-    "perl-interpreter": {
-      "epoch": "4",
-      "version": "5.26.3",
-      "release": "421.el8",
-      "installdate": "1640302874",
-      "arch": "x86_64"
-    },
-    "perl-Time-HiRes": {
-      "epoch": "4",
-      "version": "1.9758",
-      "release": "2.el8",
-      "installdate": "1640302874",
-      "arch": "x86_64"
-    },
-    "perl-ExtUtils-Manifest": {
-      "epoch": "0",
-      "version": "1.70",
-      "release": "395.el8",
-      "installdate": "1640302874",
-      "arch": "noarch"
-    },
-    "perl-Test-Harness": {
-      "epoch": "1",
-      "version": "3.42",
-      "release": "1.el8",
-      "installdate": "1640302875",
-      "arch": "noarch"
-    },
-    "perl-Module-Metadata": {
-      "epoch": "0",
-      "version": "1.000033",
-      "release": "395.el8",
-      "installdate": "1640302875",
-      "arch": "noarch"
-    },
-    "perl-SelfLoader": {
-      "epoch": "0",
-      "version": "1.23",
-      "release": "421.el8",
-      "installdate": "1640302875",
-      "arch": "noarch"
-    },
-    "perl-Module-Load": {
-      "epoch": "1",
-      "version": "0.32",
-      "release": "395.el8",
-      "installdate": "1640302875",
-      "arch": "noarch"
-    },
-    "perl-Text-Balanced": {
-      "epoch": "0",
-      "version": "2.03",
-      "release": "395.el8",
-      "installdate": "1640302875",
-      "arch": "noarch"
-    },
-    "perl-Net-Ping": {
-      "epoch": "0",
-      "version": "2.55",
-      "release": "421.el8",
-      "installdate": "1640302875",
-      "arch": "noarch"
-    },
-    "perl-Digest-SHA": {
-      "epoch": "1",
-      "version": "6.02",
-      "release": "1.el8",
-      "installdate": "1640302875",
-      "arch": "x86_64"
-    },
-    "perl-Locale-Maketext": {
-      "epoch": "0",
-      "version": "1.28",
-      "release": "396.el8",
-      "installdate": "1640302875",
-      "arch": "noarch"
-    },
-    "perl-Params-Check": {
-      "epoch": "1",
-      "version": "0.38",
-      "release": "395.el8",
-      "installdate": "1640302875",
-      "arch": "noarch"
-    },
-    "perl-Params-Util": {
-      "epoch": "0",
-      "version": "1.07",
-      "release": "22.el8",
-      "installdate": "1640302875",
-      "arch": "x86_64"
-    },
-    "perl-Sub-Install": {
-      "epoch": "0",
-      "version": "0.928",
-      "release": "14.el8",
-      "installdate": "1640302875",
-      "arch": "noarch"
-    },
-    "perl-IO-Compress": {
-      "epoch": "0",
-      "version": "2.081",
-      "release": "1.el8",
-      "installdate": "1640302875",
-      "arch": "noarch"
-    },
-    "perl-Math-Complex": {
-      "epoch": "0",
-      "version": "1.59",
-      "release": "421.el8",
-      "installdate": "1640302875",
-      "arch": "noarch"
-    },
-    "perl-JSON-PP": {
-      "epoch": "1",
-      "version": "2.97.001",
-      "release": "3.el8",
-      "installdate": "1640302875",
-      "arch": "noarch"
-    },
-    "perl-Math-BigRat": {
-      "epoch": "0",
-      "version": "0.2614",
-      "release": "1.el8",
-      "installdate": "1640302875",
-      "arch": "noarch"
-    },
-    "python-rpm-macros": {
-      "epoch": "0",
-      "version": "3",
-      "release": "41.el8",
-      "installdate": "1640302877",
-      "arch": "noarch"
-    },
-    "perl-bignum": {
-      "epoch": "0",
-      "version": "0.49",
-      "release": "2.el8",
-      "installdate": "1640302877",
-      "arch": "noarch"
-    },
-    "perl-Data-OptList": {
-      "epoch": "0",
-      "version": "0.110",
-      "release": "6.el8",
-      "installdate": "1640302877",
-      "arch": "noarch"
-    },
-    "perl-Filter-Simple": {
-      "epoch": "0",
-      "version": "0.94",
-      "release": "2.el8",
-      "installdate": "1640302877",
-      "arch": "noarch"
-    },
-    "perl-Devel-SelfStubber": {
-      "epoch": "0",
-      "version": "1.06",
-      "release": "421.el8",
-      "installdate": "1640302877",
-      "arch": "noarch"
-    },
-    "perl-experimental": {
-      "epoch": "0",
-      "version": "0.019",
-      "release": "2.el8",
-      "installdate": "1640302877",
-      "arch": "noarch"
-    },
-    "perl-B-Debug": {
-      "epoch": "0",
-      "version": "1.26",
-      "release": "2.el8",
-      "installdate": "1640302877",
-      "arch": "noarch"
-    },
-    "perl-Config-Perl-V": {
-      "epoch": "0",
-      "version": "0.30",
-      "release": "1.el8",
-      "installdate": "1640302877",
-      "arch": "noarch"
-    },
-    "perl-Devel-PPPort": {
-      "epoch": "0",
-      "version": "3.36",
-      "release": "5.el8",
-      "installdate": "1640302877",
-      "arch": "x86_64"
-    },
-    "perl-Encode-Locale": {
-      "epoch": "0",
-      "version": "1.05",
-      "release": "10.module_el8.3.0+416+dee7bcef",
-      "installdate": "1640302877",
-      "arch": "noarch"
-    },
-    "perl-ExtUtils-MM-Utils": {
-      "epoch": "1",
-      "version": "7.34",
-      "release": "1.el8",
-      "installdate": "1640302877",
-      "arch": "noarch"
-    },
-    "perl-File-Fetch": {
-      "epoch": "0",
-      "version": "0.56",
-      "release": "2.el8",
-      "installdate": "1640302877",
-      "arch": "noarch"
-    },
-    "perl-IPC-System-Simple": {
-      "epoch": "0",
-      "version": "1.25",
-      "release": "17.el8",
-      "installdate": "1640302878",
-      "arch": "noarch"
-    },
-    "perl-Locale-Codes": {
-      "epoch": "0",
-      "version": "3.57",
-      "release": "1.el8",
-      "installdate": "1640302878",
-      "arch": "noarch"
-    },
-    "gnutls": {
-      "epoch": "0",
-      "version": "3.6.16",
-      "release": "4.el8",
-      "installdate": "1640302535",
-      "arch": "x86_64"
-    },
-    "geolite2-country": {
-      "epoch": "0",
-      "version": "20180605",
-      "release": "1.el8",
-      "installdate": "1640302501",
-      "arch": "noarch"
-    },
-    "perl-Sub-Exporter": {
-      "epoch": "0",
-      "version": "0.987",
-      "release": "15.el8",
-      "installdate": "1640302878",
-      "arch": "noarch"
-    },
-    "trousers": {
-      "epoch": "0",
-      "version": "0.3.15",
-      "release": "1.el8",
-      "installdate": "1640302537",
-      "arch": "x86_64"
-    },
-    "python3-pip-wheel": {
-      "epoch": "0",
-      "version": "9.0.3",
-      "release": "22.el8",
-      "installdate": "1640302504",
-      "arch": "noarch"
-    },
-    "perl-TermReadKey": {
-      "epoch": "0",
-      "version": "2.37",
-      "release": "7.el8",
-      "installdate": "1640302878",
-      "arch": "x86_64"
-    },
-    "libevent": {
-      "epoch": "0",
-      "version": "2.1.8",
-      "release": "5.el8",
-      "installdate": "1640302537",
-      "arch": "x86_64"
-    },
-    "publicsuffix-list-dafsa": {
-      "epoch": "0",
-      "version": "20180723",
-      "release": "1.el8",
-      "installdate": "1640302504",
-      "arch": "noarch"
-    },
-    "perl-Text-Template": {
-      "epoch": "0",
-      "version": "1.51",
-      "release": "1.el8",
-      "installdate": "1640302878",
-      "arch": "noarch"
-    },
-    "cronie-anacron": {
-      "epoch": "0",
-      "version": "1.5.2",
-      "release": "6.el8",
-      "installdate": "1640302537",
-      "arch": "x86_64"
-    },
-    "libreport-filesystem": {
-      "epoch": "0",
-      "version": "2.9.5",
-      "release": "15.el8",
-      "installdate": "1640302519",
-      "arch": "x86_64"
-    },
-    "perl-utils": {
-      "epoch": "0",
-      "version": "5.26.3",
-      "release": "421.el8",
-      "installdate": "1640302879",
-      "arch": "noarch"
-    },
-    "perl-Thread-Queue": {
-      "epoch": "0",
-      "version": "3.13",
-      "release": "1.el8",
-      "installdate": "1640302879",
-      "arch": "noarch"
-    },
-    "perl-MRO-Compat": {
-      "epoch": "0",
-      "version": "0.13",
-      "release": "4.el8",
-      "installdate": "1640302879",
-      "arch": "noarch"
-    },
-    "polkit-pkla-compat": {
-      "epoch": "0",
-      "version": "0.1",
-      "release": "12.el8",
-      "installdate": "1640302543",
-      "arch": "x86_64"
-    },
-    "pcre2": {
-      "epoch": "0",
-      "version": "10.32",
-      "release": "2.el8",
-      "installdate": "1640302520",
-      "arch": "x86_64"
-    },
-    "perl-perlfaq": {
-      "epoch": "0",
-      "version": "5.20180605",
-      "release": "1.el8",
-      "installdate": "1640302879",
-      "arch": "noarch"
-    },
-    "avahi-libs": {
-      "epoch": "0",
-      "version": "0.7",
-      "release": "20.el8",
-      "installdate": "1640302543",
-      "arch": "x86_64"
-    },
-    "systemtap-sdt-devel": {
-      "epoch": "0",
-      "version": "4.6",
-      "release": "4.el8",
-      "installdate": "1640302879",
-      "arch": "x86_64"
-    },
-    "libsepol": {
-      "epoch": "0",
-      "version": "2.9",
-      "release": "3.el8",
-      "installdate": "1640302521",
-      "arch": "x86_64"
-    },
-    "network-scripts-team": {
+    "libgpg-error": {
       "epoch": "0",
       "version": "1.31",
-      "release": "2.el8",
-      "installdate": "1640302543",
+      "release": "1.el8",
+      "installdate": "1654278198",
       "arch": "x86_64"
     },
-    "libcom_err": {
+    "ghc-srpm-macros": {
       "epoch": "0",
-      "version": "1.45.6",
-      "release": "2.el8",
-      "installdate": "1640302521",
-      "arch": "x86_64"
-    },
-    "openblas-srpm-macros": {
-      "epoch": "0",
-      "version": "2",
-      "release": "2.el8",
-      "installdate": "1640302881",
+      "version": "1.4.2",
+      "release": "7.el8",
+      "installdate": "1654278576",
       "arch": "noarch"
     },
-    "util-linux-user": {
+    "python3-setools": {
+      "epoch": "0",
+      "version": "4.3.0",
+      "release": "3.el8",
+      "installdate": "1654278230",
+      "arch": "x86_64"
+    },
+    "libuuid": {
       "epoch": "0",
       "version": "2.32.1",
-      "release": "28.el8",
-      "installdate": "1640302543",
+      "release": "35.el8",
+      "installdate": "1654278199",
       "arch": "x86_64"
     },
-    "sqlite-libs": {
+    "perl-ExtUtils-Install": {
       "epoch": "0",
-      "version": "3.26.0",
-      "release": "15.el8",
-      "installdate": "1640302521",
-      "arch": "x86_64"
-    },
-    "python3-slip": {
-      "epoch": "0",
-      "version": "0.6.4",
-      "release": "11.el8",
-      "installdate": "1640302552",
+      "version": "2.14",
+      "release": "4.el8",
+      "installdate": "1654278576",
       "arch": "noarch"
     },
-    "chkconfig": {
-      "epoch": "0",
-      "version": "1.19.1",
-      "release": "1.el8",
-      "installdate": "1640302522",
-      "arch": "x86_64"
-    },
-    "dwz": {
-      "epoch": "0",
-      "version": "0.12",
-      "release": "10.el8",
-      "installdate": "1640302883",
-      "arch": "x86_64"
-    },
-    "python3-unbound": {
+    "unbound-libs": {
       "epoch": "0",
       "version": "1.7.3",
       "release": "17.el8",
-      "installdate": "1640302552",
+      "installdate": "1654278230",
       "arch": "x86_64"
     },
-    "readline": {
+    "expat": {
       "epoch": "0",
-      "version": "7.0",
-      "release": "10.el8",
-      "installdate": "1640302522",
+      "version": "2.2.5",
+      "release": "9.el8",
+      "installdate": "1654278199",
       "arch": "x86_64"
     },
-    "perl-ExtUtils-MakeMaker": {
-      "epoch": "1",
-      "version": "7.34",
-      "release": "1.el8",
-      "installdate": "1640302883",
-      "arch": "noarch"
-    },
-    "libattr": {
+    "perl-ExtUtils-Embed": {
       "epoch": "0",
-      "version": "2.4.48",
-      "release": "3.el8",
-      "installdate": "1640302522",
-      "arch": "x86_64"
-    },
-    "perl-libnetcfg": {
-      "epoch": "4",
-      "version": "5.26.3",
+      "version": "1.34",
       "release": "421.el8",
-      "installdate": "1640302883",
+      "installdate": "1654278576",
       "arch": "noarch"
+    },
+    "at": {
+      "epoch": "0",
+      "version": "3.1.20",
+      "release": "12.el8",
+      "installdate": "1654278231",
+      "arch": "x86_64"
+    },
+    "libacl": {
+      "epoch": "0",
+      "version": "2.2.53",
+      "release": "1.el8",
+      "installdate": "1654278199",
+      "arch": "x86_64"
+    },
+    "perl-inc-latest": {
+      "epoch": "2",
+      "version": "0.500",
+      "release": "9.el8",
+      "installdate": "1654278576",
+      "arch": "noarch"
+    },
+    "dbus-glib": {
+      "epoch": "0",
+      "version": "0.110",
+      "release": "2.el8",
+      "installdate": "1654278231",
+      "arch": "x86_64"
     },
     "gmp": {
       "epoch": "1",
       "version": "6.1.2",
       "release": "10.el8",
-      "installdate": "1640302522",
+      "installdate": "1654278199",
       "arch": "x86_64"
     },
-    "perl-CPAN": {
+    "python3-gobject-base": {
       "epoch": "0",
-      "version": "2.18",
-      "release": "397.el8",
-      "installdate": "1640302883",
-      "arch": "noarch"
-    },
-    "python3-dbus": {
-      "epoch": "0",
-      "version": "1.2.4",
-      "release": "15.el8",
-      "installdate": "1640302554",
+      "version": "3.28.3",
+      "release": "2.el8",
+      "installdate": "1654278231",
       "arch": "x86_64"
     },
     "lua-libs": {
       "epoch": "0",
       "version": "5.3.4",
       "release": "12.el8",
-      "installdate": "1640302522",
+      "installdate": "1654278199",
       "arch": "x86_64"
     },
-    "glibc-common": {
+    "dracut-squash": {
       "epoch": "0",
-      "version": "2.28",
-      "release": "184.el8",
-      "installdate": "1643238282",
+      "version": "049",
+      "release": "202.git20220511.el8",
+      "installdate": "1654278232",
       "arch": "x86_64"
     },
-    "libsecret": {
+    "libffi": {
       "epoch": "0",
-      "version": "0.18.6",
-      "release": "1.el8",
-      "installdate": "1640302554",
+      "version": "3.1",
+      "release": "23.el8",
+      "installdate": "1654278199",
       "arch": "x86_64"
     },
-    "libidn2": {
+    "libsss_certmap": {
       "epoch": "0",
-      "version": "2.2.0",
-      "release": "1.el8",
-      "installdate": "1640302522",
-      "arch": "x86_64"
-    },
-    "platform-python": {
-      "epoch": "0",
-      "version": "3.6.8",
-      "release": "45.el8",
-      "installdate": "1643238284",
-      "arch": "x86_64"
-    },
-    "libnl3": {
-      "epoch": "0",
-      "version": "3.5.0",
-      "release": "1.el8",
-      "installdate": "1640302522",
-      "arch": "x86_64"
-    },
-    "systemd-pam": {
-      "epoch": "0",
-      "version": "239",
-      "release": "55.el8",
-      "installdate": "1643238292",
-      "arch": "x86_64"
-    },
-    "libassuan": {
-      "epoch": "0",
-      "version": "2.5.1",
+      "version": "2.6.2",
       "release": "3.el8",
-      "installdate": "1640302522",
+      "installdate": "1654278232",
       "arch": "x86_64"
     },
-    "rpm-plugin-selinux": {
+    "nss-util": {
       "epoch": "0",
-      "version": "4.14.3",
-      "release": "21.el8",
-      "installdate": "1643238293",
+      "version": "3.67.0",
+      "release": "7.el8_5",
+      "installdate": "1654278199",
       "arch": "x86_64"
     },
-    "libusbx": {
+    "ima-evm-utils": {
       "epoch": "0",
-      "version": "1.0.23",
-      "release": "4.el8",
-      "installdate": "1640302555",
+      "version": "1.3.2",
+      "release": "12.el8",
+      "installdate": "1654278232",
       "arch": "x86_64"
     },
-    "jansson": {
+    "file-libs": {
       "epoch": "0",
-      "version": "2.14",
-      "release": "1.el8",
-      "installdate": "1640302523",
+      "version": "5.33",
+      "release": "20.el8",
+      "installdate": "1654278200",
       "arch": "x86_64"
     },
-    "NetworkManager-libnm": {
-      "epoch": "1",
-      "version": "1.36.0",
-      "release": "0.4.el8",
-      "installdate": "1643238373",
-      "arch": "x86_64"
-    },
-    "librepo": {
+    "gpgme": {
       "epoch": "0",
-      "version": "1.14.2",
-      "release": "1.el8",
-      "installdate": "1640302555",
+      "version": "1.13.1",
+      "release": "11.el8",
+      "installdate": "1654278233",
       "arch": "x86_64"
     },
-    "libref_array": {
+    "libcollection": {
       "epoch": "0",
-      "version": "0.1.5",
+      "version": "0.7.0",
       "release": "39.el8",
-      "installdate": "1640302523",
+      "installdate": "1654278200",
+      "arch": "x86_64"
+    },
+    "python3-hawkey": {
+      "epoch": "0",
+      "version": "0.63.0",
+      "release": "9.el8",
+      "installdate": "1654278233",
+      "arch": "x86_64"
+    },
+    "libtevent": {
+      "epoch": "0",
+      "version": "0.11.0",
+      "release": "0.el8",
+      "installdate": "1654278200",
+      "arch": "x86_64"
+    },
+    "plymouth-core-libs": {
+      "epoch": "0",
+      "version": "0.9.4",
+      "release": "11.20200615git1e36e30.el8",
+      "installdate": "1654278233",
+      "arch": "x86_64"
+    },
+    "cpio": {
+      "epoch": "0",
+      "version": "2.12",
+      "release": "11.el8",
+      "installdate": "1654278200",
+      "arch": "x86_64"
+    },
+    "man-db": {
+      "epoch": "0",
+      "version": "2.7.6.1",
+      "release": "18.el8",
+      "installdate": "1654278234",
+      "arch": "x86_64"
+    },
+    "libverto": {
+      "epoch": "0",
+      "version": "0.3.0",
+      "release": "5.el8",
+      "installdate": "1654278200",
+      "arch": "x86_64"
+    },
+    "quota": {
+      "epoch": "1",
+      "version": "4.04",
+      "release": "14.el8",
+      "installdate": "1654278234",
+      "arch": "x86_64"
+    },
+    "libnftnl": {
+      "epoch": "0",
+      "version": "1.1.5",
+      "release": "5.el8",
+      "installdate": "1654278200",
       "arch": "x86_64"
     },
     "policycoreutils-python-utils": {
       "epoch": "0",
       "version": "2.9",
-      "release": "18.el8",
-      "installdate": "1643238376",
+      "release": "19.el8",
+      "installdate": "1654278234",
       "arch": "noarch"
     },
-    "python3-gpg": {
+    "libgomp": {
       "epoch": "0",
-      "version": "1.13.1",
-      "release": "9.el8",
-      "installdate": "1640302555",
+      "version": "8.5.0",
+      "release": "13.el8",
+      "installdate": "1654278200",
       "arch": "x86_64"
     },
-    "nettle": {
-      "epoch": "0",
-      "version": "3.4.1",
-      "release": "7.el8",
-      "installdate": "1640302523",
-      "arch": "x86_64"
-    },
-    "device-mapper-libs": {
-      "epoch": "8",
-      "version": "1.02.181",
-      "release": "2.el8",
-      "installdate": "1643238390",
-      "arch": "x86_64"
-    },
-    "plymouth-scripts": {
-      "epoch": "0",
-      "version": "0.9.4",
-      "release": "10.20200615git1e36e30.el8",
-      "installdate": "1640302555",
-      "arch": "x86_64"
-    },
-    "gdbm-libs": {
-      "epoch": "1",
-      "version": "1.18",
-      "release": "1.el8",
-      "installdate": "1640302523",
-      "arch": "x86_64"
-    },
-    "dmidecode": {
-      "epoch": "1",
-      "version": "3.3",
-      "release": "1.el8",
-      "installdate": "1643238391",
-      "arch": "x86_64"
-    },
-    "nss-sysinit": {
-      "epoch": "0",
-      "version": "3.67.0",
-      "release": "7.el8_5",
-      "installdate": "1640302556",
-      "arch": "x86_64"
-    },
-    "libpsl": {
-      "epoch": "0",
-      "version": "0.20.2",
-      "release": "6.el8",
-      "installdate": "1640302523",
-      "arch": "x86_64"
-    },
-    "libsss_nss_idmap": {
-      "epoch": "0",
-      "version": "2.6.1",
-      "release": "2.el8",
-      "installdate": "1643238391",
-      "arch": "x86_64"
-    },
-    "libksba": {
-      "epoch": "0",
-      "version": "1.3.5",
-      "release": "7.el8",
-      "installdate": "1640302523",
-      "arch": "x86_64"
-    },
-    "sssd-nfs-idmap": {
-      "epoch": "0",
-      "version": "2.6.1",
-      "release": "2.el8",
-      "installdate": "1643238392",
-      "arch": "x86_64"
-    },
-    "python3-libcomps": {
-      "epoch": "0",
-      "version": "0.1.18",
-      "release": "1.el8",
-      "installdate": "1640302557",
-      "arch": "x86_64"
-    },
-    "checkpolicy": {
+    "policycoreutils-devel": {
       "epoch": "0",
       "version": "2.9",
-      "release": "1.el8",
-      "installdate": "1640302523",
+      "release": "19.el8",
+      "installdate": "1654278235",
       "arch": "x86_64"
     },
-    "libnfnetlink": {
+    "libdhash": {
       "epoch": "0",
-      "version": "1.0.1",
-      "release": "13.el8",
-      "installdate": "1640302523",
+      "version": "0.5.0",
+      "release": "39.el8",
+      "installdate": "1654278200",
       "arch": "x86_64"
     },
-    "sssd-kcm": {
-      "epoch": "0",
-      "version": "2.6.1",
-      "release": "2.el8",
-      "installdate": "1643238446",
-      "arch": "x86_64"
-    },
-    "python3-firewall": {
-      "epoch": "0",
+    "python3-nftables": {
+      "epoch": "1",
       "version": "0.9.3",
-      "release": "11.el8",
-      "installdate": "1640302565",
-      "arch": "noarch"
+      "release": "26.el8",
+      "installdate": "1654278243",
+      "arch": "x86_64"
     },
-    "p11-kit-trust": {
+    "libsss_idmap": {
       "epoch": "0",
-      "version": "0.23.22",
+      "version": "2.6.2",
+      "release": "3.el8",
+      "installdate": "1654278200",
+      "arch": "x86_64"
+    },
+    "python3-syspurpose": {
+      "epoch": "0",
+      "version": "1.28.28",
       "release": "1.el8",
-      "installdate": "1640302523",
+      "installdate": "1654278243",
+      "arch": "x86_64"
+    },
+    "lzo": {
+      "epoch": "0",
+      "version": "2.08",
+      "release": "14.el8",
+      "installdate": "1654278200",
       "arch": "x86_64"
     },
     "yum-utils": {
       "epoch": "0",
       "version": "4.0.21",
+      "release": "11.el8",
+      "installdate": "1654278244",
+      "arch": "noarch"
+    },
+    "grep": {
+      "epoch": "0",
+      "version": "3.1",
+      "release": "6.el8",
+      "installdate": "1654278201",
+      "arch": "x86_64"
+    },
+    "sssd-kcm": {
+      "epoch": "0",
+      "version": "2.6.2",
+      "release": "3.el8",
+      "installdate": "1654278244",
+      "arch": "x86_64"
+    },
+    "libnetfilter_conntrack": {
+      "epoch": "0",
+      "version": "1.0.6",
+      "release": "5.el8",
+      "installdate": "1654278201",
+      "arch": "x86_64"
+    },
+    "kernel": {
+      "epoch": "0",
+      "version": "4.18.0",
+      "release": "383.el8",
+      "installdate": "1654278244",
+      "arch": "x86_64"
+    },
+    "nss-softokn": {
+      "epoch": "0",
+      "version": "3.67.0",
+      "release": "7.el8_5",
+      "installdate": "1654278201",
+      "arch": "x86_64"
+    },
+    "openssh-clients": {
+      "epoch": "0",
+      "version": "8.0p1",
+      "release": "12.el8",
+      "installdate": "1654278244",
+      "arch": "x86_64"
+    },
+    "iptables": {
+      "epoch": "0",
+      "version": "1.8.4",
+      "release": "22.el8",
+      "installdate": "1654278201",
+      "arch": "x86_64"
+    },
+    "net-tools": {
+      "epoch": "0",
+      "version": "2.0",
+      "release": "0.52.20160912git.el8",
+      "installdate": "1654278245",
+      "arch": "x86_64"
+    },
+    "keyutils": {
+      "epoch": "0",
+      "version": "1.5.10",
+      "release": "9.el8",
+      "installdate": "1654278201",
+      "arch": "x86_64"
+    },
+    "parted": {
+      "epoch": "0",
+      "version": "3.2",
+      "release": "39.el8",
+      "installdate": "1654278245",
+      "arch": "x86_64"
+    },
+    "groff-base": {
+      "epoch": "0",
+      "version": "1.22.3",
+      "release": "18.el8",
+      "installdate": "1654278202",
+      "arch": "x86_64"
+    },
+    "sg3_utils": {
+      "epoch": "0",
+      "version": "1.44",
+      "release": "5.el8",
+      "installdate": "1654278245",
+      "arch": "x86_64"
+    },
+    "vim-minimal": {
+      "epoch": "2",
+      "version": "8.0.1763",
+      "release": "16.el8_5.12",
+      "installdate": "1654278202",
+      "arch": "x86_64"
+    },
+    "lshw": {
+      "epoch": "0",
+      "version": "B.02.19.2",
+      "release": "6.el8",
+      "installdate": "1654278245",
+      "arch": "x86_64"
+    },
+    "libicu": {
+      "epoch": "0",
+      "version": "60.3",
+      "release": "2.el8_1",
+      "installdate": "1654278203",
+      "arch": "x86_64"
+    },
+    "lsscsi": {
+      "epoch": "0",
+      "version": "0.32",
+      "release": "3.el8",
+      "installdate": "1654278246",
+      "arch": "x86_64"
+    },
+    "libbpf": {
+      "epoch": "0",
+      "version": "0.4.0",
+      "release": "3.el8",
+      "installdate": "1654278204",
+      "arch": "x86_64"
+    },
+    "perl-Digest": {
+      "epoch": "0",
+      "version": "1.17",
+      "release": "395.el8",
+      "installdate": "1654278567",
+      "arch": "noarch"
+    },
+    "time": {
+      "epoch": "0",
+      "version": "1.9",
+      "release": "3.el8",
+      "installdate": "1654278204",
+      "arch": "x86_64"
+    },
+    "perl-Net-SSLeay": {
+      "epoch": "0",
+      "version": "1.88",
+      "release": "1.module_el8.4.0+517+be1595ff",
+      "installdate": "1654278568",
+      "arch": "x86_64"
+    },
+    "libselinux-utils": {
+      "epoch": "0",
+      "version": "2.9",
+      "release": "5.el8",
+      "installdate": "1654278204",
+      "arch": "x86_64"
+    },
+    "perl-IO-Socket-IP": {
+      "epoch": "0",
+      "version": "0.39",
+      "release": "5.el8",
+      "installdate": "1654278568",
+      "arch": "noarch"
+    },
+    "c-ares": {
+      "epoch": "0",
+      "version": "1.13.0",
+      "release": "6.el8",
+      "installdate": "1654278204",
+      "arch": "x86_64"
+    },
+    "perl-Term-Cap": {
+      "epoch": "0",
+      "version": "1.17",
+      "release": "395.el8",
+      "installdate": "1654278568",
+      "arch": "noarch"
+    },
+    "libdaemon": {
+      "epoch": "0",
+      "version": "0.14",
+      "release": "15.el8",
+      "installdate": "1654278204",
+      "arch": "x86_64"
+    },
+    "perl-podlators": {
+      "epoch": "0",
+      "version": "4.11",
+      "release": "1.el8",
+      "installdate": "1654278568",
+      "arch": "noarch"
+    },
+    "libini_config": {
+      "epoch": "0",
+      "version": "1.3.1",
+      "release": "39.el8",
+      "installdate": "1654278205",
+      "arch": "x86_64"
+    },
+    "perl-MIME-Base64": {
+      "epoch": "0",
+      "version": "3.15",
+      "release": "396.el8",
+      "installdate": "1654278568",
+      "arch": "x86_64"
+    },
+    "perl-Socket": {
+      "epoch": "4",
+      "version": "2.027",
+      "release": "3.el8",
+      "installdate": "1654278568",
+      "arch": "x86_64"
+    },
+    "libsss_autofs": {
+      "epoch": "0",
+      "version": "2.6.2",
+      "release": "3.el8",
+      "installdate": "1654278205",
+      "arch": "x86_64"
+    },
+    "perl-libs": {
+      "epoch": "4",
+      "version": "5.26.3",
+      "release": "421.el8",
+      "installdate": "1654278569",
+      "arch": "x86_64"
+    },
+    "memstrack": {
+      "epoch": "0",
+      "version": "0.1.11",
+      "release": "1.el8",
+      "installdate": "1654278205",
+      "arch": "x86_64"
+    },
+    "perl-Text-Tabs+Wrap": {
+      "epoch": "0",
+      "version": "2013.0523",
+      "release": "395.el8",
+      "installdate": "1654278569",
+      "arch": "noarch"
+    },
+    "slang": {
+      "epoch": "0",
+      "version": "2.3.2",
+      "release": "3.el8",
+      "installdate": "1654278205",
+      "arch": "x86_64"
+    },
+    "perl-PathTools": {
+      "epoch": "0",
+      "version": "3.74",
+      "release": "1.el8",
+      "installdate": "1654278569",
+      "arch": "x86_64"
+    },
+    "libmaxminddb": {
+      "epoch": "0",
+      "version": "1.2.0",
+      "release": "10.el8",
+      "installdate": "1654278205",
+      "arch": "x86_64"
+    },
+    "perl-interpreter": {
+      "epoch": "4",
+      "version": "5.26.3",
+      "release": "421.el8",
+      "installdate": "1654278570",
+      "arch": "x86_64"
+    },
+    "platform-python-pip": {
+      "epoch": "0",
+      "version": "9.0.3",
+      "release": "22.el8",
+      "installdate": "1654278206",
+      "arch": "noarch"
+    },
+    "perl-ExtUtils-Manifest": {
+      "epoch": "0",
+      "version": "1.70",
+      "release": "395.el8",
+      "installdate": "1654278570",
+      "arch": "noarch"
+    },
+    "libssh": {
+      "epoch": "0",
+      "version": "0.9.6",
+      "release": "3.el8",
+      "installdate": "1654278208",
+      "arch": "x86_64"
+    },
+    "perl-Module-Metadata": {
+      "epoch": "0",
+      "version": "1.000033",
+      "release": "395.el8",
+      "installdate": "1654278570",
+      "arch": "noarch"
+    },
+    "libkcapi": {
+      "epoch": "0",
+      "version": "1.2.0",
+      "release": "2.el8",
+      "installdate": "1654278208",
+      "arch": "x86_64"
+    },
+    "perl-Module-Load": {
+      "epoch": "1",
+      "version": "0.32",
+      "release": "395.el8",
+      "installdate": "1654278570",
+      "arch": "noarch"
+    },
+    "curl": {
+      "epoch": "0",
+      "version": "7.61.1",
+      "release": "22.el8",
+      "installdate": "1654278208",
+      "arch": "x86_64"
+    },
+    "perl-Net-Ping": {
+      "epoch": "0",
+      "version": "2.55",
+      "release": "421.el8",
+      "installdate": "1654278570",
+      "arch": "noarch"
+    },
+    "crypto-policies": {
+      "epoch": "0",
+      "version": "20211116",
+      "release": "1.gitae470d6.el8",
+      "installdate": "1654278208",
+      "arch": "noarch"
+    },
+    "perl-Locale-Maketext": {
+      "epoch": "0",
+      "version": "1.28",
+      "release": "396.el8",
+      "installdate": "1654278570",
+      "arch": "noarch"
+    },
+    "cracklib-dicts": {
+      "epoch": "0",
+      "version": "2.9.6",
+      "release": "15.el8",
+      "installdate": "1654278209",
+      "arch": "x86_64"
+    },
+    "perl-Params-Util": {
+      "epoch": "0",
+      "version": "1.07",
+      "release": "22.el8",
+      "installdate": "1654278570",
+      "arch": "x86_64"
+    },
+    "libnsl2": {
+      "epoch": "0",
+      "version": "1.2.0",
+      "release": "2.20180605git4a062cf.el8",
+      "installdate": "1654278209",
+      "arch": "x86_64"
+    },
+    "perl-IO-Compress": {
+      "epoch": "0",
+      "version": "2.081",
+      "release": "1.el8",
+      "installdate": "1654278570",
+      "arch": "noarch"
+    },
+    "elfutils-libs": {
+      "epoch": "0",
+      "version": "0.187",
+      "release": "4.el8",
+      "installdate": "1654278209",
+      "arch": "x86_64"
+    },
+    "perl-JSON-PP": {
+      "epoch": "1",
+      "version": "2.97.001",
+      "release": "3.el8",
+      "installdate": "1654278570",
+      "arch": "noarch"
+    },
+    "libcroco": {
+      "epoch": "0",
+      "version": "0.6.12",
+      "release": "4.el8_2.1",
+      "installdate": "1654278209",
+      "arch": "x86_64"
+    },
+    "dbus-libs": {
+      "epoch": "1",
+      "version": "1.12.8",
+      "release": "18.el8",
+      "installdate": "1654278210",
+      "arch": "x86_64"
+    },
+    "perl-bignum": {
+      "epoch": "0",
+      "version": "0.49",
+      "release": "2.el8",
+      "installdate": "1654278571",
+      "arch": "noarch"
+    },
+    "systemd-libs": {
+      "epoch": "0",
+      "version": "239",
+      "release": "58.el8",
+      "installdate": "1654278210",
+      "arch": "x86_64"
+    },
+    "perl-Filter-Simple": {
+      "epoch": "0",
+      "version": "0.94",
+      "release": "2.el8",
+      "installdate": "1654278571",
+      "arch": "noarch"
+    },
+    "ca-certificates": {
+      "epoch": "0",
+      "version": "2021.2.50",
+      "release": "82.el8",
+      "installdate": "1654278210",
+      "arch": "noarch"
+    },
+    "perl-experimental": {
+      "epoch": "0",
+      "version": "0.019",
+      "release": "2.el8",
+      "installdate": "1654278572",
+      "arch": "noarch"
+    },
+    "kmod": {
+      "epoch": "0",
+      "version": "25",
+      "release": "19.el8",
+      "installdate": "1654278211",
+      "arch": "x86_64"
+    },
+    "perl-Config-Perl-V": {
+      "epoch": "0",
+      "version": "0.30",
+      "release": "1.el8",
+      "installdate": "1654278572",
+      "arch": "noarch"
+    },
+    "dbus-daemon": {
+      "epoch": "1",
+      "version": "1.12.8",
+      "release": "18.el8",
+      "installdate": "1654278211",
+      "arch": "x86_64"
+    },
+    "perl-Encode-Locale": {
+      "epoch": "0",
+      "version": "1.05",
+      "release": "10.module_el8.3.0+416+dee7bcef",
+      "installdate": "1654278572",
+      "arch": "noarch"
+    },
+    "pam": {
+      "epoch": "0",
+      "version": "1.3.1",
+      "release": "18.el8",
+      "installdate": "1654278211",
+      "arch": "x86_64"
+    },
+    "perl-File-Fetch": {
+      "epoch": "0",
+      "version": "0.56",
+      "release": "2.el8",
+      "installdate": "1654278572",
+      "arch": "noarch"
+    },
+    "os-prober": {
+      "epoch": "0",
+      "version": "1.74",
+      "release": "9.el8",
+      "installdate": "1654278212",
+      "arch": "x86_64"
+    },
+    "perl-Locale-Codes": {
+      "epoch": "0",
+      "version": "3.57",
+      "release": "1.el8",
+      "installdate": "1654278572",
+      "arch": "noarch"
+    },
+    "shared-mime-info": {
+      "epoch": "0",
+      "version": "1.9",
+      "release": "3.el8",
+      "installdate": "1654278213",
+      "arch": "x86_64"
+    },
+    "libgcc": {
+      "epoch": "0",
+      "version": "8.5.0",
+      "release": "13.el8",
+      "installdate": "1654278176",
+      "arch": "x86_64"
+    },
+    "dbus": {
+      "epoch": "1",
+      "version": "1.12.8",
+      "release": "18.el8",
+      "installdate": "1654278213",
+      "arch": "x86_64"
+    },
+    "geolite2-city": {
+      "epoch": "0",
+      "version": "20180605",
+      "release": "1.el8",
+      "installdate": "1654278178",
+      "arch": "noarch"
+    },
+    "systemd-udev": {
+      "epoch": "0",
+      "version": "239",
+      "release": "58.el8",
+      "installdate": "1654278214",
+      "arch": "x86_64"
+    },
+    "python3-setuptools-wheel": {
+      "epoch": "0",
+      "version": "39.2.0",
+      "release": "6.el8",
+      "installdate": "1654278179",
+      "arch": "noarch"
+    },
+    "policycoreutils": {
+      "epoch": "0",
+      "version": "2.9",
+      "release": "19.el8",
+      "installdate": "1654278215",
+      "arch": "x86_64"
+    },
+    "ncurses-base": {
+      "epoch": "0",
+      "version": "6.1",
+      "release": "9.20180224.el8",
+      "installdate": "1654278179",
+      "arch": "noarch"
+    },
+    "libevent": {
+      "epoch": "0",
+      "version": "2.1.8",
+      "release": "5.el8",
+      "installdate": "1654278215",
+      "arch": "x86_64"
+    },
+    "quota-nls": {
+      "epoch": "1",
+      "version": "4.04",
+      "release": "14.el8",
+      "installdate": "1654278179",
+      "arch": "noarch"
+    },
+    "python3-six": {
+      "epoch": "0",
+      "version": "1.11.0",
       "release": "8.el8",
-      "installdate": "1643238449",
+      "installdate": "1654278215",
       "arch": "noarch"
     },
-    "tuned": {
+    "cronie": {
       "epoch": "0",
-      "version": "2.16.0",
-      "release": "1.el8",
-      "installdate": "1640302565",
+      "version": "1.5.2",
+      "release": "7.el8",
+      "installdate": "1654278215",
+      "arch": "x86_64"
+    },
+    "libssh-config": {
+      "epoch": "0",
+      "version": "0.9.6",
+      "release": "3.el8",
+      "installdate": "1654278196",
       "arch": "noarch"
     },
-    "pciutils-libs": {
+    "libsolv": {
       "epoch": "0",
-      "version": "3.7.0",
-      "release": "1.el8",
-      "installdate": "1640302523",
+      "version": "0.7.20",
+      "release": "3.el8",
+      "installdate": "1654278215",
       "arch": "x86_64"
     },
-    "rpm-plugin-systemd-inhibit": {
-      "epoch": "0",
-      "version": "4.14.3",
-      "release": "21.el8",
-      "installdate": "1643238449",
-      "arch": "x86_64"
-    },
-    "yum": {
+    "dnf-data": {
       "epoch": "0",
       "version": "4.7.0",
-      "release": "5.el8",
-      "installdate": "1640302566",
+      "release": "9.el8",
+      "installdate": "1654278196",
       "arch": "noarch"
     },
-    "xz": {
+    "rpm-plugin-selinux": {
+      "epoch": "0",
+      "version": "4.14.3",
+      "release": "23.el8",
+      "installdate": "1654278215",
+      "arch": "x86_64"
+    },
+    "kbd-legacy": {
+      "epoch": "0",
+      "version": "2.0.4",
+      "release": "10.el8",
+      "installdate": "1654278196",
+      "arch": "noarch"
+    },
+    "selinux-policy-targeted": {
+      "epoch": "0",
+      "version": "3.14.3",
+      "release": "98.el8",
+      "installdate": "1654278217",
+      "arch": "noarch"
+    },
+    "firewalld-filesystem": {
+      "epoch": "0",
+      "version": "0.9.3",
+      "release": "13.el8",
+      "installdate": "1654278197",
+      "arch": "noarch"
+    },
+    "initscripts": {
+      "epoch": "0",
+      "version": "10.00.17",
+      "release": "1.el8",
+      "installdate": "1654278220",
+      "arch": "x86_64"
+    },
+    "centos-stream-release": {
+      "epoch": "0",
+      "version": "8.6",
+      "release": "1.el8",
+      "installdate": "1654278197",
+      "arch": "noarch"
+    },
+    "NetworkManager": {
+      "epoch": "1",
+      "version": "1.39.5",
+      "release": "1.el8",
+      "installdate": "1654278220",
+      "arch": "x86_64"
+    },
+    "setup": {
+      "epoch": "0",
+      "version": "2.12.2",
+      "release": "6.el8",
+      "installdate": "1654278197",
+      "arch": "noarch"
+    },
+    "polkit-libs": {
+      "epoch": "0",
+      "version": "0.115",
+      "release": "13.0.1.el8.2",
+      "installdate": "1654278221",
+      "arch": "x86_64"
+    },
+    "basesystem": {
+      "epoch": "0",
+      "version": "11",
+      "release": "5.el8",
+      "installdate": "1654278197",
+      "arch": "noarch"
+    },
+    "polkit-pkla-compat": {
+      "epoch": "0",
+      "version": "0.1",
+      "release": "12.el8",
+      "installdate": "1654278221",
+      "arch": "x86_64"
+    },
+    "libselinux": {
+      "epoch": "0",
+      "version": "2.9",
+      "release": "5.el8",
+      "installdate": "1654278197",
+      "arch": "x86_64"
+    },
+    "logrotate": {
+      "epoch": "0",
+      "version": "3.14.0",
+      "release": "4.el8",
+      "installdate": "1654278221",
+      "arch": "x86_64"
+    },
+    "glibc-langpack-en": {
+      "epoch": "0",
+      "version": "2.28",
+      "release": "203.el8",
+      "installdate": "1654278197",
+      "arch": "x86_64"
+    },
+    "libnfsidmap": {
+      "epoch": "1",
+      "version": "2.3.3",
+      "release": "51.el8",
+      "installdate": "1654278221",
+      "arch": "x86_64"
+    },
+    "glibc-gconv-extra": {
+      "epoch": "0",
+      "version": "2.28",
+      "release": "203.el8",
+      "installdate": "1654278198",
+      "arch": "x86_64"
+    },
+    "libldb": {
+      "epoch": "0",
+      "version": "2.4.1",
+      "release": "1.el8",
+      "installdate": "1654278221",
+      "arch": "x86_64"
+    },
+    "bash": {
+      "epoch": "0",
+      "version": "4.4.20",
+      "release": "4.el8",
+      "installdate": "1654278198",
+      "arch": "x86_64"
+    },
+    "cups-libs": {
+      "epoch": "1",
+      "version": "2.2.6",
+      "release": "46.el8",
+      "installdate": "1654278221",
+      "arch": "x86_64"
+    },
+    "zlib": {
+      "epoch": "0",
+      "version": "1.2.11",
+      "release": "19.el8",
+      "installdate": "1654278198",
+      "arch": "x86_64"
+    },
+    "timedatex": {
+      "epoch": "0",
+      "version": "0.5",
+      "release": "3.el8",
+      "installdate": "1654278221",
+      "arch": "x86_64"
+    },
+    "xz-libs": {
       "epoch": "0",
       "version": "5.2.4",
       "release": "3.el8",
-      "installdate": "1640302524",
+      "installdate": "1654278198",
       "arch": "x86_64"
     },
-    "iputils": {
+    "util-linux-user": {
       "epoch": "0",
-      "version": "20180629",
-      "release": "8.el8",
-      "installdate": "1643238450",
+      "version": "2.32.1",
+      "release": "35.el8",
+      "installdate": "1654278221",
       "arch": "x86_64"
     },
-    "gdbm": {
-      "epoch": "1",
+    "popt": {
+      "epoch": "0",
       "version": "1.18",
       "release": "1.el8",
-      "installdate": "1640302524",
+      "installdate": "1654278198",
+      "arch": "x86_64"
+    },
+    "network-scripts-team": {
+      "epoch": "0",
+      "version": "1.31",
+      "release": "2.el8",
+      "installdate": "1654278221",
+      "arch": "x86_64"
+    },
+    "libcap": {
+      "epoch": "0",
+      "version": "2.48",
+      "release": "4.el8",
+      "installdate": "1654278198",
+      "arch": "x86_64"
+    },
+    "kernel-modules": {
+      "epoch": "0",
+      "version": "4.18.0",
+      "release": "383.el8",
+      "installdate": "1654278223",
+      "arch": "x86_64"
+    },
+    "elfutils-libelf": {
+      "epoch": "0",
+      "version": "0.187",
+      "release": "4.el8",
+      "installdate": "1654278198",
       "arch": "x86_64"
     },
     "python3-linux-procfs": {
       "epoch": "0",
       "version": "0.7.0",
       "release": "1.el8",
-      "installdate": "1643238455",
+      "installdate": "1654278229",
       "arch": "noarch"
     },
-    "chrony": {
+    "libstdc++": {
+      "epoch": "0",
+      "version": "8.5.0",
+      "release": "13.el8",
+      "installdate": "1654278199",
+      "arch": "x86_64"
+    },
+    "python3-libsemanage": {
+      "epoch": "0",
+      "version": "2.9",
+      "release": "8.el8",
+      "installdate": "1654278230",
+      "arch": "x86_64"
+    },
+    "libxcrypt": {
+      "epoch": "0",
+      "version": "4.1.1",
+      "release": "6.el8",
+      "installdate": "1654278199",
+      "arch": "x86_64"
+    },
+    "python3-slip": {
+      "epoch": "0",
+      "version": "0.6.4",
+      "release": "13.el8",
+      "installdate": "1654278230",
+      "arch": "noarch"
+    },
+    "libxml2": {
+      "epoch": "0",
+      "version": "2.9.7",
+      "release": "14.el8",
+      "installdate": "1654278199",
+      "arch": "x86_64"
+    },
+    "gssproxy": {
+      "epoch": "0",
+      "version": "0.8.0",
+      "release": "20.el8",
+      "installdate": "1654278230",
+      "arch": "x86_64"
+    },
+    "libzstd": {
+      "epoch": "0",
+      "version": "1.4.4",
+      "release": "1.el8",
+      "installdate": "1654278199",
+      "arch": "x86_64"
+    },
+    "python3-unbound": {
+      "epoch": "0",
+      "version": "1.7.3",
+      "release": "17.el8",
+      "installdate": "1654278230",
+      "arch": "x86_64"
+    },
+    "findutils": {
+      "epoch": "1",
+      "version": "4.6.0",
+      "release": "20.el8",
+      "installdate": "1654278199",
+      "arch": "x86_64"
+    },
+    "rpcbind": {
+      "epoch": "0",
+      "version": "1.2.5",
+      "release": "8.el8",
+      "installdate": "1654278231",
+      "arch": "x86_64"
+    },
+    "libattr": {
+      "epoch": "0",
+      "version": "2.4.48",
+      "release": "3.el8",
+      "installdate": "1654278199",
+      "arch": "x86_64"
+    },
+    "authselect-libs": {
+      "epoch": "0",
+      "version": "1.2.2",
+      "release": "3.el8",
+      "installdate": "1654278231",
+      "arch": "x86_64"
+    },
+    "sed": {
+      "epoch": "0",
+      "version": "4.5",
+      "release": "5.el8",
+      "installdate": "1654278199",
+      "arch": "x86_64"
+    },
+    "dracut-network": {
+      "epoch": "0",
+      "version": "049",
+      "release": "202.git20220511.el8",
+      "installdate": "1654278231",
+      "arch": "x86_64"
+    },
+    "libidn2": {
+      "epoch": "0",
+      "version": "2.2.0",
+      "release": "1.el8",
+      "installdate": "1654278199",
+      "arch": "x86_64"
+    },
+    "python3-dbus": {
+      "epoch": "0",
+      "version": "1.2.4",
+      "release": "15.el8",
+      "installdate": "1654278231",
+      "arch": "x86_64"
+    },
+    "keyutils-libs": {
+      "epoch": "0",
+      "version": "1.5.10",
+      "release": "9.el8",
+      "installdate": "1654278199",
+      "arch": "x86_64"
+    },
+    "gobject-introspection": {
+      "epoch": "0",
+      "version": "1.56.1",
+      "release": "1.el8",
+      "installdate": "1654278231",
+      "arch": "x86_64"
+    },
+    "audit-libs": {
+      "epoch": "0",
+      "version": "3.0.7",
+      "release": "4.el8",
+      "installdate": "1654278199",
+      "arch": "x86_64"
+    },
+    "chef": {
+      "epoch": "0",
+      "version": "18.1.0",
+      "release": "1.el8",
+      "installdate": "1675120067",
+      "arch": "x86_64"
+    },
+    "libsecret": {
+      "epoch": "0",
+      "version": "0.18.6",
+      "release": "1.el8",
+      "installdate": "1654278231",
+      "arch": "x86_64"
+    },
+    "nspr": {
+      "epoch": "0",
+      "version": "4.32.0",
+      "release": "1.el8_4",
+      "installdate": "1654278199",
+      "arch": "x86_64"
+    },
+    "grub2-tools-extra": {
+      "epoch": "1",
+      "version": "2.02",
+      "release": "123.el8",
+      "installdate": "1654278232",
+      "arch": "x86_64"
+    },
+    "grub2-common": {
+      "epoch": "1",
+      "version": "2.02",
+      "release": "123.el8",
+      "installdate": "1654278199",
+      "arch": "noarch"
+    },
+    "virt-what": {
+      "epoch": "0",
+      "version": "1.18",
+      "release": "14.el8",
+      "installdate": "1654278232",
+      "arch": "x86_64"
+    },
+    "p11-kit": {
+      "epoch": "0",
+      "version": "0.23.22",
+      "release": "1.el8",
+      "installdate": "1654278199",
+      "arch": "x86_64"
+    },
+    "rpm-plugin-systemd-inhibit": {
+      "epoch": "0",
+      "version": "4.14.3",
+      "release": "23.el8",
+      "installdate": "1654278232",
+      "arch": "x86_64"
+    },
+    "libtalloc": {
+      "epoch": "0",
+      "version": "2.3.3",
+      "release": "1.el8",
+      "installdate": "1654278199",
+      "arch": "x86_64"
+    },
+    "sssd-common": {
+      "epoch": "0",
+      "version": "2.6.2",
+      "release": "3.el8",
+      "installdate": "1654278232",
+      "arch": "x86_64"
+    },
+    "libsemanage": {
+      "epoch": "0",
+      "version": "2.9",
+      "release": "8.el8",
+      "installdate": "1654278199",
+      "arch": "x86_64"
+    },
+    "tpm2-tss": {
+      "epoch": "0",
+      "version": "2.3.2",
+      "release": "4.el8",
+      "installdate": "1654278232",
+      "arch": "x86_64"
+    },
+    "diffutils": {
+      "epoch": "0",
+      "version": "3.6",
+      "release": "6.el8",
+      "installdate": "1654278200",
+      "arch": "x86_64"
+    },
+    "libusbx": {
+      "epoch": "0",
+      "version": "1.0.23",
+      "release": "4.el8",
+      "installdate": "1654278232",
+      "arch": "x86_64"
+    },
+    "file": {
+      "epoch": "0",
+      "version": "5.33",
+      "release": "20.el8",
+      "installdate": "1654278200",
+      "arch": "x86_64"
+    },
+    "gnupg2": {
+      "epoch": "0",
+      "version": "2.2.20",
+      "release": "2.el8",
+      "installdate": "1654278233",
+      "arch": "x86_64"
+    },
+    "libbasicobjects": {
+      "epoch": "0",
+      "version": "0.1.1",
+      "release": "39.el8",
+      "installdate": "1654278200",
+      "arch": "x86_64"
+    },
+    "librepo": {
+      "epoch": "0",
+      "version": "1.14.2",
+      "release": "1.el8",
+      "installdate": "1654278233",
+      "arch": "x86_64"
+    },
+    "libref_array": {
+      "epoch": "0",
+      "version": "0.1.5",
+      "release": "39.el8",
+      "installdate": "1654278200",
+      "arch": "x86_64"
+    },
+    "python3-libdnf": {
+      "epoch": "0",
+      "version": "0.63.0",
+      "release": "9.el8",
+      "installdate": "1654278233",
+      "arch": "x86_64"
+    },
+    "lz4-libs": {
+      "epoch": "0",
+      "version": "1.8.3",
+      "release": "3.el8_4",
+      "installdate": "1654278200",
+      "arch": "x86_64"
+    },
+    "python3-gpg": {
+      "epoch": "0",
+      "version": "1.13.1",
+      "release": "11.el8",
+      "installdate": "1654278233",
+      "arch": "x86_64"
+    },
+    "nettle": {
+      "epoch": "0",
+      "version": "3.4.1",
+      "release": "7.el8",
+      "installdate": "1654278200",
+      "arch": "x86_64"
+    },
+    "python3-rpm": {
+      "epoch": "0",
+      "version": "4.14.3",
+      "release": "23.el8",
+      "installdate": "1654278233",
+      "arch": "x86_64"
+    },
+    "hostname": {
+      "epoch": "0",
+      "version": "3.20",
+      "release": "7.el8.0.1",
+      "installdate": "1654278200",
+      "arch": "x86_64"
+    },
+    "plymouth-scripts": {
+      "epoch": "0",
+      "version": "0.9.4",
+      "release": "11.20200615git1e36e30.el8",
+      "installdate": "1654278233",
+      "arch": "x86_64"
+    },
+    "gdbm-libs": {
+      "epoch": "1",
+      "version": "1.18",
+      "release": "1.el8",
+      "installdate": "1654278200",
+      "arch": "x86_64"
+    },
+    "binutils": {
+      "epoch": "0",
+      "version": "2.30",
+      "release": "116.el8",
+      "installdate": "1654278234",
+      "arch": "x86_64"
+    },
+    "libtdb": {
+      "epoch": "0",
+      "version": "1.4.4",
+      "release": "1.el8",
+      "installdate": "1654278200",
+      "arch": "x86_64"
+    },
+    "nss-sysinit": {
+      "epoch": "0",
+      "version": "3.67.0",
+      "release": "7.el8_5",
+      "installdate": "1654278234",
+      "arch": "x86_64"
+    },
+    "libnl3-cli": {
+      "epoch": "0",
+      "version": "3.5.0",
+      "release": "1.el8",
+      "installdate": "1654278200",
+      "arch": "x86_64"
+    },
+    "redhat-lsb-submod-security": {
       "epoch": "0",
       "version": "4.1",
-      "release": "1.el8",
-      "installdate": "1640302566",
+      "release": "47.el8",
+      "installdate": "1654278234",
       "arch": "x86_64"
     },
-    "libpcap": {
-      "epoch": "14",
-      "version": "1.9.1",
-      "release": "5.el8",
-      "installdate": "1640302524",
-      "arch": "x86_64"
-    },
-    "vim-minimal": {
+    "ethtool": {
       "epoch": "2",
-      "version": "8.0.1763",
-      "release": "16.el8_5.3",
-      "installdate": "1643238457",
+      "version": "5.13",
+      "release": "1.el8",
+      "installdate": "1654278200",
+      "arch": "x86_64"
+    },
+    "kernel-tools": {
+      "epoch": "0",
+      "version": "4.18.0",
+      "release": "383.el8",
+      "installdate": "1654278234",
+      "arch": "x86_64"
+    },
+    "bc": {
+      "epoch": "0",
+      "version": "1.07.1",
+      "release": "5.el8",
+      "installdate": "1654278200",
+      "arch": "x86_64"
+    },
+    "python3-policycoreutils": {
+      "epoch": "0",
+      "version": "2.9",
+      "release": "19.el8",
+      "installdate": "1654278234",
+      "arch": "noarch"
+    },
+    "e2fsprogs-libs": {
+      "epoch": "0",
+      "version": "1.45.6",
+      "release": "5.el8",
+      "installdate": "1654278200",
+      "arch": "x86_64"
+    },
+    "python3-libcomps": {
+      "epoch": "0",
+      "version": "0.1.18",
+      "release": "1.el8",
+      "installdate": "1654278234",
+      "arch": "x86_64"
+    },
+    "m4": {
+      "epoch": "0",
+      "version": "1.4.18",
+      "release": "7.el8",
+      "installdate": "1654278200",
+      "arch": "x86_64"
+    },
+    "dnf": {
+      "epoch": "0",
+      "version": "4.7.0",
+      "release": "9.el8",
+      "installdate": "1654278235",
+      "arch": "noarch"
+    },
+    "dmidecode": {
+      "epoch": "1",
+      "version": "3.3",
+      "release": "4.el8",
+      "installdate": "1654278200",
+      "arch": "x86_64"
+    },
+    "selinux-policy-devel": {
+      "epoch": "0",
+      "version": "3.14.3",
+      "release": "98.el8",
+      "installdate": "1654278235",
+      "arch": "noarch"
+    },
+    "libedit": {
+      "epoch": "0",
+      "version": "3.1",
+      "release": "23.20170329cvs.el8",
+      "installdate": "1654278200",
+      "arch": "x86_64"
+    },
+    "dnf-plugins-core": {
+      "epoch": "0",
+      "version": "4.0.21",
+      "release": "11.el8",
+      "installdate": "1654278243",
+      "arch": "noarch"
+    },
+    "libseccomp": {
+      "epoch": "0",
+      "version": "2.5.2",
+      "release": "1.el8",
+      "installdate": "1654278200",
+      "arch": "x86_64"
+    },
+    "python3-firewall": {
+      "epoch": "0",
+      "version": "0.9.3",
+      "release": "13.el8",
+      "installdate": "1654278243",
+      "arch": "noarch"
+    },
+    "libtasn1": {
+      "epoch": "0",
+      "version": "4.13",
+      "release": "3.el8",
+      "installdate": "1654278200",
+      "arch": "x86_64"
+    },
+    "python3-pyyaml": {
+      "epoch": "0",
+      "version": "3.12",
+      "release": "12.el8",
+      "installdate": "1654278243",
+      "arch": "x86_64"
+    },
+    "libyaml": {
+      "epoch": "0",
+      "version": "0.1.7",
+      "release": "5.el8",
+      "installdate": "1654278200",
+      "arch": "x86_64"
+    },
+    "tuned": {
+      "epoch": "0",
+      "version": "2.18.0",
+      "release": "2.el8",
+      "installdate": "1654278243",
+      "arch": "noarch"
+    },
+    "numactl-libs": {
+      "epoch": "0",
+      "version": "2.0.12",
+      "release": "13.el8",
+      "installdate": "1654278200",
+      "arch": "x86_64"
+    },
+    "firewalld": {
+      "epoch": "0",
+      "version": "0.9.3",
+      "release": "13.el8",
+      "installdate": "1654278244",
+      "arch": "noarch"
+    },
+    "pcre": {
+      "epoch": "0",
+      "version": "8.42",
+      "release": "6.el8",
+      "installdate": "1654278201",
+      "arch": "x86_64"
+    },
+    "yum": {
+      "epoch": "0",
+      "version": "4.7.0",
+      "release": "9.el8",
+      "installdate": "1654278244",
+      "arch": "noarch"
+    },
+    "psmisc": {
+      "epoch": "0",
+      "version": "23.1",
+      "release": "5.el8",
+      "installdate": "1654278201",
+      "arch": "x86_64"
+    },
+    "wget": {
+      "epoch": "0",
+      "version": "1.19.5",
+      "release": "10.el8",
+      "installdate": "1654278244",
+      "arch": "x86_64"
+    },
+    "squashfs-tools": {
+      "epoch": "0",
+      "version": "4.3",
+      "release": "20.el8",
+      "installdate": "1654278201",
+      "arch": "x86_64"
+    },
+    "kexec-tools": {
+      "epoch": "0",
+      "version": "2.0.24",
+      "release": "1.el8",
+      "installdate": "1654278244",
+      "arch": "x86_64"
+    },
+    "libteam": {
+      "epoch": "0",
+      "version": "1.31",
+      "release": "2.el8",
+      "installdate": "1654278201",
+      "arch": "x86_64"
+    },
+    "authselect": {
+      "epoch": "0",
+      "version": "1.2.2",
+      "release": "3.el8",
+      "installdate": "1654278244",
+      "arch": "x86_64"
+    },
+    "nss-softokn-freebl": {
+      "epoch": "0",
+      "version": "3.67.0",
+      "release": "7.el8_5",
+      "installdate": "1654278201",
+      "arch": "x86_64"
+    },
+    "NetworkManager-team": {
+      "epoch": "1",
+      "version": "1.39.5",
+      "release": "1.el8",
+      "installdate": "1654278244",
+      "arch": "x86_64"
+    },
+    "libibverbs": {
+      "epoch": "0",
+      "version": "37.2",
+      "release": "1.el8",
+      "installdate": "1654278201",
+      "arch": "x86_64"
+    },
+    "rsyslog": {
+      "epoch": "0",
+      "version": "8.2102.0",
+      "release": "9.el8",
+      "installdate": "1654278244",
+      "arch": "x86_64"
+    },
+    "iptables-libs": {
+      "epoch": "0",
+      "version": "1.8.4",
+      "release": "22.el8",
+      "installdate": "1654278201",
       "arch": "x86_64"
     },
     "openssh-server": {
       "epoch": "0",
       "version": "8.0p1",
       "release": "12.el8",
-      "installdate": "1640302567",
+      "installdate": "1654278245",
       "arch": "x86_64"
     },
-    "nftables": {
+    "iptables-ebtables": {
+      "epoch": "0",
+      "version": "1.8.4",
+      "release": "22.el8",
+      "installdate": "1654278201",
+      "arch": "x86_64"
+    },
+    "grub2-pc-modules": {
       "epoch": "1",
-      "version": "0.9.3",
+      "version": "2.02",
+      "release": "123.el8",
+      "installdate": "1654278201",
+      "arch": "noarch"
+    },
+    "mpfr": {
+      "epoch": "0",
+      "version": "3.1.6",
+      "release": "1.el8",
+      "installdate": "1654278201",
+      "arch": "x86_64"
+    },
+    "ipset": {
+      "epoch": "0",
+      "version": "7.1",
+      "release": "1.el8",
+      "installdate": "1654278202",
+      "arch": "x86_64"
+    },
+    "acl": {
+      "epoch": "0",
+      "version": "2.2.53",
+      "release": "1.el8",
+      "installdate": "1654278202",
+      "arch": "x86_64"
+    },
+    "tar": {
+      "epoch": "2",
+      "version": "1.30",
+      "release": "5.el8",
+      "installdate": "1654278202",
+      "arch": "x86_64"
+    },
+    "patch": {
+      "epoch": "0",
+      "version": "2.7.6",
+      "release": "11.el8",
+      "installdate": "1654278202",
+      "arch": "x86_64"
+    },
+    "libmetalink": {
+      "epoch": "0",
+      "version": "0.1.3",
+      "release": "7.el8",
+      "installdate": "1654278202",
+      "arch": "x86_64"
+    },
+    "mozjs60": {
+      "epoch": "0",
+      "version": "60.9.0",
+      "release": "4.el8",
+      "installdate": "1654278204",
+      "arch": "x86_64"
+    },
+    "snappy": {
+      "epoch": "0",
+      "version": "1.1.8",
+      "release": "3.el8",
+      "installdate": "1654278204",
+      "arch": "x86_64"
+    },
+    "libss": {
+      "epoch": "0",
+      "version": "1.45.6",
+      "release": "5.el8",
+      "installdate": "1654278204",
+      "arch": "x86_64"
+    },
+    "ed": {
+      "epoch": "0",
+      "version": "1.14.2",
+      "release": "4.el8",
+      "installdate": "1654278204",
+      "arch": "x86_64"
+    },
+    "libpng": {
+      "epoch": "2",
+      "version": "1.6.34",
+      "release": "5.el8",
+      "installdate": "1654278204",
+      "arch": "x86_64"
+    },
+    "pigz": {
+      "epoch": "0",
+      "version": "2.4",
+      "release": "4.el8",
+      "installdate": "1654278204",
+      "arch": "x86_64"
+    },
+    "kernel-tools-libs": {
+      "epoch": "0",
+      "version": "4.18.0",
+      "release": "383.el8",
+      "installdate": "1654278204",
+      "arch": "x86_64"
+    },
+    "brotli": {
+      "epoch": "0",
+      "version": "1.0.6",
+      "release": "3.el8",
+      "installdate": "1654278204",
+      "arch": "x86_64"
+    },
+    "fuse-libs": {
+      "epoch": "0",
+      "version": "2.9.7",
+      "release": "15.el8",
+      "installdate": "1654278204",
+      "arch": "x86_64"
+    },
+    "hdparm": {
+      "epoch": "0",
+      "version": "9.54",
+      "release": "4.el8",
+      "installdate": "1654278204",
+      "arch": "x86_64"
+    },
+    "libndp": {
+      "epoch": "0",
+      "version": "1.7",
+      "release": "6.el8",
+      "installdate": "1654278204",
+      "arch": "x86_64"
+    },
+    "libpath_utils": {
+      "epoch": "0",
+      "version": "0.2.1",
+      "release": "39.el8",
+      "installdate": "1654278205",
+      "arch": "x86_64"
+    },
+    "libpipeline": {
+      "epoch": "0",
+      "version": "1.5.0",
+      "release": "2.el8",
+      "installdate": "1654278205",
+      "arch": "x86_64"
+    },
+    "gawk": {
+      "epoch": "0",
+      "version": "4.2.1",
+      "release": "4.el8",
+      "installdate": "1654278205",
+      "arch": "x86_64"
+    },
+    "libsss_nss_idmap": {
+      "epoch": "0",
+      "version": "2.6.2",
+      "release": "3.el8",
+      "installdate": "1654278205",
+      "arch": "x86_64"
+    },
+    "lmdb-libs": {
+      "epoch": "0",
+      "version": "0.9.24",
+      "release": "1.el8",
+      "installdate": "1654278205",
+      "arch": "x86_64"
+    },
+    "ncurses": {
+      "epoch": "0",
+      "version": "6.1",
+      "release": "9.20180224.el8",
+      "installdate": "1654278205",
+      "arch": "x86_64"
+    },
+    "sg3_utils-libs": {
+      "epoch": "0",
+      "version": "1.44",
+      "release": "5.el8",
+      "installdate": "1654278205",
+      "arch": "x86_64"
+    },
+    "newt": {
+      "epoch": "0",
+      "version": "0.52.20",
+      "release": "11.el8",
+      "installdate": "1654278205",
+      "arch": "x86_64"
+    },
+    "libfastjson": {
+      "epoch": "0",
+      "version": "0.99.9",
+      "release": "1.el8",
+      "installdate": "1654278205",
+      "arch": "x86_64"
+    },
+    "ipcalc": {
+      "epoch": "0",
+      "version": "0.2.4",
+      "release": "4.el8",
+      "installdate": "1654278205",
+      "arch": "x86_64"
+    },
+    "cyrus-sasl-lib": {
+      "epoch": "0",
+      "version": "2.1.27",
+      "release": "6.el8_5",
+      "installdate": "1654278205",
+      "arch": "x86_64"
+    },
+    "platform-python-setuptools": {
+      "epoch": "0",
+      "version": "39.2.0",
+      "release": "6.el8",
+      "installdate": "1654278206",
+      "arch": "noarch"
+    },
+    "grub2-tools-minimal": {
+      "epoch": "1",
+      "version": "2.02",
+      "release": "123.el8",
+      "installdate": "1654278208",
+      "arch": "x86_64"
+    },
+    "openldap": {
+      "epoch": "0",
+      "version": "2.4.46",
+      "release": "18.el8",
+      "installdate": "1654278208",
+      "arch": "x86_64"
+    },
+    "grubby": {
+      "epoch": "0",
+      "version": "8.40",
+      "release": "42.el8",
+      "installdate": "1654278208",
+      "arch": "x86_64"
+    },
+    "libkcapi-hmaccalc": {
+      "epoch": "0",
+      "version": "1.2.0",
+      "release": "2.el8",
+      "installdate": "1654278208",
+      "arch": "x86_64"
+    },
+    "libdb-utils": {
+      "epoch": "0",
+      "version": "5.3.28",
+      "release": "42.el8_4",
+      "installdate": "1654278208",
+      "arch": "x86_64"
+    },
+    "libcurl": {
+      "epoch": "0",
+      "version": "7.61.1",
+      "release": "22.el8",
+      "installdate": "1654278208",
+      "arch": "x86_64"
+    },
+    "crypto-policies-scripts": {
+      "epoch": "0",
+      "version": "20211116",
+      "release": "1.gitae470d6.el8",
+      "installdate": "1654278208",
+      "arch": "noarch"
+    },
+    "elfutils-default-yama-scope": {
+      "epoch": "0",
+      "version": "0.187",
+      "release": "4.el8",
+      "installdate": "1654278208",
+      "arch": "noarch"
+    },
+    "cracklib": {
+      "epoch": "0",
+      "version": "2.9.6",
+      "release": "15.el8",
+      "installdate": "1654278209",
+      "arch": "x86_64"
+    },
+    "procps-ng": {
+      "epoch": "0",
+      "version": "3.3.15",
+      "release": "7.el8",
+      "installdate": "1654278209",
+      "arch": "x86_64"
+    },
+    "libtirpc": {
+      "epoch": "0",
+      "version": "1.1.4",
+      "release": "6.el8",
+      "installdate": "1654278209",
+      "arch": "x86_64"
+    },
+    "kpartx": {
+      "epoch": "0",
+      "version": "0.8.4",
       "release": "24.el8",
-      "installdate": "1640302524",
+      "installdate": "1654278209",
+      "arch": "x86_64"
+    },
+    "elfutils-debuginfod-client": {
+      "epoch": "0",
+      "version": "0.187",
+      "release": "4.el8",
+      "installdate": "1654278209",
+      "arch": "x86_64"
+    },
+    "openssl-pkcs11": {
+      "epoch": "0",
+      "version": "0.4.10",
+      "release": "2.el8",
+      "installdate": "1654278209",
+      "arch": "x86_64"
+    },
+    "gettext-libs": {
+      "epoch": "0",
+      "version": "0.19.8.1",
+      "release": "17.el8",
+      "installdate": "1654278209",
+      "arch": "x86_64"
+    },
+    "dbus-common": {
+      "epoch": "1",
+      "version": "1.12.8",
+      "release": "18.el8",
+      "installdate": "1654278209",
+      "arch": "noarch"
+    },
+    "libmount": {
+      "epoch": "0",
+      "version": "2.32.1",
+      "release": "35.el8",
+      "installdate": "1654278209",
+      "arch": "x86_64"
+    },
+    "dbus-tools": {
+      "epoch": "1",
+      "version": "1.12.8",
+      "release": "18.el8",
+      "installdate": "1654278210",
+      "arch": "x86_64"
+    },
+    "coreutils": {
+      "epoch": "0",
+      "version": "8.30",
+      "release": "12.el8",
+      "installdate": "1654278210",
+      "arch": "x86_64"
+    },
+    "shadow-utils": {
+      "epoch": "2",
+      "version": "4.6",
+      "release": "16.el8",
+      "installdate": "1654278210",
+      "arch": "x86_64"
+    },
+    "device-mapper-libs": {
+      "epoch": "8",
+      "version": "1.02.181",
+      "release": "3.el8",
+      "installdate": "1654278210",
+      "arch": "x86_64"
+    },
+    "openssl-libs": {
+      "epoch": "1",
+      "version": "1.1.1k",
+      "release": "6.el8",
+      "installdate": "1654278211",
+      "arch": "x86_64"
+    },
+    "rpm-libs": {
+      "epoch": "0",
+      "version": "4.14.3",
+      "release": "23.el8",
+      "installdate": "1654278211",
+      "arch": "x86_64"
+    },
+    "kmod-libs": {
+      "epoch": "0",
+      "version": "25",
+      "release": "19.el8",
+      "installdate": "1654278211",
+      "arch": "x86_64"
+    },
+    "trousers-lib": {
+      "epoch": "0",
+      "version": "0.3.15",
+      "release": "1.el8",
+      "installdate": "1654278211",
+      "arch": "x86_64"
+    },
+    "libutempter": {
+      "epoch": "0",
+      "version": "1.1.6",
+      "release": "14.el8",
+      "installdate": "1654278211",
+      "arch": "x86_64"
+    },
+    "libpwquality": {
+      "epoch": "0",
+      "version": "1.4.4",
+      "release": "3.el8",
+      "installdate": "1654278211",
+      "arch": "x86_64"
+    },
+    "util-linux": {
+      "epoch": "0",
+      "version": "2.32.1",
+      "release": "35.el8",
+      "installdate": "1654278212",
+      "arch": "x86_64"
+    },
+    "dracut": {
+      "epoch": "0",
+      "version": "049",
+      "release": "202.git20220511.el8",
+      "installdate": "1654278212",
+      "arch": "x86_64"
+    },
+    "gettext": {
+      "epoch": "0",
+      "version": "0.19.8.1",
+      "release": "17.el8",
+      "installdate": "1654278212",
+      "arch": "x86_64"
+    },
+    "glib2": {
+      "epoch": "0",
+      "version": "2.56.4",
+      "release": "159.el8",
+      "installdate": "1654278213",
+      "arch": "x86_64"
+    },
+    "perl-Module-Loaded": {
+      "epoch": "1",
+      "version": "0.08",
+      "release": "421.el8",
+      "installdate": "1654278572",
+      "arch": "noarch"
+    },
+    "perl-Sub-Exporter": {
+      "epoch": "0",
+      "version": "0.987",
+      "release": "15.el8",
+      "installdate": "1654278572",
+      "arch": "noarch"
+    },
+    "perl-Pod-Parser": {
+      "epoch": "0",
+      "version": "1.63",
+      "release": "396.el8",
+      "installdate": "1654278572",
+      "arch": "noarch"
+    },
+    "perl-TermReadKey": {
+      "epoch": "0",
+      "version": "2.37",
+      "release": "7.el8",
+      "installdate": "1654278572",
+      "arch": "x86_64"
+    },
+    "perl-Test-Simple": {
+      "epoch": "1",
+      "version": "1.302135",
+      "release": "1.el8",
+      "installdate": "1654278572",
+      "arch": "noarch"
+    },
+    "perl-Text-Template": {
+      "epoch": "0",
+      "version": "1.51",
+      "release": "1.el8",
+      "installdate": "1654278572",
+      "arch": "noarch"
+    },
+    "perl-Unicode-Collate": {
+      "epoch": "0",
+      "version": "1.25",
+      "release": "2.el8",
+      "installdate": "1654278572",
+      "arch": "x86_64"
+    },
+    "perl-utils": {
+      "epoch": "0",
+      "version": "5.26.3",
+      "release": "421.el8",
+      "installdate": "1654278573",
+      "arch": "noarch"
+    },
+    "perl-Text-Diff": {
+      "epoch": "0",
+      "version": "1.45",
+      "release": "2.el8",
+      "installdate": "1654278573",
+      "arch": "noarch"
+    },
+    "perl-Thread-Queue": {
+      "epoch": "0",
+      "version": "3.13",
+      "release": "1.el8",
+      "installdate": "1654278573",
+      "arch": "noarch"
+    },
+    "perl-File-HomeDir": {
+      "epoch": "0",
+      "version": "1.002",
+      "release": "4.el8",
+      "installdate": "1654278573",
+      "arch": "noarch"
+    },
+    "perl-MRO-Compat": {
+      "epoch": "0",
+      "version": "0.13",
+      "release": "4.el8",
+      "installdate": "1654278573",
+      "arch": "noarch"
+    },
+    "perl-Software-License": {
+      "epoch": "0",
+      "version": "0.103013",
+      "release": "2.el8",
+      "installdate": "1654278573",
+      "arch": "noarch"
+    },
+    "perl-perlfaq": {
+      "epoch": "0",
+      "version": "5.20180605",
+      "release": "1.el8",
+      "installdate": "1654278573",
+      "arch": "noarch"
+    },
+    "zip": {
+      "epoch": "0",
+      "version": "3.0",
+      "release": "23.el8",
+      "installdate": "1654278573",
+      "arch": "x86_64"
+    },
+    "systemtap-sdt-devel": {
+      "epoch": "0",
+      "version": "4.7",
+      "release": "1.el8",
+      "installdate": "1654278573",
+      "arch": "x86_64"
+    },
+    "qt5-srpm-macros": {
+      "epoch": "0",
+      "version": "5.15.3",
+      "release": "1.el8",
+      "installdate": "1654278574",
+      "arch": "noarch"
+    },
+    "openblas-srpm-macros": {
+      "epoch": "0",
+      "version": "2",
+      "release": "2.el8",
+      "installdate": "1654278574",
+      "arch": "noarch"
+    },
+    "go-srpm-macros": {
+      "epoch": "0",
+      "version": "2",
+      "release": "17.el8",
+      "installdate": "1654278576",
+      "arch": "noarch"
+    },
+    "efi-srpm-macros": {
+      "epoch": "0",
+      "version": "3",
+      "release": "3.el8",
+      "installdate": "1654278576",
+      "arch": "noarch"
+    },
+    "redhat-rpm-config": {
+      "epoch": "0",
+      "version": "130",
+      "release": "1.el8",
+      "installdate": "1654278576",
+      "arch": "noarch"
+    },
+    "perl-devel": {
+      "epoch": "4",
+      "version": "5.26.3",
+      "release": "421.el8",
+      "installdate": "1654278576",
+      "arch": "x86_64"
+    },
+    "perl-ExtUtils-CBuilder": {
+      "epoch": "1",
+      "version": "0.280230",
+      "release": "2.el8",
+      "installdate": "1654278576",
+      "arch": "noarch"
+    },
+    "perl-ExtUtils-Miniperl": {
+      "epoch": "0",
+      "version": "1.06",
+      "release": "421.el8",
+      "installdate": "1654278576",
+      "arch": "noarch"
+    },
+    "perl-Encode-devel": {
+      "epoch": "4",
+      "version": "2.97",
+      "release": "3.el8",
+      "installdate": "1654278576",
+      "arch": "x86_64"
+    },
+    "perl-Module-Build": {
+      "epoch": "2",
+      "version": "0.42.24",
+      "release": "5.el8",
+      "installdate": "1654278576",
+      "arch": "noarch"
+    },
+    "perl": {
+      "epoch": "4",
+      "version": "5.26.3",
+      "release": "421.el8",
+      "installdate": "1654278576",
+      "arch": "x86_64"
+    },
+    "audit": {
+      "epoch": "0",
+      "version": "3.0.7",
+      "release": "4.el8",
+      "installdate": "1654278245",
       "arch": "x86_64"
     },
     "irqbalance": {
       "epoch": "2",
       "version": "1.4.0",
       "release": "6.el8",
-      "installdate": "1640302567",
+      "installdate": "1654278245",
       "arch": "x86_64"
     },
-    "ipset-libs": {
+    "sudo": {
       "epoch": "0",
-      "version": "7.1",
-      "release": "1.el8",
-      "installdate": "1640302524",
+      "version": "1.8.29",
+      "release": "8.el8",
+      "installdate": "1654278245",
       "arch": "x86_64"
     },
     "xfsprogs": {
       "epoch": "0",
       "version": "5.0.0",
       "release": "10.el8",
-      "installdate": "1640302567",
+      "installdate": "1654278245",
       "arch": "x86_64"
     },
-    "spax": {
+    "prefixdevname": {
       "epoch": "0",
-      "version": "1.5.3",
-      "release": "13.el8",
-      "installdate": "1640302525",
+      "version": "0.1.0",
+      "release": "6.el8",
+      "installdate": "1654278245",
       "arch": "x86_64"
     },
-    "libcomps": {
+    "rsync": {
       "epoch": "0",
-      "version": "0.1.18",
-      "release": "1.el8",
-      "installdate": "1640302525",
+      "version": "3.1.3",
+      "release": "14.el8",
+      "installdate": "1654278245",
       "arch": "x86_64"
     },
     "bzip2": {
       "epoch": "0",
       "version": "1.0.6",
       "release": "26.el8",
-      "installdate": "1640302568",
+      "installdate": "1654278246",
       "arch": "x86_64"
     },
-    "ncurses-compat-libs": {
+    "libsysfs": {
       "epoch": "0",
-      "version": "6.1",
-      "release": "9.20180224.el8",
-      "installdate": "1640302527",
+      "version": "2.1.0",
+      "release": "25.el8",
+      "installdate": "1654278246",
       "arch": "x86_64"
     },
     "langpacks-en": {
       "epoch": "0",
       "version": "1.0",
       "release": "12.el8",
-      "installdate": "1640302568",
+      "installdate": "1654278246",
       "arch": "noarch"
     },
-    "coreutils-common": {
+    "gpg-pubkey": {
       "epoch": "0",
-      "version": "8.30",
-      "release": "12.el8",
-      "installdate": "1640302527",
-      "arch": "x86_64"
+      "version": "8483c65d",
+      "release": "5ccc5b19",
+      "installdate": "1654278563",
+      "arch": "(none)"
     },
     "perl-Digest-MD5": {
       "epoch": "0",
       "version": "2.55",
       "release": "396.el8",
-      "installdate": "1640302871",
+      "installdate": "1654278567",
       "arch": "x86_64"
     },
-    "freetype": {
+    "perl-libnet": {
       "epoch": "0",
-      "version": "2.9.1",
-      "release": "4.el8_3.1",
-      "installdate": "1640302527",
-      "arch": "x86_64"
+      "version": "3.11",
+      "release": "3.el8",
+      "installdate": "1654278567",
+      "arch": "noarch"
     },
     "perl-URI": {
       "epoch": "0",
       "version": "1.73",
       "release": "3.el8",
-      "installdate": "1640302871",
+      "installdate": "1654278568",
       "arch": "noarch"
     },
-    "less": {
+    "perl-Mozilla-CA": {
       "epoch": "0",
-      "version": "530",
-      "release": "1.el8",
-      "installdate": "1640302527",
-      "arch": "x86_64"
+      "version": "20160104",
+      "release": "7.module_el8.3.0+416+dee7bcef",
+      "installdate": "1654278568",
+      "arch": "noarch"
     },
     "perl-Time-Local": {
       "epoch": "1",
       "version": "1.280",
       "release": "1.el8",
-      "installdate": "1640302871",
+      "installdate": "1654278568",
       "arch": "noarch"
     },
-    "hardlink": {
-      "epoch": "1",
-      "version": "1.3",
-      "release": "6.el8",
-      "installdate": "1640302527",
-      "arch": "x86_64"
+    "perl-Term-ANSIColor": {
+      "epoch": "0",
+      "version": "4.06",
+      "release": "396.el8",
+      "installdate": "1654278568",
+      "arch": "noarch"
     },
     "perl-File-Temp": {
       "epoch": "0",
       "version": "0.230.600",
       "release": "1.el8",
-      "installdate": "1640302871",
+      "installdate": "1654278568",
       "arch": "noarch"
     },
-    "libnghttp2": {
+    "perl-HTTP-Tiny": {
       "epoch": "0",
-      "version": "1.33.0",
-      "release": "3.el8_2.1",
-      "installdate": "1640302527",
-      "arch": "x86_64"
+      "version": "0.074",
+      "release": "1.el8",
+      "installdate": "1654278568",
+      "arch": "noarch"
     },
     "perl-Pod-Perldoc": {
       "epoch": "0",
       "version": "3.28",
       "release": "396.el8",
-      "installdate": "1640302872",
+      "installdate": "1654278568",
+      "arch": "noarch"
+    },
+    "perl-Pod-Usage": {
+      "epoch": "4",
+      "version": "1.69",
+      "release": "395.el8",
+      "installdate": "1654278568",
       "arch": "noarch"
     },
     "perl-Storable": {
       "epoch": "1",
       "version": "3.11",
       "release": "3.el8",
-      "installdate": "1640302872",
+      "installdate": "1654278568",
       "arch": "x86_64"
     },
-    "libsigsegv": {
+    "perl-Errno": {
       "epoch": "0",
-      "version": "2.11",
-      "release": "5.el8",
-      "installdate": "1640302527",
+      "version": "1.28",
+      "release": "421.el8",
+      "installdate": "1654278568",
       "arch": "x86_64"
     },
     "perl-Encode": {
       "epoch": "4",
       "version": "2.97",
       "release": "3.el8",
-      "installdate": "1640302872",
+      "installdate": "1654278568",
       "arch": "x86_64"
+    },
+    "perl-Exporter": {
+      "epoch": "0",
+      "version": "5.72",
+      "release": "396.el8",
+      "installdate": "1654278568",
+      "arch": "noarch"
     },
     "perl-Scalar-List-Utils": {
       "epoch": "3",
       "version": "1.49",
       "release": "2.el8",
-      "installdate": "1640302873",
+      "installdate": "1654278569",
       "arch": "x86_64"
     },
-    "npth": {
-      "epoch": "0",
-      "version": "1.5",
-      "release": "4.el8",
-      "installdate": "1640302528",
+    "perl-macros": {
+      "epoch": "4",
+      "version": "5.26.3",
+      "release": "421.el8",
+      "installdate": "1654278569",
       "arch": "x86_64"
     },
     "perl-Unicode-Normalize": {
       "epoch": "0",
       "version": "1.25",
       "release": "396.el8",
-      "installdate": "1640302873",
+      "installdate": "1654278569",
       "arch": "x86_64"
     },
-    "libestr": {
+    "perl-IO": {
       "epoch": "0",
-      "version": "0.1.10",
-      "release": "1.el8",
-      "installdate": "1640302528",
+      "version": "1.38",
+      "release": "421.el8",
+      "installdate": "1654278569",
       "arch": "x86_64"
     },
     "perl-constant": {
       "epoch": "0",
       "version": "1.33",
       "release": "396.el8",
-      "installdate": "1640302873",
+      "installdate": "1654278569",
       "arch": "noarch"
     },
-    "libxkbcommon": {
+    "perl-threads-shared": {
       "epoch": "0",
-      "version": "0.9.1",
-      "release": "1.el8",
-      "installdate": "1640302528",
+      "version": "1.58",
+      "release": "2.el8",
+      "installdate": "1654278569",
       "arch": "x86_64"
     },
     "perl-version": {
       "epoch": "6",
       "version": "0.99.24",
       "release": "1.el8",
-      "installdate": "1640302874",
+      "installdate": "1654278570",
       "arch": "x86_64"
+    },
+    "perl-CPAN-Meta-Requirements": {
+      "epoch": "0",
+      "version": "2.140",
+      "release": "396.el8",
+      "installdate": "1654278570",
+      "arch": "noarch"
     },
     "perl-ExtUtils-ParseXS": {
       "epoch": "1",
       "version": "3.35",
       "release": "2.el8",
-      "installdate": "1640302874",
+      "installdate": "1654278570",
+      "arch": "noarch"
+    },
+    "perl-Module-CoreList": {
+      "epoch": "1",
+      "version": "5.20181130",
+      "release": "1.el8",
+      "installdate": "1654278570",
       "arch": "noarch"
     },
     "perl-Filter": {
       "epoch": "2",
       "version": "1.58",
       "release": "2.el8",
-      "installdate": "1640302875",
+      "installdate": "1654278570",
       "arch": "x86_64"
     },
-    "libarchive": {
+    "perl-Compress-Raw-Zlib": {
       "epoch": "0",
-      "version": "3.3.3",
+      "version": "2.081",
       "release": "1.el8",
-      "installdate": "1640302531",
+      "installdate": "1654278570",
       "arch": "x86_64"
     },
     "perl-Perl-OSType": {
       "epoch": "0",
       "version": "1.010",
       "release": "396.el8",
-      "installdate": "1640302875",
+      "installdate": "1654278570",
       "arch": "noarch"
     },
-    "openssl": {
-      "epoch": "1",
-      "version": "1.1.1k",
-      "release": "5.el8_5",
-      "installdate": "1640302531",
+    "perl-encoding": {
+      "epoch": "4",
+      "version": "2.22",
+      "release": "3.el8",
+      "installdate": "1654278570",
       "arch": "x86_64"
     },
     "perl-CPAN-Meta-YAML": {
       "epoch": "0",
       "version": "0.018",
       "release": "397.el8",
-      "installdate": "1640302875",
+      "installdate": "1654278570",
       "arch": "noarch"
     },
-    "gzip": {
-      "epoch": "0",
-      "version": "1.9",
-      "release": "12.el8",
-      "installdate": "1640302531",
-      "arch": "x86_64"
+    "perl-ExtUtils-Command": {
+      "epoch": "1",
+      "version": "7.34",
+      "release": "1.el8",
+      "installdate": "1654278570",
+      "arch": "noarch"
     },
     "perl-Locale-Maketext-Simple": {
       "epoch": "1",
       "version": "0.21",
       "release": "421.el8",
-      "installdate": "1640302875",
+      "installdate": "1654278570",
       "arch": "noarch"
     },
-    "krb5-libs": {
+    "perl-Module-Load-Conditional": {
       "epoch": "0",
-      "version": "1.18.2",
-      "release": "14.el8",
-      "installdate": "1640302532",
-      "arch": "x86_64"
+      "version": "0.68",
+      "release": "395.el8",
+      "installdate": "1654278570",
+      "arch": "noarch"
     },
     "perl-Pod-Html": {
       "epoch": "0",
       "version": "1.22.02",
       "release": "421.el8",
-      "installdate": "1640302875",
+      "installdate": "1654278570",
       "arch": "noarch"
+    },
+    "perl-Compress-Raw-Bzip2": {
+      "epoch": "0",
+      "version": "2.081",
+      "release": "1.el8",
+      "installdate": "1654278570",
+      "arch": "x86_64"
     },
     "perl-IO-Zlib": {
       "epoch": "1",
       "version": "1.10",
       "release": "421.el8",
-      "installdate": "1640302875",
+      "installdate": "1654278570",
+      "arch": "noarch"
+    },
+    "perl-Math-BigInt": {
+      "epoch": "1",
+      "version": "1.9998.11",
+      "release": "7.el8",
+      "installdate": "1654278570",
       "arch": "noarch"
     },
     "perl-CPAN-Meta": {
       "epoch": "0",
       "version": "2.150010",
       "release": "396.el8",
-      "installdate": "1640302875",
+      "installdate": "1654278570",
       "arch": "noarch"
     },
-    "libfdisk": {
+    "python-srpm-macros": {
       "epoch": "0",
-      "version": "2.32.1",
-      "release": "28.el8",
-      "installdate": "1640302532",
-      "arch": "x86_64"
+      "version": "3",
+      "release": "41.el8",
+      "installdate": "1654278570",
+      "arch": "noarch"
     },
-    "which": {
+    "python3-rpm-macros": {
       "epoch": "0",
-      "version": "2.21",
-      "release": "17.el8",
-      "installdate": "1640302532",
-      "arch": "x86_64"
+      "version": "3",
+      "release": "41.el8",
+      "installdate": "1654278571",
+      "arch": "noarch"
     },
     "perl-Math-BigInt-FastCalc": {
       "epoch": "0",
       "version": "0.500.600",
       "release": "6.el8",
-      "installdate": "1640302877",
+      "installdate": "1654278571",
       "arch": "x86_64"
     },
-    "libblkid": {
+    "perl-open": {
       "epoch": "0",
-      "version": "2.32.1",
-      "release": "28.el8",
-      "installdate": "1640302533",
-      "arch": "x86_64"
+      "version": "1.11",
+      "release": "421.el8",
+      "installdate": "1654278571",
+      "arch": "noarch"
     },
     "perl-Archive-Zip": {
       "epoch": "0",
       "version": "1.60",
       "release": "3.el8",
-      "installdate": "1640302877",
+      "installdate": "1654278571",
       "arch": "noarch"
     },
-    "libdb": {
-      "epoch": "0",
-      "version": "5.3.28",
-      "release": "42.el8_4",
-      "installdate": "1640302533",
-      "arch": "x86_64"
+    "perl-Module-CoreList-tools": {
+      "epoch": "1",
+      "version": "5.20181130",
+      "release": "1.el8",
+      "installdate": "1654278571",
+      "arch": "noarch"
     },
     "perl-Attribute-Handlers": {
       "epoch": "0",
       "version": "0.99",
       "release": "421.el8",
-      "installdate": "1640302877",
+      "installdate": "1654278572",
       "arch": "noarch"
     },
-    "cryptsetup-libs": {
+    "perl-Compress-Bzip2": {
       "epoch": "0",
-      "version": "2.3.3",
-      "release": "4.el8",
-      "installdate": "1640302534",
+      "version": "2.26",
+      "release": "6.el8",
+      "installdate": "1654278572",
       "arch": "x86_64"
     },
     "perl-DB_File": {
       "epoch": "0",
       "version": "1.842",
       "release": "1.el8",
-      "installdate": "1640302877",
+      "installdate": "1654278572",
       "arch": "x86_64"
     },
-    "kbd": {
+    "perl-Devel-Size": {
       "epoch": "0",
-      "version": "2.0.4",
-      "release": "10.el8",
-      "installdate": "1640302534",
+      "version": "0.81",
+      "release": "2.el8",
+      "installdate": "1654278572",
       "arch": "x86_64"
     },
     "perl-Env": {
       "epoch": "0",
       "version": "1.04",
       "release": "395.el8",
-      "installdate": "1640302877",
+      "installdate": "1654278572",
+      "arch": "noarch"
+    },
+    "perl-IPC-Cmd": {
+      "epoch": "2",
+      "version": "1.02",
+      "release": "1.el8",
+      "installdate": "1654278572",
       "arch": "noarch"
     },
     "perl-IPC-SysV": {
       "epoch": "0",
       "version": "2.07",
       "release": "397.el8",
-      "installdate": "1640302878",
+      "installdate": "1654278572",
       "arch": "x86_64"
+    },
+    "perl-autodie": {
+      "epoch": "0",
+      "version": "2.29",
+      "release": "396.el8",
+      "installdate": "1654278572",
+      "arch": "noarch"
+    },
+    "perl-Memoize": {
+      "epoch": "0",
+      "version": "1.03",
+      "release": "421.el8",
+      "installdate": "1654278572",
+      "arch": "noarch"
+    },
+    "gnutls": {
+      "epoch": "0",
+      "version": "3.6.16",
+      "release": "4.el8",
+      "installdate": "1654278213",
+      "arch": "x86_64"
+    },
+    "geolite2-country": {
+      "epoch": "0",
+      "version": "20180605",
+      "release": "1.el8",
+      "installdate": "1654278176",
+      "arch": "noarch"
+    },
+    "perl-Pod-Checker": {
+      "epoch": "4",
+      "version": "1.73",
+      "release": "395.el8",
+      "installdate": "1654278572",
+      "arch": "noarch"
+    },
+    "trousers": {
+      "epoch": "0",
+      "version": "0.3.15",
+      "release": "1.el8",
+      "installdate": "1654278215",
+      "arch": "x86_64"
+    },
+    "python3-pip-wheel": {
+      "epoch": "0",
+      "version": "9.0.3",
+      "release": "22.el8",
+      "installdate": "1654278179",
+      "arch": "noarch"
+    },
+    "perl-Test": {
+      "epoch": "0",
+      "version": "1.30",
+      "release": "421.el8",
+      "installdate": "1654278572",
+      "arch": "noarch"
+    },
+    "python3-libselinux": {
+      "epoch": "0",
+      "version": "2.9",
+      "release": "5.el8",
+      "installdate": "1654278215",
+      "arch": "x86_64"
+    },
+    "publicsuffix-list-dafsa": {
+      "epoch": "0",
+      "version": "20180723",
+      "release": "1.el8",
+      "installdate": "1654278179",
+      "arch": "noarch"
+    },
+    "perl-Time-Piece": {
+      "epoch": "0",
+      "version": "1.31",
+      "release": "421.el8",
+      "installdate": "1654278572",
+      "arch": "x86_64"
+    },
+    "cronie-anacron": {
+      "epoch": "0",
+      "version": "1.5.2",
+      "release": "7.el8",
+      "installdate": "1654278215",
+      "arch": "x86_64"
+    },
+    "libreport-filesystem": {
+      "epoch": "0",
+      "version": "2.9.5",
+      "release": "15.el8",
+      "installdate": "1654278196",
+      "arch": "x86_64"
+    },
+    "perl-Algorithm-Diff": {
+      "epoch": "0",
+      "version": "1.1903",
+      "release": "9.el8",
+      "installdate": "1654278573",
+      "arch": "noarch"
+    },
+    "selinux-policy": {
+      "epoch": "0",
+      "version": "3.14.3",
+      "release": "98.el8",
+      "installdate": "1654278215",
+      "arch": "noarch"
+    },
+    "hwdata": {
+      "epoch": "0",
+      "version": "0.314",
+      "release": "8.12.el8",
+      "installdate": "1654278197",
+      "arch": "noarch"
+    },
+    "perl-File-Which": {
+      "epoch": "0",
+      "version": "1.22",
+      "release": "2.el8",
+      "installdate": "1654278573",
+      "arch": "noarch"
+    },
+    "NetworkManager-libnm": {
+      "epoch": "1",
+      "version": "1.39.5",
+      "release": "1.el8",
+      "installdate": "1654278220",
+      "arch": "x86_64"
+    },
+    "centos-stream-repos": {
+      "epoch": "0",
+      "version": "8",
+      "release": "6.el8",
+      "installdate": "1654278197",
+      "arch": "noarch"
+    },
+    "perl-Data-Section": {
+      "epoch": "0",
+      "version": "0.200007",
+      "release": "3.el8",
+      "installdate": "1654278573",
+      "arch": "noarch"
+    },
+    "polkit": {
+      "epoch": "0",
+      "version": "0.115",
+      "release": "13.0.1.el8.2",
+      "installdate": "1654278221",
+      "arch": "x86_64"
+    },
+    "pcre2": {
+      "epoch": "0",
+      "version": "10.32",
+      "release": "2.el8",
+      "installdate": "1654278197",
+      "arch": "x86_64"
+    },
+    "unzip": {
+      "epoch": "0",
+      "version": "6.0",
+      "release": "46.el8",
+      "installdate": "1654278573",
+      "arch": "x86_64"
+    },
+    "avahi-libs": {
+      "epoch": "0",
+      "version": "0.7",
+      "release": "20.el8",
+      "installdate": "1654278221",
+      "arch": "x86_64"
+    },
+    "glibc-common": {
+      "epoch": "0",
+      "version": "2.28",
+      "release": "203.el8",
+      "installdate": "1654278197",
+      "arch": "x86_64"
+    },
+    "sssd-nfs-idmap": {
+      "epoch": "0",
+      "version": "2.6.2",
+      "release": "3.el8",
+      "installdate": "1654278221",
+      "arch": "x86_64"
+    },
+    "libsepol": {
+      "epoch": "0",
+      "version": "2.9",
+      "release": "3.el8",
+      "installdate": "1654278198",
+      "arch": "x86_64"
+    },
+    "rust-srpm-macros": {
+      "epoch": "0",
+      "version": "5",
+      "release": "2.el8",
+      "installdate": "1654278574",
+      "arch": "noarch"
+    },
+    "passwd": {
+      "epoch": "0",
+      "version": "0.80",
+      "release": "4.el8",
+      "installdate": "1654278221",
+      "arch": "x86_64"
+    },
+    "libcom_err": {
+      "epoch": "0",
+      "version": "1.45.6",
+      "release": "5.el8",
+      "installdate": "1654278198",
+      "arch": "x86_64"
+    },
+    "ocaml-srpm-macros": {
+      "epoch": "0",
+      "version": "5",
+      "release": "4.el8",
+      "installdate": "1654278574",
+      "arch": "noarch"
+    },
+    "teamd": {
+      "epoch": "0",
+      "version": "1.31",
+      "release": "2.el8",
+      "installdate": "1654278221",
+      "arch": "x86_64"
+    },
+    "sqlite-libs": {
+      "epoch": "0",
+      "version": "3.26.0",
+      "release": "15.el8",
+      "installdate": "1654278198",
+      "arch": "x86_64"
+    },
+    "python3-pyudev": {
+      "epoch": "0",
+      "version": "0.21.0",
+      "release": "7.el8",
+      "installdate": "1654278229",
+      "arch": "noarch"
+    },
+    "chkconfig": {
+      "epoch": "0",
+      "version": "1.19.1",
+      "release": "1.el8",
+      "installdate": "1654278199",
+      "arch": "x86_64"
+    },
+    "dwz": {
+      "epoch": "0",
+      "version": "0.12",
+      "release": "10.el8",
+      "installdate": "1654278576",
+      "arch": "x86_64"
+    },
+    "libverto-libevent": {
+      "epoch": "0",
+      "version": "0.3.0",
+      "release": "5.el8",
+      "installdate": "1654278230",
+      "arch": "x86_64"
+    },
+    "readline": {
+      "epoch": "0",
+      "version": "7.0",
+      "release": "10.el8",
+      "installdate": "1654278199",
+      "arch": "x86_64"
+    },
+    "perl-ExtUtils-MakeMaker": {
+      "epoch": "1",
+      "version": "7.34",
+      "release": "1.el8",
+      "installdate": "1654278576",
+      "arch": "noarch"
+    },
+    "postfix": {
+      "epoch": "2",
+      "version": "3.5.8",
+      "release": "4.el8",
+      "installdate": "1654278230",
+      "arch": "x86_64"
+    },
+    "libunistring": {
+      "epoch": "0",
+      "version": "0.9.9",
+      "release": "3.el8",
+      "installdate": "1654278199",
+      "arch": "x86_64"
+    },
+    "perl-libnetcfg": {
+      "epoch": "4",
+      "version": "5.26.3",
+      "release": "421.el8",
+      "installdate": "1654278576",
+      "arch": "noarch"
+    },
+    "iputils": {
+      "epoch": "0",
+      "version": "20180629",
+      "release": "10.el8",
+      "installdate": "1654278231",
+      "arch": "x86_64"
+    },
+    "libmnl": {
+      "epoch": "0",
+      "version": "1.0.4",
+      "release": "6.el8",
+      "installdate": "1654278199",
+      "arch": "x86_64"
+    },
+    "perl-CPAN": {
+      "epoch": "0",
+      "version": "2.18",
+      "release": "397.el8",
+      "installdate": "1654278576",
+      "arch": "noarch"
+    },
+    "python3-slip-dbus": {
+      "epoch": "0",
+      "version": "0.6.4",
+      "release": "13.el8",
+      "installdate": "1654278231",
+      "arch": "noarch"
+    },
+    "libcap-ng": {
+      "epoch": "0",
+      "version": "0.7.11",
+      "release": "1.el8",
+      "installdate": "1654278199",
+      "arch": "x86_64"
+    },
+    "pinentry": {
+      "epoch": "0",
+      "version": "1.1.0",
+      "release": "2.el8",
+      "installdate": "1654278231",
+      "arch": "x86_64"
+    },
+    "libgcrypt": {
+      "epoch": "0",
+      "version": "1.8.5",
+      "release": "6.el8",
+      "installdate": "1654278199",
+      "arch": "x86_64"
+    },
+    "sssd-client": {
+      "epoch": "0",
+      "version": "2.6.2",
+      "release": "3.el8",
+      "installdate": "1654278232",
+      "arch": "x86_64"
+    },
+    "libnl3": {
+      "epoch": "0",
+      "version": "3.5.0",
+      "release": "1.el8",
+      "installdate": "1654278199",
+      "arch": "x86_64"
+    },
+    "mailx": {
+      "epoch": "0",
+      "version": "12.5",
+      "release": "29.el8",
+      "installdate": "1654278232",
+      "arch": "x86_64"
+    },
+    "libassuan": {
+      "epoch": "0",
+      "version": "2.5.1",
+      "release": "3.el8",
+      "installdate": "1654278199",
+      "arch": "x86_64"
+    },
+    "gnupg2-smime": {
+      "epoch": "0",
+      "version": "2.2.20",
+      "release": "2.el8",
+      "installdate": "1654278232",
+      "arch": "x86_64"
+    },
+    "json-c": {
+      "epoch": "0",
+      "version": "0.13.1",
+      "release": "3.el8",
+      "installdate": "1654278200",
+      "arch": "x86_64"
+    },
+    "libdnf": {
+      "epoch": "0",
+      "version": "0.63.0",
+      "release": "9.el8",
+      "installdate": "1654278233",
+      "arch": "x86_64"
+    },
+    "libsmartcols": {
+      "epoch": "0",
+      "version": "2.32.1",
+      "release": "35.el8",
+      "installdate": "1654278200",
+      "arch": "x86_64"
+    },
+    "rpm-build-libs": {
+      "epoch": "0",
+      "version": "4.14.3",
+      "release": "23.el8",
+      "installdate": "1654278233",
+      "arch": "x86_64"
+    },
+    "make": {
+      "epoch": "1",
+      "version": "4.2.1",
+      "release": "11.el8",
+      "installdate": "1654278200",
+      "arch": "x86_64"
+    },
+    "plymouth": {
+      "epoch": "0",
+      "version": "0.9.4",
+      "release": "11.20200615git1e36e30.el8",
+      "installdate": "1654278233",
+      "arch": "x86_64"
+    },
+    "jansson": {
+      "epoch": "0",
+      "version": "2.14",
+      "release": "1.el8",
+      "installdate": "1654278200",
+      "arch": "x86_64"
+    },
+    "nss": {
+      "epoch": "0",
+      "version": "3.67.0",
+      "release": "7.el8_5",
+      "installdate": "1654278234",
+      "arch": "x86_64"
+    },
+    "libpsl": {
+      "epoch": "0",
+      "version": "0.20.2",
+      "release": "6.el8",
+      "installdate": "1654278200",
+      "arch": "x86_64"
+    },
+    "python3-audit": {
+      "epoch": "0",
+      "version": "3.0.7",
+      "release": "4.el8",
+      "installdate": "1654278234",
+      "arch": "x86_64"
+    },
+    "libksba": {
+      "epoch": "0",
+      "version": "1.3.5",
+      "release": "7.el8",
+      "installdate": "1654278200",
+      "arch": "x86_64"
+    },
+    "python3-dnf": {
+      "epoch": "0",
+      "version": "4.7.0",
+      "release": "9.el8",
+      "installdate": "1654278235",
+      "arch": "noarch"
+    },
+    "checkpolicy": {
+      "epoch": "0",
+      "version": "2.9",
+      "release": "1.el8",
+      "installdate": "1654278200",
+      "arch": "x86_64"
+    },
+    "python3-dnf-plugins-core": {
+      "epoch": "0",
+      "version": "4.0.21",
+      "release": "11.el8",
+      "installdate": "1654278243",
+      "arch": "noarch"
+    },
+    "libnfnetlink": {
+      "epoch": "0",
+      "version": "1.0.1",
+      "release": "13.el8",
+      "installdate": "1654278200",
+      "arch": "x86_64"
+    },
+    "python3-perf": {
+      "epoch": "0",
+      "version": "4.18.0",
+      "release": "383.el8",
+      "installdate": "1654278243",
+      "arch": "x86_64"
+    },
+    "p11-kit-trust": {
+      "epoch": "0",
+      "version": "0.23.22",
+      "release": "1.el8",
+      "installdate": "1654278200",
+      "arch": "x86_64"
+    },
+    "nfs-utils": {
+      "epoch": "1",
+      "version": "2.3.3",
+      "release": "51.el8",
+      "installdate": "1654278243",
+      "arch": "x86_64"
+    },
+    "pciutils-libs": {
+      "epoch": "0",
+      "version": "3.7.0",
+      "release": "1.el8",
+      "installdate": "1654278201",
+      "arch": "x86_64"
+    },
+    "redhat-lsb-core": {
+      "epoch": "0",
+      "version": "4.1",
+      "release": "47.el8",
+      "installdate": "1654278244",
+      "arch": "x86_64"
+    },
+    "xz": {
+      "epoch": "0",
+      "version": "5.2.4",
+      "release": "3.el8",
+      "installdate": "1654278201",
+      "arch": "x86_64"
+    },
+    "grub2-pc": {
+      "epoch": "1",
+      "version": "2.02",
+      "release": "123.el8",
+      "installdate": "1654278244",
+      "arch": "x86_64"
+    },
+    "gdbm": {
+      "epoch": "1",
+      "version": "1.18",
+      "release": "1.el8",
+      "installdate": "1654278201",
+      "arch": "x86_64"
+    },
+    "chrony": {
+      "epoch": "0",
+      "version": "4.1",
+      "release": "1.el8",
+      "installdate": "1654278244",
+      "arch": "x86_64"
+    },
+    "libpcap": {
+      "epoch": "14",
+      "version": "1.9.1",
+      "release": "5.el8",
+      "installdate": "1654278201",
+      "arch": "x86_64"
+    },
+    "NetworkManager-tui": {
+      "epoch": "1",
+      "version": "1.39.5",
+      "release": "1.el8",
+      "installdate": "1654278245",
+      "arch": "x86_64"
+    },
+    "nftables": {
+      "epoch": "1",
+      "version": "0.9.3",
+      "release": "26.el8",
+      "installdate": "1654278201",
+      "arch": "x86_64"
+    },
+    "dracut-config-rescue": {
+      "epoch": "0",
+      "version": "049",
+      "release": "202.git20220511.el8",
+      "installdate": "1654278245",
+      "arch": "x86_64"
+    },
+    "ipset-libs": {
+      "epoch": "0",
+      "version": "7.1",
+      "release": "1.el8",
+      "installdate": "1654278202",
+      "arch": "x86_64"
+    },
+    "e2fsprogs": {
+      "epoch": "0",
+      "version": "1.45.6",
+      "release": "5.el8",
+      "installdate": "1654278245",
+      "arch": "x86_64"
+    },
+    "spax": {
+      "epoch": "0",
+      "version": "1.5.3",
+      "release": "13.el8",
+      "installdate": "1654278202",
+      "arch": "x86_64"
+    },
+    "biosdevname": {
+      "epoch": "0",
+      "version": "0.7.3",
+      "release": "2.el8",
+      "installdate": "1654278245",
+      "arch": "x86_64"
+    },
+    "libcomps": {
+      "epoch": "0",
+      "version": "0.1.18",
+      "release": "1.el8",
+      "installdate": "1654278202",
+      "arch": "x86_64"
+    },
+    "iprutils": {
+      "epoch": "0",
+      "version": "2.4.19",
+      "release": "1.el8",
+      "installdate": "1654278246",
+      "arch": "x86_64"
+    },
+    "ncurses-compat-libs": {
+      "epoch": "0",
+      "version": "6.1",
+      "release": "9.20180224.el8",
+      "installdate": "1654278204",
+      "arch": "x86_64"
+    },
+    "rootfiles": {
+      "epoch": "0",
+      "version": "8.1",
+      "release": "22.el8",
+      "installdate": "1654278246",
+      "arch": "noarch"
+    },
+    "coreutils-common": {
+      "epoch": "0",
+      "version": "8.30",
+      "release": "12.el8",
+      "installdate": "1654278204",
+      "arch": "x86_64"
+    },
+    "perl-Data-Dumper": {
+      "epoch": "0",
+      "version": "2.167",
+      "release": "399.el8",
+      "installdate": "1654278567",
+      "arch": "x86_64"
+    },
+    "freetype": {
+      "epoch": "0",
+      "version": "2.9.1",
+      "release": "4.el8_3.1",
+      "installdate": "1654278204",
+      "arch": "x86_64"
+    },
+    "perl-Pod-Escapes": {
+      "epoch": "1",
+      "version": "1.07",
+      "release": "395.el8",
+      "installdate": "1654278568",
+      "arch": "noarch"
+    },
+    "less": {
+      "epoch": "0",
+      "version": "530",
+      "release": "1.el8",
+      "installdate": "1654278204",
+      "arch": "x86_64"
+    },
+    "perl-IO-Socket-SSL": {
+      "epoch": "0",
+      "version": "2.066",
+      "release": "4.module_el8.4.0+517+be1595ff",
+      "installdate": "1654278568",
+      "arch": "noarch"
+    },
+    "hardlink": {
+      "epoch": "1",
+      "version": "1.3",
+      "release": "6.el8",
+      "installdate": "1654278204",
+      "arch": "x86_64"
+    },
+    "perl-Pod-Simple": {
+      "epoch": "1",
+      "version": "3.35",
+      "release": "395.el8",
+      "installdate": "1654278568",
+      "arch": "noarch"
+    },
+    "libnghttp2": {
+      "epoch": "0",
+      "version": "1.33.0",
+      "release": "3.el8_2.1",
+      "installdate": "1654278205",
+      "arch": "x86_64"
+    },
+    "perl-Text-ParseWords": {
+      "epoch": "0",
+      "version": "3.30",
+      "release": "395.el8",
+      "installdate": "1654278568",
+      "arch": "noarch"
+    },
+    "perl-Getopt-Long": {
+      "epoch": "1",
+      "version": "2.50",
+      "release": "4.el8",
+      "installdate": "1654278568",
+      "arch": "noarch"
+    },
+    "libsigsegv": {
+      "epoch": "0",
+      "version": "2.11",
+      "release": "5.el8",
+      "installdate": "1654278205",
+      "arch": "x86_64"
+    },
+    "perl-Carp": {
+      "epoch": "0",
+      "version": "1.42",
+      "release": "396.el8",
+      "installdate": "1654278568",
+      "arch": "noarch"
+    },
+    "libsss_sudo": {
+      "epoch": "0",
+      "version": "2.6.2",
+      "release": "3.el8",
+      "installdate": "1654278205",
+      "arch": "x86_64"
+    },
+    "perl-parent": {
+      "epoch": "1",
+      "version": "0.237",
+      "release": "1.el8",
+      "installdate": "1654278569",
+      "arch": "noarch"
+    },
+    "npth": {
+      "epoch": "0",
+      "version": "1.5",
+      "release": "4.el8",
+      "installdate": "1654278205",
+      "arch": "x86_64"
+    },
+    "perl-File-Path": {
+      "epoch": "0",
+      "version": "2.15",
+      "release": "2.el8",
+      "installdate": "1654278569",
+      "arch": "noarch"
+    },
+    "libestr": {
+      "epoch": "0",
+      "version": "0.1.10",
+      "release": "3.el8",
+      "installdate": "1654278205",
+      "arch": "x86_64"
+    },
+    "perl-threads": {
+      "epoch": "1",
+      "version": "2.21",
+      "release": "2.el8",
+      "installdate": "1654278569",
+      "arch": "x86_64"
+    },
+    "libxkbcommon": {
+      "epoch": "0",
+      "version": "0.9.1",
+      "release": "1.el8",
+      "installdate": "1654278205",
+      "arch": "x86_64"
+    },
+    "perl-Time-HiRes": {
+      "epoch": "4",
+      "version": "1.9758",
+      "release": "2.el8",
+      "installdate": "1654278570",
+      "arch": "x86_64"
+    },
+    "python3-libs": {
+      "epoch": "0",
+      "version": "3.6.8",
+      "release": "46.el8",
+      "installdate": "1654278208",
+      "arch": "x86_64"
+    },
+    "perl-Test-Harness": {
+      "epoch": "1",
+      "version": "3.42",
+      "release": "1.el8",
+      "installdate": "1654278570",
+      "arch": "noarch"
+    },
+    "platform-python": {
+      "epoch": "0",
+      "version": "3.6.8",
+      "release": "46.el8",
+      "installdate": "1654278208",
+      "arch": "x86_64"
+    },
+    "perl-SelfLoader": {
+      "epoch": "0",
+      "version": "1.23",
+      "release": "421.el8",
+      "installdate": "1654278570",
+      "arch": "noarch"
+    },
+    "libarchive": {
+      "epoch": "0",
+      "version": "3.3.3",
+      "release": "3.el8_5",
+      "installdate": "1654278208",
+      "arch": "x86_64"
+    },
+    "perl-Text-Balanced": {
+      "epoch": "0",
+      "version": "2.03",
+      "release": "395.el8",
+      "installdate": "1654278570",
+      "arch": "noarch"
+    },
+    "openssl": {
+      "epoch": "1",
+      "version": "1.1.1k",
+      "release": "6.el8",
+      "installdate": "1654278208",
+      "arch": "x86_64"
+    },
+    "perl-Digest-SHA": {
+      "epoch": "1",
+      "version": "6.02",
+      "release": "1.el8",
+      "installdate": "1654278570",
+      "arch": "x86_64"
+    },
+    "gzip": {
+      "epoch": "0",
+      "version": "1.9",
+      "release": "13.el8",
+      "installdate": "1654278208",
+      "arch": "x86_64"
+    },
+    "perl-Params-Check": {
+      "epoch": "1",
+      "version": "0.38",
+      "release": "395.el8",
+      "installdate": "1654278570",
+      "arch": "noarch"
+    },
+    "krb5-libs": {
+      "epoch": "0",
+      "version": "1.18.2",
+      "release": "20.el8",
+      "installdate": "1654278209",
+      "arch": "x86_64"
+    },
+    "perl-Sub-Install": {
+      "epoch": "0",
+      "version": "0.928",
+      "release": "14.el8",
+      "installdate": "1654278570",
+      "arch": "noarch"
+    },
+    "device-mapper": {
+      "epoch": "8",
+      "version": "1.02.181",
+      "release": "3.el8",
+      "installdate": "1654278209",
+      "arch": "x86_64"
+    },
+    "perl-Math-Complex": {
+      "epoch": "0",
+      "version": "1.59",
+      "release": "421.el8",
+      "installdate": "1654278570",
+      "arch": "noarch"
+    },
+    "rpm": {
+      "epoch": "0",
+      "version": "4.14.3",
+      "release": "23.el8",
+      "installdate": "1654278209",
+      "arch": "x86_64"
+    },
+    "perl-Math-BigRat": {
+      "epoch": "0",
+      "version": "0.2614",
+      "release": "1.el8",
+      "installdate": "1654278570",
+      "arch": "noarch"
+    },
+    "libfdisk": {
+      "epoch": "0",
+      "version": "2.32.1",
+      "release": "35.el8",
+      "installdate": "1654278209",
+      "arch": "x86_64"
+    },
+    "python-rpm-macros": {
+      "epoch": "0",
+      "version": "3",
+      "release": "41.el8",
+      "installdate": "1654278571",
+      "arch": "noarch"
+    },
+    "which": {
+      "epoch": "0",
+      "version": "2.21",
+      "release": "18.el8",
+      "installdate": "1654278210",
+      "arch": "x86_64"
+    },
+    "perl-Data-OptList": {
+      "epoch": "0",
+      "version": "0.110",
+      "release": "6.el8",
+      "installdate": "1654278571",
+      "arch": "noarch"
+    },
+    "libblkid": {
+      "epoch": "0",
+      "version": "2.32.1",
+      "release": "35.el8",
+      "installdate": "1654278210",
+      "arch": "x86_64"
+    },
+    "perl-Devel-SelfStubber": {
+      "epoch": "0",
+      "version": "1.06",
+      "release": "421.el8",
+      "installdate": "1654278571",
+      "arch": "noarch"
+    },
+    "libdb": {
+      "epoch": "0",
+      "version": "5.3.28",
+      "release": "42.el8_4",
+      "installdate": "1654278211",
+      "arch": "x86_64"
+    },
+    "perl-B-Debug": {
+      "epoch": "0",
+      "version": "1.26",
+      "release": "2.el8",
+      "installdate": "1654278572",
+      "arch": "noarch"
+    },
+    "cryptsetup-libs": {
+      "epoch": "0",
+      "version": "2.3.7",
+      "release": "2.el8",
+      "installdate": "1654278211",
+      "arch": "x86_64"
+    },
+    "perl-Devel-PPPort": {
+      "epoch": "0",
+      "version": "3.36",
+      "release": "5.el8",
+      "installdate": "1654278572",
+      "arch": "x86_64"
+    },
+    "kbd": {
+      "epoch": "0",
+      "version": "2.0.4",
+      "release": "10.el8",
+      "installdate": "1654278211",
+      "arch": "x86_64"
+    },
+    "perl-ExtUtils-MM-Utils": {
+      "epoch": "1",
+      "version": "7.34",
+      "release": "1.el8",
+      "installdate": "1654278572",
+      "arch": "noarch"
+    },
+    "systemd-pam": {
+      "epoch": "0",
+      "version": "239",
+      "release": "58.el8",
+      "installdate": "1654278212",
+      "arch": "x86_64"
+    },
+    "perl-IPC-System-Simple": {
+      "epoch": "0",
+      "version": "1.25",
+      "release": "17.el8",
+      "installdate": "1654278572",
+      "arch": "noarch"
     },
     "grub2-tools": {
       "epoch": "1",
       "version": "2.02",
-      "release": "106.el8",
-      "installdate": "1640302535",
+      "release": "123.el8",
+      "installdate": "1654278213",
       "arch": "x86_64"
     }
   },
@@ -5863,7 +5768,7 @@
   "platform_family": "rhel",
   "platform_version": "8",
   "root_group": "root",
-  "shard_seed": 246944626,
+  "shard_seed": 118903342,
   "shells": [
     "/bin/sh",
     "/bin/bash",

--- a/lib/fauxhai/platforms/centos-stream/8.json
+++ b/lib/fauxhai/platforms/centos-stream/8.json
@@ -1,0 +1,5882 @@
+{
+  "block_device": {
+    "sda": {
+      "size": "134217728",
+      "removable": "0",
+      "model": "VBOX HARDDISK",
+      "rev": "1.0",
+      "state": "running",
+      "timeout": "30",
+      "vendor": "ATA",
+      "queue_depth": "32",
+      "rotational": "1",
+      "physical_block_size": "512",
+      "logical_block_size": "512"
+    }
+  },
+  "chef_packages": {
+    "chef": {
+      "version": "17.9.26",
+      "chef_root": "/opt/chef/embedded/lib/ruby/gems/3.0.0/gems/chef-17.9.26/lib",
+      "chef_effortless": null
+    },
+    "ohai": {
+      "version": "17.9.1",
+      "ohai_root": "/opt/chef/embedded/lib/ruby/gems/3.0.0/gems/ohai-17.9.1/lib/ohai"
+    }
+  },
+  "command": {
+    "ps": "ps -ef"
+  },
+  "counters": {
+    "network": {
+      "interfaces": {
+        "lo": {
+          "tx": {
+            "queuelen": "1",
+            "bytes": 0,
+            "packets": 0,
+            "errors": 0,
+            "drop": 0,
+            "carrier": 0,
+            "collisions": 0
+          },
+          "rx": {
+            "bytes": 0,
+            "packets": 0,
+            "errors": 0,
+            "drop": 0,
+            "overrun": 0
+          }
+        },
+        "eth0": {
+          "rx": {
+            "bytes": 0,
+            "packets": 0,
+            "errors": 0,
+            "drop": 0,
+            "overrun": 0,
+            "frame": 0,
+            "compressed": 0,
+            "multicast": 0
+          },
+          "tx": {
+            "bytes": 0,
+            "packets": 0,
+            "errors": 0,
+            "drop": 0,
+            "overrun": 0,
+            "collisions": 0,
+            "carrier": 0,
+            "compressed": 0
+          }
+        }
+      }
+    }
+  },
+  "cpu": {
+    "real": 1,
+    "total": 1,
+    "cores": 1
+  },
+  "current_user": "fauxhai",
+  "dmi": {
+    "dmidecode_version": "3.3",
+    "smbios_version": "2.5",
+    "structures": {
+      "count": "10",
+      "size": "450"
+    },
+    "table_location": "0x000E1000",
+    "bios": {
+      "all_records": [
+        {
+          "record_id": "0x0000",
+          "size": "0",
+          "application_identifier": "BIOS Information",
+          "Vendor": "innotek GmbH",
+          "Version": "VirtualBox",
+          "Release Date": "12/01/2006",
+          "Address": "0xE0000",
+          "Runtime Size": "128 kB",
+          "ROM Size": "128 kB",
+          "Characteristics": {
+            "ACPI is supported": null
+          }
+        }
+      ],
+      "vendor": "innotek GmbH",
+      "version": "VirtualBox",
+      "release_date": "12/01/2006",
+      "address": "0xE0000",
+      "runtime_size": "128 kB",
+      "rom_size": "128 kB"
+    },
+    "system": {
+      "all_records": [
+        {
+          "record_id": "0x0001",
+          "size": "1",
+          "application_identifier": "System Information",
+          "Manufacturer": "innotek GmbH",
+          "Product Name": "VirtualBox",
+          "Version": "1.2",
+          "Serial Number": "0",
+          "UUID": "da8a21f1-856a-2e46-95f6-78c789ce0179",
+          "Wake-up Type": "Power Switch",
+          "SKU Number": "Not Specified",
+          "Family": "Virtual Machine"
+        }
+      ],
+      "manufacturer": "innotek GmbH",
+      "product_name": "VirtualBox",
+      "version": "1.2",
+      "serial_number": "0",
+      "uuid": "da8a21f1-856a-2e46-95f6-78c789ce0179",
+      "wake_up_type": "Power Switch",
+      "sku_number": "Not Specified",
+      "family": "Virtual Machine"
+    },
+    "base_board": {
+      "all_records": [
+        {
+          "record_id": "0x0008",
+          "size": "2",
+          "application_identifier": "Base Board Information",
+          "Manufacturer": "Oracle Corporation",
+          "Product Name": "VirtualBox",
+          "Version": "1.2",
+          "Serial Number": "0",
+          "Asset Tag": "Not Specified",
+          "Features": {
+            "Board is a hosting board": null
+          },
+          "Location In Chassis": "Not Specified",
+          "Chassis Handle": "0x0003",
+          "Type": "Motherboard",
+          "Contained Object Handles": "0"
+        }
+      ],
+      "manufacturer": "Oracle Corporation",
+      "product_name": "VirtualBox",
+      "version": "1.2",
+      "serial_number": "0",
+      "asset_tag": "Not Specified",
+      "location_in_chassis": "Not Specified",
+      "chassis_handle": "0x0003",
+      "type": "Motherboard",
+      "contained_object_handles": "0"
+    },
+    "chassis": {
+      "all_records": [
+        {
+          "record_id": "0x0003",
+          "size": "3",
+          "application_identifier": "Chassis Information",
+          "Manufacturer": "Oracle Corporation",
+          "Type": "Other",
+          "Lock": "Not Present",
+          "Version": "Not Specified",
+          "Serial Number": "Not Specified",
+          "Asset Tag": "Not Specified",
+          "Boot-up State": "Safe",
+          "Power Supply State": "Safe",
+          "Thermal State": "Safe",
+          "Security Status": "None"
+        }
+      ],
+      "manufacturer": "Oracle Corporation",
+      "type": "Other",
+      "lock": "Not Present",
+      "version": "Not Specified",
+      "serial_number": "Not Specified",
+      "asset_tag": "Not Specified",
+      "boot_up_state": "Safe",
+      "power_supply_state": "Safe",
+      "thermal_state": "Safe",
+      "security_status": "None"
+    },
+    "oem_strings": {
+      "all_records": [
+        {
+          "record_id": "0x0002",
+          "size": "11",
+          "application_identifier": "OEM Strings",
+          "String 1": "vboxVer_6.1.32",
+          "String 2": "vboxRev_149290"
+        }
+      ],
+      "string_1": "vboxVer_6.1.32",
+      "string_2": "vboxRev_149290"
+    }
+  },
+  "domain": "local",
+  "filesystem": {
+    "by_device": {
+      "devtmpfs": {
+        "kb_size": "913212",
+        "kb_used": "0",
+        "kb_available": "913212",
+        "percent_used": "0%",
+        "total_inodes": "228303",
+        "inodes_used": "326",
+        "inodes_available": "227977",
+        "inodes_percent_used": "1%",
+        "fs_type": "devtmpfs",
+        "mount_options": [
+          "rw",
+          "nosuid",
+          "seclabel",
+          "size=913212k",
+          "nr_inodes=228303",
+          "mode=755"
+        ],
+        "mounts": [
+          "/dev"
+        ]
+      },
+      "tmpfs": {
+        "kb_size": "186056",
+        "kb_used": "0",
+        "kb_available": "186056",
+        "percent_used": "0%",
+        "total_inodes": "232570",
+        "inodes_used": "5",
+        "inodes_available": "232565",
+        "inodes_percent_used": "1%",
+        "fs_type": "tmpfs",
+        "mount_options": [
+          "rw",
+          "nosuid",
+          "nodev",
+          "relatime",
+          "seclabel",
+          "size=186056k",
+          "mode=700"
+        ],
+        "mounts": [
+          "/dev/shm",
+          "/run",
+          "/sys/fs/cgroup",
+          "/run/user/1000",
+          "/run/user/0"
+        ]
+      },
+      "/dev/sda2": {
+        "kb_size": "64829516",
+        "kb_used": "2689348",
+        "kb_available": "62140168",
+        "percent_used": "5%",
+        "total_inodes": "32430592",
+        "inodes_used": "47361",
+        "inodes_available": "32383231",
+        "inodes_percent_used": "1%",
+        "fs_type": "xfs",
+        "mount_options": [
+          "rw",
+          "relatime",
+          "seclabel",
+          "attr2",
+          "inode64",
+          "logbufs=8",
+          "logbsize=32k",
+          "noquota"
+        ],
+        "uuid": "63ee0043-c7c5-4fcd-a3e1-b87d4b320bc4",
+        "mounts": [
+          "/"
+        ]
+      },
+      "vagrant": {
+        "kb_size": "495333060",
+        "kb_used": "456844832",
+        "kb_available": "38488228",
+        "percent_used": "93%",
+        "fs_type": "vboxsf",
+        "mount_options": [
+          "rw",
+          "nodev",
+          "relatime",
+          "iocharset=utf8",
+          "uid=1000",
+          "gid=1000",
+          "_netdev"
+        ],
+        "mounts": [
+          "/vagrant"
+        ]
+      },
+      "sysfs": {
+        "fs_type": "sysfs",
+        "mount_options": [
+          "rw",
+          "nosuid",
+          "nodev",
+          "noexec",
+          "relatime",
+          "seclabel"
+        ],
+        "mounts": [
+          "/sys"
+        ]
+      },
+      "proc": {
+        "fs_type": "proc",
+        "mount_options": [
+          "rw",
+          "nosuid",
+          "nodev",
+          "noexec",
+          "relatime"
+        ],
+        "mounts": [
+          "/proc"
+        ]
+      },
+      "securityfs": {
+        "fs_type": "securityfs",
+        "mount_options": [
+          "rw",
+          "nosuid",
+          "nodev",
+          "noexec",
+          "relatime"
+        ],
+        "mounts": [
+          "/sys/kernel/security"
+        ]
+      },
+      "devpts": {
+        "fs_type": "devpts",
+        "mount_options": [
+          "rw",
+          "nosuid",
+          "noexec",
+          "relatime",
+          "seclabel",
+          "gid=5",
+          "mode=620",
+          "ptmxmode=000"
+        ],
+        "mounts": [
+          "/dev/pts"
+        ]
+      },
+      "cgroup": {
+        "fs_type": "cgroup",
+        "mount_options": [
+          "rw",
+          "nosuid",
+          "nodev",
+          "noexec",
+          "relatime",
+          "seclabel",
+          "devices"
+        ],
+        "mounts": [
+          "/sys/fs/cgroup/systemd",
+          "/sys/fs/cgroup/blkio",
+          "/sys/fs/cgroup/memory",
+          "/sys/fs/cgroup/pids",
+          "/sys/fs/cgroup/cpu,cpuacct",
+          "/sys/fs/cgroup/net_cls,net_prio",
+          "/sys/fs/cgroup/perf_event",
+          "/sys/fs/cgroup/cpuset",
+          "/sys/fs/cgroup/rdma",
+          "/sys/fs/cgroup/freezer",
+          "/sys/fs/cgroup/hugetlb",
+          "/sys/fs/cgroup/devices"
+        ]
+      },
+      "pstore": {
+        "fs_type": "pstore",
+        "mount_options": [
+          "rw",
+          "nosuid",
+          "nodev",
+          "noexec",
+          "relatime",
+          "seclabel"
+        ],
+        "mounts": [
+          "/sys/fs/pstore"
+        ]
+      },
+      "bpf": {
+        "fs_type": "bpf",
+        "mount_options": [
+          "rw",
+          "nosuid",
+          "nodev",
+          "noexec",
+          "relatime",
+          "mode=700"
+        ],
+        "mounts": [
+          "/sys/fs/bpf"
+        ]
+      },
+      "none": {
+        "fs_type": "tracefs",
+        "mount_options": [
+          "rw",
+          "relatime",
+          "seclabel"
+        ],
+        "mounts": [
+          "/sys/kernel/tracing"
+        ]
+      },
+      "configfs": {
+        "fs_type": "configfs",
+        "mount_options": [
+          "rw",
+          "relatime"
+        ],
+        "mounts": [
+          "/sys/kernel/config"
+        ]
+      },
+      "selinuxfs": {
+        "fs_type": "selinuxfs",
+        "mount_options": [
+          "rw",
+          "relatime"
+        ],
+        "mounts": [
+          "/sys/fs/selinux"
+        ]
+      },
+      "systemd-1": {
+        "fs_type": "autofs",
+        "mount_options": [
+          "rw",
+          "relatime",
+          "fd=35",
+          "pgrp=1",
+          "timeout=0",
+          "minproto=5",
+          "maxproto=5",
+          "direct",
+          "pipe_ino=18053"
+        ],
+        "mounts": [
+          "/proc/sys/fs/binfmt_misc"
+        ]
+      },
+      "mqueue": {
+        "fs_type": "mqueue",
+        "mount_options": [
+          "rw",
+          "relatime",
+          "seclabel"
+        ],
+        "mounts": [
+          "/dev/mqueue"
+        ]
+      },
+      "hugetlbfs": {
+        "fs_type": "hugetlbfs",
+        "mount_options": [
+          "rw",
+          "relatime",
+          "seclabel",
+          "pagesize=2M"
+        ],
+        "mounts": [
+          "/dev/hugepages"
+        ]
+      },
+      "debugfs": {
+        "fs_type": "debugfs",
+        "mount_options": [
+          "rw",
+          "relatime",
+          "seclabel"
+        ],
+        "mounts": [
+          "/sys/kernel/debug"
+        ]
+      },
+      "sunrpc": {
+        "fs_type": "rpc_pipefs",
+        "mount_options": [
+          "rw",
+          "relatime"
+        ],
+        "mounts": [
+          "/var/lib/nfs/rpc_pipefs"
+        ]
+      },
+      "/dev/sda": {
+        "mounts": [
+
+        ]
+      },
+      "/dev/sda1": {
+        "fs_type": "swap",
+        "uuid": "0d01112d-3db9-4c8b-9b6b-9db9416fb74d",
+        "mounts": [
+
+        ]
+      }
+    },
+    "by_mountpoint": {
+      "/dev": {
+        "kb_size": "913212",
+        "kb_used": "0",
+        "kb_available": "913212",
+        "percent_used": "0%",
+        "total_inodes": "228303",
+        "inodes_used": "326",
+        "inodes_available": "227977",
+        "inodes_percent_used": "1%",
+        "fs_type": "devtmpfs",
+        "mount_options": [
+          "rw",
+          "nosuid",
+          "seclabel",
+          "size=913212k",
+          "nr_inodes=228303",
+          "mode=755"
+        ],
+        "devices": [
+          "devtmpfs"
+        ]
+      },
+      "/dev/shm": {
+        "kb_size": "930280",
+        "kb_used": "0",
+        "kb_available": "930280",
+        "percent_used": "0%",
+        "total_inodes": "232570",
+        "inodes_used": "1",
+        "inodes_available": "232569",
+        "inodes_percent_used": "1%",
+        "fs_type": "tmpfs",
+        "mount_options": [
+          "rw",
+          "nosuid",
+          "nodev",
+          "seclabel"
+        ],
+        "devices": [
+          "tmpfs"
+        ]
+      },
+      "/run": {
+        "kb_size": "930280",
+        "kb_used": "16804",
+        "kb_available": "913476",
+        "percent_used": "2%",
+        "total_inodes": "232570",
+        "inodes_used": "461",
+        "inodes_available": "232109",
+        "inodes_percent_used": "1%",
+        "fs_type": "tmpfs",
+        "mount_options": [
+          "rw",
+          "nosuid",
+          "nodev",
+          "seclabel",
+          "mode=755"
+        ],
+        "devices": [
+          "tmpfs"
+        ]
+      },
+      "/sys/fs/cgroup": {
+        "kb_size": "930280",
+        "kb_used": "0",
+        "kb_available": "930280",
+        "percent_used": "0%",
+        "total_inodes": "232570",
+        "inodes_used": "17",
+        "inodes_available": "232553",
+        "inodes_percent_used": "1%",
+        "fs_type": "tmpfs",
+        "mount_options": [
+          "ro",
+          "nosuid",
+          "nodev",
+          "noexec",
+          "seclabel",
+          "mode=755"
+        ],
+        "devices": [
+          "tmpfs"
+        ]
+      },
+      "/": {
+        "kb_size": "64829516",
+        "kb_used": "2689348",
+        "kb_available": "62140168",
+        "percent_used": "5%",
+        "total_inodes": "32430592",
+        "inodes_used": "47361",
+        "inodes_available": "32383231",
+        "inodes_percent_used": "1%",
+        "fs_type": "xfs",
+        "mount_options": [
+          "rw",
+          "relatime",
+          "seclabel",
+          "attr2",
+          "inode64",
+          "logbufs=8",
+          "logbsize=32k",
+          "noquota"
+        ],
+        "uuid": "63ee0043-c7c5-4fcd-a3e1-b87d4b320bc4",
+        "devices": [
+          "/dev/sda2"
+        ]
+      },
+      "/vagrant": {
+        "kb_size": "495333060",
+        "kb_used": "456844832",
+        "kb_available": "38488228",
+        "percent_used": "93%",
+        "fs_type": "vboxsf",
+        "mount_options": [
+          "rw",
+          "nodev",
+          "relatime",
+          "iocharset=utf8",
+          "uid=1000",
+          "gid=1000",
+          "_netdev"
+        ],
+        "devices": [
+          "vagrant"
+        ]
+      },
+      "/run/user/1000": {
+        "kb_size": "186056",
+        "kb_used": "0",
+        "kb_available": "186056",
+        "percent_used": "0%",
+        "total_inodes": "232570",
+        "inodes_used": "5",
+        "inodes_available": "232565",
+        "inodes_percent_used": "1%",
+        "fs_type": "tmpfs",
+        "mount_options": [
+          "rw",
+          "nosuid",
+          "nodev",
+          "relatime",
+          "seclabel",
+          "size=186056k",
+          "mode=700",
+          "uid=1000",
+          "gid=1000"
+        ],
+        "devices": [
+          "tmpfs"
+        ]
+      },
+      "/run/user/0": {
+        "kb_size": "186056",
+        "kb_used": "0",
+        "kb_available": "186056",
+        "percent_used": "0%",
+        "total_inodes": "232570",
+        "inodes_used": "5",
+        "inodes_available": "232565",
+        "inodes_percent_used": "1%",
+        "fs_type": "tmpfs",
+        "mount_options": [
+          "rw",
+          "nosuid",
+          "nodev",
+          "relatime",
+          "seclabel",
+          "size=186056k",
+          "mode=700"
+        ],
+        "devices": [
+          "tmpfs"
+        ]
+      },
+      "/sys": {
+        "fs_type": "sysfs",
+        "mount_options": [
+          "rw",
+          "nosuid",
+          "nodev",
+          "noexec",
+          "relatime",
+          "seclabel"
+        ],
+        "devices": [
+          "sysfs"
+        ]
+      },
+      "/proc": {
+        "fs_type": "proc",
+        "mount_options": [
+          "rw",
+          "nosuid",
+          "nodev",
+          "noexec",
+          "relatime"
+        ],
+        "devices": [
+          "proc"
+        ]
+      },
+      "/sys/kernel/security": {
+        "fs_type": "securityfs",
+        "mount_options": [
+          "rw",
+          "nosuid",
+          "nodev",
+          "noexec",
+          "relatime"
+        ],
+        "devices": [
+          "securityfs"
+        ]
+      },
+      "/dev/pts": {
+        "fs_type": "devpts",
+        "mount_options": [
+          "rw",
+          "nosuid",
+          "noexec",
+          "relatime",
+          "seclabel",
+          "gid=5",
+          "mode=620",
+          "ptmxmode=000"
+        ],
+        "devices": [
+          "devpts"
+        ]
+      },
+      "/sys/fs/cgroup/systemd": {
+        "fs_type": "cgroup",
+        "mount_options": [
+          "rw",
+          "nosuid",
+          "nodev",
+          "noexec",
+          "relatime",
+          "seclabel",
+          "xattr",
+          "release_agent=/usr/lib/systemd/systemd-cgroups-agent",
+          "name=systemd"
+        ],
+        "devices": [
+          "cgroup"
+        ]
+      },
+      "/sys/fs/pstore": {
+        "fs_type": "pstore",
+        "mount_options": [
+          "rw",
+          "nosuid",
+          "nodev",
+          "noexec",
+          "relatime",
+          "seclabel"
+        ],
+        "devices": [
+          "pstore"
+        ]
+      },
+      "/sys/fs/bpf": {
+        "fs_type": "bpf",
+        "mount_options": [
+          "rw",
+          "nosuid",
+          "nodev",
+          "noexec",
+          "relatime",
+          "mode=700"
+        ],
+        "devices": [
+          "bpf"
+        ]
+      },
+      "/sys/fs/cgroup/blkio": {
+        "fs_type": "cgroup",
+        "mount_options": [
+          "rw",
+          "nosuid",
+          "nodev",
+          "noexec",
+          "relatime",
+          "seclabel",
+          "blkio"
+        ],
+        "devices": [
+          "cgroup"
+        ]
+      },
+      "/sys/fs/cgroup/memory": {
+        "fs_type": "cgroup",
+        "mount_options": [
+          "rw",
+          "nosuid",
+          "nodev",
+          "noexec",
+          "relatime",
+          "seclabel",
+          "memory"
+        ],
+        "devices": [
+          "cgroup"
+        ]
+      },
+      "/sys/fs/cgroup/pids": {
+        "fs_type": "cgroup",
+        "mount_options": [
+          "rw",
+          "nosuid",
+          "nodev",
+          "noexec",
+          "relatime",
+          "seclabel",
+          "pids"
+        ],
+        "devices": [
+          "cgroup"
+        ]
+      },
+      "/sys/fs/cgroup/cpu,cpuacct": {
+        "fs_type": "cgroup",
+        "mount_options": [
+          "rw",
+          "nosuid",
+          "nodev",
+          "noexec",
+          "relatime",
+          "seclabel",
+          "cpu",
+          "cpuacct"
+        ],
+        "devices": [
+          "cgroup"
+        ]
+      },
+      "/sys/fs/cgroup/net_cls,net_prio": {
+        "fs_type": "cgroup",
+        "mount_options": [
+          "rw",
+          "nosuid",
+          "nodev",
+          "noexec",
+          "relatime",
+          "seclabel",
+          "net_cls",
+          "net_prio"
+        ],
+        "devices": [
+          "cgroup"
+        ]
+      },
+      "/sys/fs/cgroup/perf_event": {
+        "fs_type": "cgroup",
+        "mount_options": [
+          "rw",
+          "nosuid",
+          "nodev",
+          "noexec",
+          "relatime",
+          "seclabel",
+          "perf_event"
+        ],
+        "devices": [
+          "cgroup"
+        ]
+      },
+      "/sys/fs/cgroup/cpuset": {
+        "fs_type": "cgroup",
+        "mount_options": [
+          "rw",
+          "nosuid",
+          "nodev",
+          "noexec",
+          "relatime",
+          "seclabel",
+          "cpuset"
+        ],
+        "devices": [
+          "cgroup"
+        ]
+      },
+      "/sys/fs/cgroup/rdma": {
+        "fs_type": "cgroup",
+        "mount_options": [
+          "rw",
+          "nosuid",
+          "nodev",
+          "noexec",
+          "relatime",
+          "seclabel",
+          "rdma"
+        ],
+        "devices": [
+          "cgroup"
+        ]
+      },
+      "/sys/fs/cgroup/freezer": {
+        "fs_type": "cgroup",
+        "mount_options": [
+          "rw",
+          "nosuid",
+          "nodev",
+          "noexec",
+          "relatime",
+          "seclabel",
+          "freezer"
+        ],
+        "devices": [
+          "cgroup"
+        ]
+      },
+      "/sys/fs/cgroup/hugetlb": {
+        "fs_type": "cgroup",
+        "mount_options": [
+          "rw",
+          "nosuid",
+          "nodev",
+          "noexec",
+          "relatime",
+          "seclabel",
+          "hugetlb"
+        ],
+        "devices": [
+          "cgroup"
+        ]
+      },
+      "/sys/fs/cgroup/devices": {
+        "fs_type": "cgroup",
+        "mount_options": [
+          "rw",
+          "nosuid",
+          "nodev",
+          "noexec",
+          "relatime",
+          "seclabel",
+          "devices"
+        ],
+        "devices": [
+          "cgroup"
+        ]
+      },
+      "/sys/kernel/tracing": {
+        "fs_type": "tracefs",
+        "mount_options": [
+          "rw",
+          "relatime",
+          "seclabel"
+        ],
+        "devices": [
+          "none"
+        ]
+      },
+      "/sys/kernel/config": {
+        "fs_type": "configfs",
+        "mount_options": [
+          "rw",
+          "relatime"
+        ],
+        "devices": [
+          "configfs"
+        ]
+      },
+      "/sys/fs/selinux": {
+        "fs_type": "selinuxfs",
+        "mount_options": [
+          "rw",
+          "relatime"
+        ],
+        "devices": [
+          "selinuxfs"
+        ]
+      },
+      "/proc/sys/fs/binfmt_misc": {
+        "fs_type": "autofs",
+        "mount_options": [
+          "rw",
+          "relatime",
+          "fd=35",
+          "pgrp=1",
+          "timeout=0",
+          "minproto=5",
+          "maxproto=5",
+          "direct",
+          "pipe_ino=18053"
+        ],
+        "devices": [
+          "systemd-1"
+        ]
+      },
+      "/dev/mqueue": {
+        "fs_type": "mqueue",
+        "mount_options": [
+          "rw",
+          "relatime",
+          "seclabel"
+        ],
+        "devices": [
+          "mqueue"
+        ]
+      },
+      "/dev/hugepages": {
+        "fs_type": "hugetlbfs",
+        "mount_options": [
+          "rw",
+          "relatime",
+          "seclabel",
+          "pagesize=2M"
+        ],
+        "devices": [
+          "hugetlbfs"
+        ]
+      },
+      "/sys/kernel/debug": {
+        "fs_type": "debugfs",
+        "mount_options": [
+          "rw",
+          "relatime",
+          "seclabel"
+        ],
+        "devices": [
+          "debugfs"
+        ]
+      },
+      "/var/lib/nfs/rpc_pipefs": {
+        "fs_type": "rpc_pipefs",
+        "mount_options": [
+          "rw",
+          "relatime"
+        ],
+        "devices": [
+          "sunrpc"
+        ]
+      }
+    },
+    "by_pair": {
+      "devtmpfs,/dev": {
+        "device": "devtmpfs",
+        "kb_size": "913212",
+        "kb_used": "0",
+        "kb_available": "913212",
+        "percent_used": "0%",
+        "mount": "/dev",
+        "total_inodes": "228303",
+        "inodes_used": "326",
+        "inodes_available": "227977",
+        "inodes_percent_used": "1%",
+        "fs_type": "devtmpfs",
+        "mount_options": [
+          "rw",
+          "nosuid",
+          "seclabel",
+          "size=913212k",
+          "nr_inodes=228303",
+          "mode=755"
+        ]
+      },
+      "tmpfs,/dev/shm": {
+        "device": "tmpfs",
+        "kb_size": "930280",
+        "kb_used": "0",
+        "kb_available": "930280",
+        "percent_used": "0%",
+        "mount": "/dev/shm",
+        "total_inodes": "232570",
+        "inodes_used": "1",
+        "inodes_available": "232569",
+        "inodes_percent_used": "1%",
+        "fs_type": "tmpfs",
+        "mount_options": [
+          "rw",
+          "nosuid",
+          "nodev",
+          "seclabel"
+        ]
+      },
+      "tmpfs,/run": {
+        "device": "tmpfs",
+        "kb_size": "930280",
+        "kb_used": "16804",
+        "kb_available": "913476",
+        "percent_used": "2%",
+        "mount": "/run",
+        "total_inodes": "232570",
+        "inodes_used": "461",
+        "inodes_available": "232109",
+        "inodes_percent_used": "1%",
+        "fs_type": "tmpfs",
+        "mount_options": [
+          "rw",
+          "nosuid",
+          "nodev",
+          "seclabel",
+          "mode=755"
+        ]
+      },
+      "tmpfs,/sys/fs/cgroup": {
+        "device": "tmpfs",
+        "kb_size": "930280",
+        "kb_used": "0",
+        "kb_available": "930280",
+        "percent_used": "0%",
+        "mount": "/sys/fs/cgroup",
+        "total_inodes": "232570",
+        "inodes_used": "17",
+        "inodes_available": "232553",
+        "inodes_percent_used": "1%",
+        "fs_type": "tmpfs",
+        "mount_options": [
+          "ro",
+          "nosuid",
+          "nodev",
+          "noexec",
+          "seclabel",
+          "mode=755"
+        ]
+      },
+      "/dev/sda2,/": {
+        "device": "/dev/sda2",
+        "kb_size": "64829516",
+        "kb_used": "2689348",
+        "kb_available": "62140168",
+        "percent_used": "5%",
+        "mount": "/",
+        "total_inodes": "32430592",
+        "inodes_used": "47361",
+        "inodes_available": "32383231",
+        "inodes_percent_used": "1%",
+        "fs_type": "xfs",
+        "mount_options": [
+          "rw",
+          "relatime",
+          "seclabel",
+          "attr2",
+          "inode64",
+          "logbufs=8",
+          "logbsize=32k",
+          "noquota"
+        ],
+        "uuid": "63ee0043-c7c5-4fcd-a3e1-b87d4b320bc4"
+      },
+      "vagrant,/vagrant": {
+        "device": "vagrant",
+        "kb_size": "495333060",
+        "kb_used": "456844832",
+        "kb_available": "38488228",
+        "percent_used": "93%",
+        "mount": "/vagrant",
+        "fs_type": "vboxsf",
+        "mount_options": [
+          "rw",
+          "nodev",
+          "relatime",
+          "iocharset=utf8",
+          "uid=1000",
+          "gid=1000",
+          "_netdev"
+        ]
+      },
+      "tmpfs,/run/user/1000": {
+        "device": "tmpfs",
+        "kb_size": "186056",
+        "kb_used": "0",
+        "kb_available": "186056",
+        "percent_used": "0%",
+        "mount": "/run/user/1000",
+        "total_inodes": "232570",
+        "inodes_used": "5",
+        "inodes_available": "232565",
+        "inodes_percent_used": "1%",
+        "fs_type": "tmpfs",
+        "mount_options": [
+          "rw",
+          "nosuid",
+          "nodev",
+          "relatime",
+          "seclabel",
+          "size=186056k",
+          "mode=700",
+          "uid=1000",
+          "gid=1000"
+        ]
+      },
+      "tmpfs,/run/user/0": {
+        "device": "tmpfs",
+        "kb_size": "186056",
+        "kb_used": "0",
+        "kb_available": "186056",
+        "percent_used": "0%",
+        "mount": "/run/user/0",
+        "total_inodes": "232570",
+        "inodes_used": "5",
+        "inodes_available": "232565",
+        "inodes_percent_used": "1%",
+        "fs_type": "tmpfs",
+        "mount_options": [
+          "rw",
+          "nosuid",
+          "nodev",
+          "relatime",
+          "seclabel",
+          "size=186056k",
+          "mode=700"
+        ]
+      },
+      "sysfs,/sys": {
+        "device": "sysfs",
+        "mount": "/sys",
+        "fs_type": "sysfs",
+        "mount_options": [
+          "rw",
+          "nosuid",
+          "nodev",
+          "noexec",
+          "relatime",
+          "seclabel"
+        ]
+      },
+      "proc,/proc": {
+        "device": "proc",
+        "mount": "/proc",
+        "fs_type": "proc",
+        "mount_options": [
+          "rw",
+          "nosuid",
+          "nodev",
+          "noexec",
+          "relatime"
+        ]
+      },
+      "securityfs,/sys/kernel/security": {
+        "device": "securityfs",
+        "mount": "/sys/kernel/security",
+        "fs_type": "securityfs",
+        "mount_options": [
+          "rw",
+          "nosuid",
+          "nodev",
+          "noexec",
+          "relatime"
+        ]
+      },
+      "devpts,/dev/pts": {
+        "device": "devpts",
+        "mount": "/dev/pts",
+        "fs_type": "devpts",
+        "mount_options": [
+          "rw",
+          "nosuid",
+          "noexec",
+          "relatime",
+          "seclabel",
+          "gid=5",
+          "mode=620",
+          "ptmxmode=000"
+        ]
+      },
+      "cgroup,/sys/fs/cgroup/systemd": {
+        "device": "cgroup",
+        "mount": "/sys/fs/cgroup/systemd",
+        "fs_type": "cgroup",
+        "mount_options": [
+          "rw",
+          "nosuid",
+          "nodev",
+          "noexec",
+          "relatime",
+          "seclabel",
+          "xattr",
+          "release_agent=/usr/lib/systemd/systemd-cgroups-agent",
+          "name=systemd"
+        ]
+      },
+      "pstore,/sys/fs/pstore": {
+        "device": "pstore",
+        "mount": "/sys/fs/pstore",
+        "fs_type": "pstore",
+        "mount_options": [
+          "rw",
+          "nosuid",
+          "nodev",
+          "noexec",
+          "relatime",
+          "seclabel"
+        ]
+      },
+      "bpf,/sys/fs/bpf": {
+        "device": "bpf",
+        "mount": "/sys/fs/bpf",
+        "fs_type": "bpf",
+        "mount_options": [
+          "rw",
+          "nosuid",
+          "nodev",
+          "noexec",
+          "relatime",
+          "mode=700"
+        ]
+      },
+      "cgroup,/sys/fs/cgroup/blkio": {
+        "device": "cgroup",
+        "mount": "/sys/fs/cgroup/blkio",
+        "fs_type": "cgroup",
+        "mount_options": [
+          "rw",
+          "nosuid",
+          "nodev",
+          "noexec",
+          "relatime",
+          "seclabel",
+          "blkio"
+        ]
+      },
+      "cgroup,/sys/fs/cgroup/memory": {
+        "device": "cgroup",
+        "mount": "/sys/fs/cgroup/memory",
+        "fs_type": "cgroup",
+        "mount_options": [
+          "rw",
+          "nosuid",
+          "nodev",
+          "noexec",
+          "relatime",
+          "seclabel",
+          "memory"
+        ]
+      },
+      "cgroup,/sys/fs/cgroup/pids": {
+        "device": "cgroup",
+        "mount": "/sys/fs/cgroup/pids",
+        "fs_type": "cgroup",
+        "mount_options": [
+          "rw",
+          "nosuid",
+          "nodev",
+          "noexec",
+          "relatime",
+          "seclabel",
+          "pids"
+        ]
+      },
+      "cgroup,/sys/fs/cgroup/cpu,cpuacct": {
+        "device": "cgroup",
+        "mount": "/sys/fs/cgroup/cpu,cpuacct",
+        "fs_type": "cgroup",
+        "mount_options": [
+          "rw",
+          "nosuid",
+          "nodev",
+          "noexec",
+          "relatime",
+          "seclabel",
+          "cpu",
+          "cpuacct"
+        ]
+      },
+      "cgroup,/sys/fs/cgroup/net_cls,net_prio": {
+        "device": "cgroup",
+        "mount": "/sys/fs/cgroup/net_cls,net_prio",
+        "fs_type": "cgroup",
+        "mount_options": [
+          "rw",
+          "nosuid",
+          "nodev",
+          "noexec",
+          "relatime",
+          "seclabel",
+          "net_cls",
+          "net_prio"
+        ]
+      },
+      "cgroup,/sys/fs/cgroup/perf_event": {
+        "device": "cgroup",
+        "mount": "/sys/fs/cgroup/perf_event",
+        "fs_type": "cgroup",
+        "mount_options": [
+          "rw",
+          "nosuid",
+          "nodev",
+          "noexec",
+          "relatime",
+          "seclabel",
+          "perf_event"
+        ]
+      },
+      "cgroup,/sys/fs/cgroup/cpuset": {
+        "device": "cgroup",
+        "mount": "/sys/fs/cgroup/cpuset",
+        "fs_type": "cgroup",
+        "mount_options": [
+          "rw",
+          "nosuid",
+          "nodev",
+          "noexec",
+          "relatime",
+          "seclabel",
+          "cpuset"
+        ]
+      },
+      "cgroup,/sys/fs/cgroup/rdma": {
+        "device": "cgroup",
+        "mount": "/sys/fs/cgroup/rdma",
+        "fs_type": "cgroup",
+        "mount_options": [
+          "rw",
+          "nosuid",
+          "nodev",
+          "noexec",
+          "relatime",
+          "seclabel",
+          "rdma"
+        ]
+      },
+      "cgroup,/sys/fs/cgroup/freezer": {
+        "device": "cgroup",
+        "mount": "/sys/fs/cgroup/freezer",
+        "fs_type": "cgroup",
+        "mount_options": [
+          "rw",
+          "nosuid",
+          "nodev",
+          "noexec",
+          "relatime",
+          "seclabel",
+          "freezer"
+        ]
+      },
+      "cgroup,/sys/fs/cgroup/hugetlb": {
+        "device": "cgroup",
+        "mount": "/sys/fs/cgroup/hugetlb",
+        "fs_type": "cgroup",
+        "mount_options": [
+          "rw",
+          "nosuid",
+          "nodev",
+          "noexec",
+          "relatime",
+          "seclabel",
+          "hugetlb"
+        ]
+      },
+      "cgroup,/sys/fs/cgroup/devices": {
+        "device": "cgroup",
+        "mount": "/sys/fs/cgroup/devices",
+        "fs_type": "cgroup",
+        "mount_options": [
+          "rw",
+          "nosuid",
+          "nodev",
+          "noexec",
+          "relatime",
+          "seclabel",
+          "devices"
+        ]
+      },
+      "none,/sys/kernel/tracing": {
+        "device": "none",
+        "mount": "/sys/kernel/tracing",
+        "fs_type": "tracefs",
+        "mount_options": [
+          "rw",
+          "relatime",
+          "seclabel"
+        ]
+      },
+      "configfs,/sys/kernel/config": {
+        "device": "configfs",
+        "mount": "/sys/kernel/config",
+        "fs_type": "configfs",
+        "mount_options": [
+          "rw",
+          "relatime"
+        ]
+      },
+      "selinuxfs,/sys/fs/selinux": {
+        "device": "selinuxfs",
+        "mount": "/sys/fs/selinux",
+        "fs_type": "selinuxfs",
+        "mount_options": [
+          "rw",
+          "relatime"
+        ]
+      },
+      "systemd-1,/proc/sys/fs/binfmt_misc": {
+        "device": "systemd-1",
+        "mount": "/proc/sys/fs/binfmt_misc",
+        "fs_type": "autofs",
+        "mount_options": [
+          "rw",
+          "relatime",
+          "fd=35",
+          "pgrp=1",
+          "timeout=0",
+          "minproto=5",
+          "maxproto=5",
+          "direct",
+          "pipe_ino=18053"
+        ]
+      },
+      "mqueue,/dev/mqueue": {
+        "device": "mqueue",
+        "mount": "/dev/mqueue",
+        "fs_type": "mqueue",
+        "mount_options": [
+          "rw",
+          "relatime",
+          "seclabel"
+        ]
+      },
+      "hugetlbfs,/dev/hugepages": {
+        "device": "hugetlbfs",
+        "mount": "/dev/hugepages",
+        "fs_type": "hugetlbfs",
+        "mount_options": [
+          "rw",
+          "relatime",
+          "seclabel",
+          "pagesize=2M"
+        ]
+      },
+      "debugfs,/sys/kernel/debug": {
+        "device": "debugfs",
+        "mount": "/sys/kernel/debug",
+        "fs_type": "debugfs",
+        "mount_options": [
+          "rw",
+          "relatime",
+          "seclabel"
+        ]
+      },
+      "sunrpc,/var/lib/nfs/rpc_pipefs": {
+        "device": "sunrpc",
+        "mount": "/var/lib/nfs/rpc_pipefs",
+        "fs_type": "rpc_pipefs",
+        "mount_options": [
+          "rw",
+          "relatime"
+        ]
+      },
+      "/dev/sda,": {
+        "device": "/dev/sda"
+      },
+      "/dev/sda1,": {
+        "device": "/dev/sda1",
+        "fs_type": "swap",
+        "uuid": "0d01112d-3db9-4c8b-9b6b-9db9416fb74d"
+      }
+    }
+  },
+  "fips": {
+    "kernel": {
+      "enabled": true
+    }
+  },
+  "fqdn": "fauxhai.local",
+  "hostname": "Fauxhai",
+  "idle": "30 days 15 hours 07 minutes 30 seconds",
+  "idletime_seconds": 2646450,
+  "init_package": "systemd",
+  "ipaddress": "10.0.0.2",
+  "kernel": {
+    "name": "Linux",
+    "release": "4.18.0-348.2.1.el8_5.x86_64",
+    "version": "#1 SMP Tue Nov 16 14:42:35 UTC 2021",
+    "machine": "x86_64",
+    "processor": "x86_64",
+    "os": "GNU/Linux",
+    "modules": {
+      "vboxsf": {
+        "size": "90112",
+        "refcount": "1",
+        "version": "6.1.30 r148432"
+      },
+      "intel_rapl_msr": {
+        "size": "16384",
+        "refcount": "0"
+      },
+      "intel_rapl_common": {
+        "size": "24576",
+        "refcount": "1"
+      },
+      "crct10dif_pclmul": {
+        "size": "16384",
+        "refcount": "1"
+      },
+      "crc32_pclmul": {
+        "size": "16384",
+        "refcount": "0"
+      },
+      "ghash_clmulni_intel": {
+        "size": "16384",
+        "refcount": "0"
+      },
+      "rapl": {
+        "size": "20480",
+        "refcount": "0"
+      },
+      "pcspkr": {
+        "size": "16384",
+        "refcount": "0"
+      },
+      "joydev": {
+        "size": "24576",
+        "refcount": "0"
+      },
+      "i2c_piix4": {
+        "size": "24576",
+        "refcount": "0"
+      },
+      "video": {
+        "size": "49152",
+        "refcount": "0"
+      },
+      "sunrpc": {
+        "size": "557056",
+        "refcount": "1"
+      },
+      "xfs": {
+        "size": "1544192",
+        "refcount": "1"
+      },
+      "libcrc32c": {
+        "size": "16384",
+        "refcount": "1"
+      },
+      "sd_mod": {
+        "size": "53248",
+        "refcount": "3"
+      },
+      "t10_pi": {
+        "size": "16384",
+        "refcount": "1"
+      },
+      "sg": {
+        "size": "40960",
+        "refcount": "0",
+        "version": "3.5.36"
+      },
+      "ata_generic": {
+        "size": "16384",
+        "refcount": "0",
+        "version": "0.2.15"
+      },
+      "vboxvideo": {
+        "size": "45056",
+        "refcount": "1",
+        "version": "6.1.30 r148432"
+      },
+      "drm_ttm_helper": {
+        "size": "16384",
+        "refcount": "1"
+      },
+      "ttm": {
+        "size": "77824",
+        "refcount": "2"
+      },
+      "drm_kms_helper": {
+        "size": "253952",
+        "refcount": "1"
+      },
+      "drm": {
+        "size": "573440",
+        "refcount": "5"
+      },
+      "ahci": {
+        "size": "40960",
+        "refcount": "2",
+        "version": "3.0"
+      },
+      "libahci": {
+        "size": "40960",
+        "refcount": "1"
+      },
+      "ata_piix": {
+        "size": "36864",
+        "refcount": "0",
+        "version": "2.13"
+      },
+      "libata": {
+        "size": "270336",
+        "refcount": "4",
+        "version": "3.00"
+      },
+      "crc32c_intel": {
+        "size": "24576",
+        "refcount": "1"
+      },
+      "e1000": {
+        "size": "151552",
+        "refcount": "0",
+        "version": "7.3.21-k8-NAPI"
+      },
+      "serio_raw": {
+        "size": "16384",
+        "refcount": "0"
+      },
+      "vboxguest": {
+        "size": "385024",
+        "refcount": "2",
+        "version": "6.1.30 r148432"
+      },
+      "syscopyarea": {
+        "size": "16384",
+        "refcount": "1"
+      },
+      "sysfillrect": {
+        "size": "16384",
+        "refcount": "1"
+      },
+      "sysimgblt": {
+        "size": "16384",
+        "refcount": "1"
+      },
+      "fb_sys_fops": {
+        "size": "16384",
+        "refcount": "1"
+      }
+    }
+  },
+  "keys": {
+    "ssh": {
+      "host_dsa_public": "ssh-dss AAAAB3NzaC1kc3MAAACBAJFo9BLAw4WKEs5hgipk5m423FzBsDXCZSMcC9ca/om/1VYzMqImixGe3uICDzNFUWxFoLJTQAOccyzo6MXZiQqwWJDLFi5qOSr6w2XcMyE+zd4wOyMoDiVM5fizmG8K3FzrqvGjwBcHcBdOQnavSijoj38DN25J9zhrid5BY4WlAAAAFQDxXrCyG52XCzn3FV4ej38wJBkomQAAAIBovGPJ4mP2P6BK8lHl0PPbktwQbWlpJ13oz6REJFDVcUi7vV26bX/BjQX+ohzZQzljdz1SpUbPc/8nuA4darYkVh91eBi307EN8IdxRHj2eBgp/ZG4yshIebG3WHrwJD/xUjjZ1MRfyDT1ermVi4LvjjPgWDxLZnPpMaR6S1nzgQAAAIEAj0Vd6DCWslvlsZ8+N53HWsqPi3gnx35JoLPz9Z2epkKIKqmEHav+93G3hdfztVa4I4t3phoPniQchYryF5+RNg8hqxKzjNtrIqUYCeuf2NJrksNsH7OZygPHZpqt4kTuwAGZxjxEGfAI0y8DhkU2ntp2LnzRnWH106BQBCmcXwo= fauxhai.local",
+      "host_rsa_public": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCtLCeqtqr/HbnORckw1ukdLhpfGoOPFi5/esKEokzTqq1gsgQ2V8emmyjfq1i6XXfRtSBxkdlHv/GWdP5wBTuE2G85MzBkVSQPvmwQN8lX/JMPEEtKXkeOo0o92/PiSmvY4eRsdF0mw40Uvg7jtE3f3fxj497kzh5fKtkrHnF4x9gXCbVdr3FqXJfggR5IJwAxToerbK7x/uRS+7YuZI9Pip3tt14nv9ezwXcuGb/tvjWOZINiFl8izVIFKi7sxfTX09p4NgamxRS7TD2Yd0jT8nEoF9UZTsgXcJ1kDSx7N7NxFfNfP6rCdOGRRz4gUhXtsUjG/XkxPeCwZ7A9VnOD fauxhai.local"
+    }
+  },
+  "languages": {
+    "ruby": {
+      "platform": "x86_64-linux",
+      "version": "3.0.3",
+      "release_date": "2021-11-24",
+      "target": "x86_64-pc-linux-gnu",
+      "target_cpu": "x86_64",
+      "target_vendor": "pc",
+      "target_os": "linux",
+      "host": "x86_64-pc-linux-gnu",
+      "host_cpu": "x86_64",
+      "host_os": "linux",
+      "host_vendor": "pc",
+      "bin_dir": "/usr/local/bin",
+      "ruby_bin": "/usr/local/bin/ruby",
+      "gem_bin": "/usr/local/bin/gem",
+      "gems_dir": "/usr/local/gems"
+    },
+    "powershell": null
+  },
+  "lsb": {
+    "id": "CentOSStream",
+    "description": "CentOS Stream release 8",
+    "release": "8",
+    "codename": "n/a"
+  },
+  "macaddress": "11:11:11:11:11:11",
+  "machinename": "Fauxhai",
+  "memory": {
+    "total": "1048576kB"
+  },
+  "network": {
+    "interfaces": {
+      "lo": {
+        "mtu": "65536",
+        "flags": [
+          "LOOPBACK",
+          "UP",
+          "LOWER_UP"
+        ],
+        "encapsulation": "Loopback",
+        "addresses": {
+          "127.0.0.1": {
+            "family": "inet",
+            "prefixlen": "8",
+            "netmask": "255.0.0.0",
+            "scope": "Node",
+            "ip_scope": "LOOPBACK"
+          },
+          "::1": {
+            "family": "inet6",
+            "prefixlen": "128",
+            "scope": "Node",
+            "tags": [
+
+            ],
+            "ip_scope": "LINK LOCAL LOOPBACK"
+          }
+        },
+        "state": "unknown"
+      },
+      "eth0": {
+        "type": "eth",
+        "number": "0",
+        "mtu": "1500",
+        "flags": [
+          "BROADCAST",
+          "MULTICAST",
+          "UP",
+          "LOWER_UP"
+        ],
+        "encapsulation": "Ethernet",
+        "addresses": {
+          "11:11:11:11:11:11": {
+            "family": "lladdr"
+          },
+          "10.0.0.2": {
+            "family": "inet",
+            "prefixlen": "24",
+            "netmask": "255.255.255.0",
+            "broadcast": "10.0.0.255",
+            "scope": "Global",
+            "ip_scope": "RFC1918 PRIVATE"
+          },
+          "fe80::11:1111:1111:1111": {
+            "family": "inet6",
+            "prefixlen": "64",
+            "scope": "Link",
+            "tags": [
+
+            ],
+            "ip_scope": "LINK LOCAL UNICAST"
+          }
+        },
+        "state": "up",
+        "arp": {
+          "10.0.0.1": "fe:ff:ff:ff:ff:ff"
+        },
+        "routes": [
+          {
+            "destination": "default",
+            "family": "inet",
+            "via": "10.0.0.1"
+          },
+          {
+            "destination": "10.0.0.0/24",
+            "family": "inet",
+            "scope": "link",
+            "proto": "kernel",
+            "src": "10.0.0.2"
+          },
+          {
+            "destination": "fe80::/64",
+            "family": "inet6",
+            "metric": "256",
+            "proto": "kernel"
+          }
+        ],
+        "ring_params": {
+        }
+      }
+    },
+    "default_interface": "eth0",
+    "default_gateway": "10.0.0.1"
+  },
+  "ohai_time": 1643239257.2132964,
+  "os": "linux",
+  "os_release": {
+    "name": "CentOS Stream",
+    "version": "8",
+    "id": "centos",
+    "id_like": [
+      "rhel",
+      "fedora"
+    ],
+    "version_id": "8",
+    "platform_id": "platform:el8",
+    "pretty_name": "CentOS Stream 8",
+    "ansi_color": "0;31",
+    "cpe_name": "cpe:/o:centos:centos:8",
+    "home_url": "https://centos.org/",
+    "bug_report_url": "https://bugzilla.redhat.com/",
+    "redhat_support_product": "Red Hat Enterprise Linux 8",
+    "redhat_support_product_version": "CentOS Stream"
+  },
+  "os_version": "4.18.0-348.2.1.el8_5.x86_64",
+  "packages": {
+    "perl-Module-Loaded": {
+      "epoch": "1",
+      "version": "0.08",
+      "release": "421.el8",
+      "installdate": "1640302878",
+      "arch": "noarch"
+    },
+    "tzdata": {
+      "epoch": "0",
+      "version": "2021e",
+      "release": "1.el8",
+      "installdate": "1640302504",
+      "arch": "noarch"
+    },
+    "perl-Pod-Parser": {
+      "epoch": "0",
+      "version": "1.63",
+      "release": "396.el8",
+      "installdate": "1640302878",
+      "arch": "noarch"
+    },
+    "libmodulemd": {
+      "epoch": "0",
+      "version": "2.13.0",
+      "release": "1.el8",
+      "installdate": "1640302537",
+      "arch": "x86_64"
+    },
+    "xkeyboard-config": {
+      "epoch": "0",
+      "version": "2.28",
+      "release": "1.el8",
+      "installdate": "1640302504",
+      "arch": "noarch"
+    },
+    "perl-Test-Simple": {
+      "epoch": "1",
+      "version": "1.302135",
+      "release": "1.el8",
+      "installdate": "1640302878",
+      "arch": "noarch"
+    },
+    "crontabs": {
+      "epoch": "0",
+      "version": "1.11",
+      "release": "17.20190603git.el8",
+      "installdate": "1640302537",
+      "arch": "noarch"
+    },
+    "perl-Unicode-Collate": {
+      "epoch": "0",
+      "version": "1.25",
+      "release": "2.el8",
+      "installdate": "1640302879",
+      "arch": "x86_64"
+    },
+    "kbd-misc": {
+      "epoch": "0",
+      "version": "2.0.4",
+      "release": "10.el8",
+      "installdate": "1640302519",
+      "arch": "noarch"
+    },
+    "perl-Text-Diff": {
+      "epoch": "0",
+      "version": "1.45",
+      "release": "2.el8",
+      "installdate": "1640302879",
+      "arch": "noarch"
+    },
+    "initscripts": {
+      "epoch": "0",
+      "version": "10.00.15",
+      "release": "1.el8",
+      "installdate": "1640302542",
+      "arch": "x86_64"
+    },
+    "perl-File-HomeDir": {
+      "epoch": "0",
+      "version": "1.002",
+      "release": "4.el8",
+      "installdate": "1640302879",
+      "arch": "noarch"
+    },
+    "polkit-libs": {
+      "epoch": "0",
+      "version": "0.115",
+      "release": "12.el8",
+      "installdate": "1640302542",
+      "arch": "x86_64"
+    },
+    "filesystem": {
+      "epoch": "0",
+      "version": "3.8",
+      "release": "6.el8",
+      "installdate": "1640302520",
+      "arch": "x86_64"
+    },
+    "perl-Software-License": {
+      "epoch": "0",
+      "version": "0.103013",
+      "release": "2.el8",
+      "installdate": "1640302879",
+      "arch": "noarch"
+    },
+    "iproute": {
+      "epoch": "0",
+      "version": "5.15.0",
+      "release": "1.el8",
+      "installdate": "1640302543",
+      "arch": "x86_64"
+    },
+    "ncurses-libs": {
+      "epoch": "0",
+      "version": "6.1",
+      "release": "9.20180224.el8",
+      "installdate": "1640302520",
+      "arch": "x86_64"
+    },
+    "zip": {
+      "epoch": "0",
+      "version": "3.0",
+      "release": "23.el8",
+      "installdate": "1640302879",
+      "arch": "x86_64"
+    },
+    "python3-decorator": {
+      "epoch": "0",
+      "version": "4.2.1",
+      "release": "2.el8",
+      "installdate": "1640302543",
+      "arch": "noarch"
+    },
+    "cups-client": {
+      "epoch": "1",
+      "version": "2.2.6",
+      "release": "41.el8",
+      "installdate": "1640302543",
+      "arch": "x86_64"
+    },
+    "info": {
+      "epoch": "0",
+      "version": "6.5",
+      "release": "6.el8",
+      "installdate": "1640302521",
+      "arch": "x86_64"
+    },
+    "qt5-srpm-macros": {
+      "epoch": "0",
+      "version": "5.15.2",
+      "release": "1.el8",
+      "installdate": "1640302881",
+      "arch": "noarch"
+    },
+    "timedatex": {
+      "epoch": "0",
+      "version": "0.5",
+      "release": "3.el8",
+      "installdate": "1640302543",
+      "arch": "x86_64"
+    },
+    "bzip2-libs": {
+      "epoch": "0",
+      "version": "1.0.6",
+      "release": "26.el8",
+      "installdate": "1640302521",
+      "arch": "x86_64"
+    },
+    "python3-libsemanage": {
+      "epoch": "0",
+      "version": "2.9",
+      "release": "6.el8",
+      "installdate": "1640302552",
+      "arch": "x86_64"
+    },
+    "libgpg-error": {
+      "epoch": "0",
+      "version": "1.31",
+      "release": "1.el8",
+      "installdate": "1640302522",
+      "arch": "x86_64"
+    },
+    "ghc-srpm-macros": {
+      "epoch": "0",
+      "version": "1.4.2",
+      "release": "7.el8",
+      "installdate": "1640302883",
+      "arch": "noarch"
+    },
+    "libuuid": {
+      "epoch": "0",
+      "version": "2.32.1",
+      "release": "28.el8",
+      "installdate": "1640302522",
+      "arch": "x86_64"
+    },
+    "perl-ExtUtils-Install": {
+      "epoch": "0",
+      "version": "2.14",
+      "release": "4.el8",
+      "installdate": "1640302883",
+      "arch": "noarch"
+    },
+    "python3-configobj": {
+      "epoch": "0",
+      "version": "5.0.6",
+      "release": "11.el8",
+      "installdate": "1640302552",
+      "arch": "noarch"
+    },
+    "libzstd": {
+      "epoch": "0",
+      "version": "1.4.4",
+      "release": "1.el8",
+      "installdate": "1640302522",
+      "arch": "x86_64"
+    },
+    "perl-ExtUtils-Embed": {
+      "epoch": "0",
+      "version": "1.34",
+      "release": "421.el8",
+      "installdate": "1640302883",
+      "arch": "noarch"
+    },
+    "at": {
+      "epoch": "0",
+      "version": "3.1.20",
+      "release": "11.el8",
+      "installdate": "1640302553",
+      "arch": "x86_64"
+    },
+    "sed": {
+      "epoch": "0",
+      "version": "4.5",
+      "release": "5.el8",
+      "installdate": "1640302522",
+      "arch": "x86_64"
+    },
+    "perl-inc-latest": {
+      "epoch": "2",
+      "version": "0.500",
+      "release": "9.el8",
+      "installdate": "1640302883",
+      "arch": "noarch"
+    },
+    "libcap-ng": {
+      "epoch": "0",
+      "version": "0.7.11",
+      "release": "1.el8",
+      "installdate": "1640302522",
+      "arch": "x86_64"
+    },
+    "gobject-introspection": {
+      "epoch": "0",
+      "version": "1.56.1",
+      "release": "1.el8",
+      "installdate": "1640302554",
+      "arch": "x86_64"
+    },
+    "libgcrypt": {
+      "epoch": "0",
+      "version": "1.8.5",
+      "release": "6.el8",
+      "installdate": "1640302522",
+      "arch": "x86_64"
+    },
+    "glibc": {
+      "epoch": "0",
+      "version": "2.28",
+      "release": "184.el8",
+      "installdate": "1643238283",
+      "arch": "x86_64"
+    },
+    "grub2-tools-extra": {
+      "epoch": "1",
+      "version": "2.02",
+      "release": "106.el8",
+      "installdate": "1640302554",
+      "arch": "x86_64"
+    },
+    "libffi": {
+      "epoch": "0",
+      "version": "3.1",
+      "release": "23.el8",
+      "installdate": "1640302522",
+      "arch": "x86_64"
+    },
+    "systemd-libs": {
+      "epoch": "0",
+      "version": "239",
+      "release": "55.el8",
+      "installdate": "1643238290",
+      "arch": "x86_64"
+    },
+    "nss-util": {
+      "epoch": "0",
+      "version": "3.67.0",
+      "release": "7.el8_5",
+      "installdate": "1640302522",
+      "arch": "x86_64"
+    },
+    "rpm-libs": {
+      "epoch": "0",
+      "version": "4.14.3",
+      "release": "21.el8",
+      "installdate": "1643238293",
+      "arch": "x86_64"
+    },
+    "tpm2-tss": {
+      "epoch": "0",
+      "version": "2.3.2",
+      "release": "4.el8",
+      "installdate": "1640302555",
+      "arch": "x86_64"
+    },
+    "file-libs": {
+      "epoch": "0",
+      "version": "5.33",
+      "release": "20.el8",
+      "installdate": "1640302523",
+      "arch": "x86_64"
+    },
+    "selinux-policy-targeted": {
+      "epoch": "0",
+      "version": "3.14.3",
+      "release": "86.el8",
+      "installdate": "1643238336",
+      "arch": "noarch"
+    },
+    "gnupg2": {
+      "epoch": "0",
+      "version": "2.2.20",
+      "release": "2.el8",
+      "installdate": "1640302555",
+      "arch": "x86_64"
+    },
+    "libbasicobjects": {
+      "epoch": "0",
+      "version": "0.1.1",
+      "release": "39.el8",
+      "installdate": "1640302523",
+      "arch": "x86_64"
+    },
+    "libsss_idmap": {
+      "epoch": "0",
+      "version": "2.6.1",
+      "release": "2.el8",
+      "installdate": "1643238375",
+      "arch": "x86_64"
+    },
+    "python3-libdnf": {
+      "epoch": "0",
+      "version": "0.63.0",
+      "release": "5.el8",
+      "installdate": "1640302555",
+      "arch": "x86_64"
+    },
+    "lz4-libs": {
+      "epoch": "0",
+      "version": "1.8.3",
+      "release": "3.el8_4",
+      "installdate": "1640302523",
+      "arch": "x86_64"
+    },
+    "selinux-policy-devel": {
+      "epoch": "0",
+      "version": "3.14.3",
+      "release": "86.el8",
+      "installdate": "1643238377",
+      "arch": "noarch"
+    },
+    "hostname": {
+      "epoch": "0",
+      "version": "3.20",
+      "release": "7.el8.0.1",
+      "installdate": "1640302523",
+      "arch": "x86_64"
+    },
+    "python3-dnf-plugins-core": {
+      "epoch": "0",
+      "version": "4.0.21",
+      "release": "8.el8",
+      "installdate": "1643238391",
+      "arch": "noarch"
+    },
+    "libverto": {
+      "epoch": "0",
+      "version": "0.3.0",
+      "release": "5.el8",
+      "installdate": "1640302523",
+      "arch": "x86_64"
+    },
+    "libsss_autofs": {
+      "epoch": "0",
+      "version": "2.6.1",
+      "release": "2.el8",
+      "installdate": "1643238391",
+      "arch": "x86_64"
+    },
+    "redhat-lsb-submod-security": {
+      "epoch": "0",
+      "version": "4.1",
+      "release": "47.el8",
+      "installdate": "1640302556",
+      "arch": "x86_64"
+    },
+    "libnftnl": {
+      "epoch": "0",
+      "version": "1.1.5",
+      "release": "4.el8",
+      "installdate": "1640302523",
+      "arch": "x86_64"
+    },
+    "libsss_sudo": {
+      "epoch": "0",
+      "version": "2.6.1",
+      "release": "2.el8",
+      "installdate": "1643238392",
+      "arch": "x86_64"
+    },
+    "centos-gpg-keys": {
+      "epoch": "1",
+      "version": "8",
+      "release": "4.el8",
+      "installdate": "1643238393",
+      "arch": "noarch"
+    },
+    "dnf": {
+      "epoch": "0",
+      "version": "4.7.0",
+      "release": "5.el8",
+      "installdate": "1640302557",
+      "arch": "noarch"
+    },
+    "libdhash": {
+      "epoch": "0",
+      "version": "0.5.0",
+      "release": "39.el8",
+      "installdate": "1640302523",
+      "arch": "x86_64"
+    },
+    "kernel": {
+      "epoch": "0",
+      "version": "4.18.0",
+      "release": "348.2.1.el8_5",
+      "installdate": "1640302566",
+      "arch": "x86_64",
+      "versions": [
+        {
+          "epoch": "0",
+          "version": "4.18.0",
+          "release": "358.el8",
+          "installdate": "1643238446",
+          "arch": "x86_64"
+        },
+        {
+          "epoch": "0",
+          "version": "4.18.0",
+          "release": "348.2.1.el8_5",
+          "installdate": "1640302566",
+          "arch": "x86_64"
+        }
+      ]
+    },
+    "kernel-tools": {
+      "epoch": "0",
+      "version": "4.18.0",
+      "release": "358.el8",
+      "installdate": "1643238449",
+      "arch": "x86_64"
+    },
+    "python3-pyyaml": {
+      "epoch": "0",
+      "version": "3.12",
+      "release": "12.el8",
+      "installdate": "1640302565",
+      "arch": "x86_64"
+    },
+    "lzo": {
+      "epoch": "0",
+      "version": "2.08",
+      "release": "14.el8",
+      "installdate": "1640302523",
+      "arch": "x86_64"
+    },
+    "NetworkManager-team": {
+      "epoch": "1",
+      "version": "1.36.0",
+      "release": "0.4.el8",
+      "installdate": "1643238449",
+      "arch": "x86_64"
+    },
+    "firewalld": {
+      "epoch": "0",
+      "version": "0.9.3",
+      "release": "11.el8",
+      "installdate": "1640302566",
+      "arch": "noarch"
+    },
+    "grep": {
+      "epoch": "0",
+      "version": "3.1",
+      "release": "6.el8",
+      "installdate": "1640302524",
+      "arch": "x86_64"
+    },
+    "rsyslog": {
+      "epoch": "0",
+      "version": "8.2102.0",
+      "release": "7.el8",
+      "installdate": "1643238450",
+      "arch": "x86_64"
+    },
+    "wget": {
+      "epoch": "0",
+      "version": "1.19.5",
+      "release": "10.el8",
+      "installdate": "1640302566",
+      "arch": "x86_64"
+    },
+    "libnetfilter_conntrack": {
+      "epoch": "0",
+      "version": "1.0.6",
+      "release": "5.el8",
+      "installdate": "1640302524",
+      "arch": "x86_64"
+    },
+    "postfix": {
+      "epoch": "2",
+      "version": "3.5.8",
+      "release": "3.el8",
+      "installdate": "1643238452",
+      "arch": "x86_64"
+    },
+    "authselect": {
+      "epoch": "0",
+      "version": "1.2.2",
+      "release": "3.el8",
+      "installdate": "1640302566",
+      "arch": "x86_64"
+    },
+    "nss-softokn": {
+      "epoch": "0",
+      "version": "3.67.0",
+      "release": "7.el8_5",
+      "installdate": "1640302524",
+      "arch": "x86_64"
+    },
+    "libgomp": {
+      "epoch": "0",
+      "version": "8.5.0",
+      "release": "7.el8",
+      "installdate": "1643238456",
+      "arch": "x86_64"
+    },
+    "iptables": {
+      "epoch": "0",
+      "version": "1.8.4",
+      "release": "22.el8",
+      "installdate": "1640302524",
+      "arch": "x86_64"
+    },
+    "chef": {
+      "epoch": "0",
+      "version": "17.9.26",
+      "release": "1.el8",
+      "installdate": "1643239069",
+      "arch": "x86_64"
+    },
+    "audit": {
+      "epoch": "0",
+      "version": "3.0",
+      "release": "0.17.20191104git1c2f876.el8",
+      "installdate": "1640302567",
+      "arch": "x86_64"
+    },
+    "keyutils": {
+      "epoch": "0",
+      "version": "1.5.10",
+      "release": "9.el8",
+      "installdate": "1640302524",
+      "arch": "x86_64"
+    },
+    "sudo": {
+      "epoch": "0",
+      "version": "1.8.29",
+      "release": "8.el8",
+      "installdate": "1640302567",
+      "arch": "x86_64"
+    },
+    "groff-base": {
+      "epoch": "0",
+      "version": "1.22.3",
+      "release": "18.el8",
+      "installdate": "1640302525",
+      "arch": "x86_64"
+    },
+    "prefixdevname": {
+      "epoch": "0",
+      "version": "0.1.0",
+      "release": "6.el8",
+      "installdate": "1640302568",
+      "arch": "x86_64"
+    },
+    "rsync": {
+      "epoch": "0",
+      "version": "3.1.3",
+      "release": "14.el8",
+      "installdate": "1640302568",
+      "arch": "x86_64"
+    },
+    "libicu": {
+      "epoch": "0",
+      "version": "60.3",
+      "release": "2.el8_1",
+      "installdate": "1640302526",
+      "arch": "x86_64"
+    },
+    "libsysfs": {
+      "epoch": "0",
+      "version": "2.1.0",
+      "release": "24.el8",
+      "installdate": "1640302568",
+      "arch": "x86_64"
+    },
+    "libbpf": {
+      "epoch": "0",
+      "version": "0.4.0",
+      "release": "2.el8",
+      "installdate": "1640302527",
+      "arch": "x86_64"
+    },
+    "gpg-pubkey": {
+      "epoch": "0",
+      "version": "8483c65d",
+      "release": "5ccc5b19",
+      "installdate": "1640302866",
+      "arch": "(none)"
+    },
+    "time": {
+      "epoch": "0",
+      "version": "1.9",
+      "release": "3.el8",
+      "installdate": "1640302527",
+      "arch": "x86_64"
+    },
+    "perl-libnet": {
+      "epoch": "0",
+      "version": "3.11",
+      "release": "3.el8",
+      "installdate": "1640302871",
+      "arch": "noarch"
+    },
+    "libselinux-utils": {
+      "epoch": "0",
+      "version": "2.9",
+      "release": "5.el8",
+      "installdate": "1640302527",
+      "arch": "x86_64"
+    },
+    "perl-Mozilla-CA": {
+      "epoch": "0",
+      "version": "20160104",
+      "release": "7.module_el8.3.0+416+dee7bcef",
+      "installdate": "1640302871",
+      "arch": "noarch"
+    },
+    "c-ares": {
+      "epoch": "0",
+      "version": "1.13.0",
+      "release": "6.el8",
+      "installdate": "1640302527",
+      "arch": "x86_64"
+    },
+    "perl-Term-ANSIColor": {
+      "epoch": "0",
+      "version": "4.06",
+      "release": "396.el8",
+      "installdate": "1640302871",
+      "arch": "noarch"
+    },
+    "libdaemon": {
+      "epoch": "0",
+      "version": "0.14",
+      "release": "15.el8",
+      "installdate": "1640302527",
+      "arch": "x86_64"
+    },
+    "perl-HTTP-Tiny": {
+      "epoch": "0",
+      "version": "0.074",
+      "release": "1.el8",
+      "installdate": "1640302872",
+      "arch": "noarch"
+    },
+    "libini_config": {
+      "epoch": "0",
+      "version": "1.3.1",
+      "release": "39.el8",
+      "installdate": "1640302527",
+      "arch": "x86_64"
+    },
+    "perl-Pod-Usage": {
+      "epoch": "4",
+      "version": "1.69",
+      "release": "395.el8",
+      "installdate": "1640302872",
+      "arch": "noarch"
+    },
+    "perl-Errno": {
+      "epoch": "0",
+      "version": "1.28",
+      "release": "421.el8",
+      "installdate": "1640302872",
+      "arch": "x86_64"
+    },
+    "perl-Exporter": {
+      "epoch": "0",
+      "version": "5.72",
+      "release": "396.el8",
+      "installdate": "1640302872",
+      "arch": "noarch"
+    },
+    "memstrack": {
+      "epoch": "0",
+      "version": "0.1.11",
+      "release": "1.el8",
+      "installdate": "1640302527",
+      "arch": "x86_64"
+    },
+    "perl-macros": {
+      "epoch": "4",
+      "version": "5.26.3",
+      "release": "421.el8",
+      "installdate": "1640302873",
+      "arch": "x86_64"
+    },
+    "slang": {
+      "epoch": "0",
+      "version": "2.3.2",
+      "release": "3.el8",
+      "installdate": "1640302528",
+      "arch": "x86_64"
+    },
+    "perl-IO": {
+      "epoch": "0",
+      "version": "1.38",
+      "release": "421.el8",
+      "installdate": "1640302873",
+      "arch": "x86_64"
+    },
+    "libmaxminddb": {
+      "epoch": "0",
+      "version": "1.2.0",
+      "release": "10.el8",
+      "installdate": "1640302528",
+      "arch": "x86_64"
+    },
+    "perl-threads-shared": {
+      "epoch": "0",
+      "version": "1.58",
+      "release": "2.el8",
+      "installdate": "1640302873",
+      "arch": "x86_64"
+    },
+    "platform-python-pip": {
+      "epoch": "0",
+      "version": "9.0.3",
+      "release": "22.el8",
+      "installdate": "1640302528",
+      "arch": "noarch"
+    },
+    "perl-CPAN-Meta-Requirements": {
+      "epoch": "0",
+      "version": "2.140",
+      "release": "396.el8",
+      "installdate": "1640302874",
+      "arch": "noarch"
+    },
+    "libssh": {
+      "epoch": "0",
+      "version": "0.9.6",
+      "release": "3.el8",
+      "installdate": "1640302531",
+      "arch": "x86_64"
+    },
+    "perl-Module-CoreList": {
+      "epoch": "1",
+      "version": "5.20181130",
+      "release": "1.el8",
+      "installdate": "1640302875",
+      "arch": "noarch"
+    },
+    "libkcapi": {
+      "epoch": "0",
+      "version": "1.2.0",
+      "release": "2.el8",
+      "installdate": "1640302531",
+      "arch": "x86_64"
+    },
+    "perl-Compress-Raw-Zlib": {
+      "epoch": "0",
+      "version": "2.081",
+      "release": "1.el8",
+      "installdate": "1640302875",
+      "arch": "x86_64"
+    },
+    "curl": {
+      "epoch": "0",
+      "version": "7.61.1",
+      "release": "22.el8",
+      "installdate": "1640302531",
+      "arch": "x86_64"
+    },
+    "perl-encoding": {
+      "epoch": "4",
+      "version": "2.22",
+      "release": "3.el8",
+      "installdate": "1640302875",
+      "arch": "x86_64"
+    },
+    "crypto-policies": {
+      "epoch": "0",
+      "version": "20211116",
+      "release": "1.gitae470d6.el8",
+      "installdate": "1640302531",
+      "arch": "noarch"
+    },
+    "perl-ExtUtils-Command": {
+      "epoch": "1",
+      "version": "7.34",
+      "release": "1.el8",
+      "installdate": "1640302875",
+      "arch": "noarch"
+    },
+    "cracklib-dicts": {
+      "epoch": "0",
+      "version": "2.9.6",
+      "release": "15.el8",
+      "installdate": "1640302532",
+      "arch": "x86_64"
+    },
+    "perl-Module-Load-Conditional": {
+      "epoch": "0",
+      "version": "0.68",
+      "release": "395.el8",
+      "installdate": "1640302875",
+      "arch": "noarch"
+    },
+    "libnsl2": {
+      "epoch": "0",
+      "version": "1.2.0",
+      "release": "2.20180605git4a062cf.el8",
+      "installdate": "1640302532",
+      "arch": "x86_64"
+    },
+    "perl-Compress-Raw-Bzip2": {
+      "epoch": "0",
+      "version": "2.081",
+      "release": "1.el8",
+      "installdate": "1640302875",
+      "arch": "x86_64"
+    },
+    "elfutils-libs": {
+      "epoch": "0",
+      "version": "0.186",
+      "release": "1.el8",
+      "installdate": "1640302532",
+      "arch": "x86_64"
+    },
+    "perl-Math-BigInt": {
+      "epoch": "1",
+      "version": "1.9998.11",
+      "release": "7.el8",
+      "installdate": "1640302875",
+      "arch": "noarch"
+    },
+    "libcroco": {
+      "epoch": "0",
+      "version": "0.6.12",
+      "release": "4.el8_2.1",
+      "installdate": "1640302532",
+      "arch": "x86_64"
+    },
+    "python-srpm-macros": {
+      "epoch": "0",
+      "version": "3",
+      "release": "41.el8",
+      "installdate": "1640302876",
+      "arch": "noarch"
+    },
+    "dbus-libs": {
+      "epoch": "1",
+      "version": "1.12.8",
+      "release": "18.el8",
+      "installdate": "1640302532",
+      "arch": "x86_64"
+    },
+    "python3-rpm-macros": {
+      "epoch": "0",
+      "version": "3",
+      "release": "41.el8",
+      "installdate": "1640302877",
+      "arch": "noarch"
+    },
+    "perl-open": {
+      "epoch": "0",
+      "version": "1.11",
+      "release": "421.el8",
+      "installdate": "1640302877",
+      "arch": "noarch"
+    },
+    "ca-certificates": {
+      "epoch": "0",
+      "version": "2021.2.50",
+      "release": "82.el8",
+      "installdate": "1640302533",
+      "arch": "noarch"
+    },
+    "perl-Module-CoreList-tools": {
+      "epoch": "1",
+      "version": "5.20181130",
+      "release": "1.el8",
+      "installdate": "1640302877",
+      "arch": "noarch"
+    },
+    "kmod": {
+      "epoch": "0",
+      "version": "25",
+      "release": "19.el8",
+      "installdate": "1640302533",
+      "arch": "x86_64"
+    },
+    "perl-Compress-Bzip2": {
+      "epoch": "0",
+      "version": "2.26",
+      "release": "6.el8",
+      "installdate": "1640302877",
+      "arch": "x86_64"
+    },
+    "dbus-daemon": {
+      "epoch": "1",
+      "version": "1.12.8",
+      "release": "18.el8",
+      "installdate": "1640302534",
+      "arch": "x86_64"
+    },
+    "perl-Devel-Size": {
+      "epoch": "0",
+      "version": "0.81",
+      "release": "2.el8",
+      "installdate": "1640302877",
+      "arch": "x86_64"
+    },
+    "pam": {
+      "epoch": "0",
+      "version": "1.3.1",
+      "release": "15.el8",
+      "installdate": "1640302534",
+      "arch": "x86_64"
+    },
+    "perl-IPC-Cmd": {
+      "epoch": "2",
+      "version": "1.02",
+      "release": "1.el8",
+      "installdate": "1640302877",
+      "arch": "noarch"
+    },
+    "os-prober": {
+      "epoch": "0",
+      "version": "1.74",
+      "release": "9.el8",
+      "installdate": "1640302535",
+      "arch": "x86_64"
+    },
+    "perl-autodie": {
+      "epoch": "0",
+      "version": "2.29",
+      "release": "396.el8",
+      "installdate": "1640302878",
+      "arch": "noarch"
+    },
+    "shared-mime-info": {
+      "epoch": "0",
+      "version": "1.9",
+      "release": "3.el8",
+      "installdate": "1640302535",
+      "arch": "x86_64"
+    },
+    "dbus": {
+      "epoch": "1",
+      "version": "1.12.8",
+      "release": "18.el8",
+      "installdate": "1640302535",
+      "arch": "x86_64"
+    },
+    "geolite2-city": {
+      "epoch": "0",
+      "version": "20180605",
+      "release": "1.el8",
+      "installdate": "1640302503",
+      "arch": "noarch"
+    },
+    "python3-setuptools-wheel": {
+      "epoch": "0",
+      "version": "39.2.0",
+      "release": "6.el8",
+      "installdate": "1640302504",
+      "arch": "noarch"
+    },
+    "python3-six": {
+      "epoch": "0",
+      "version": "1.11.0",
+      "release": "8.el8",
+      "installdate": "1640302537",
+      "arch": "noarch"
+    },
+    "ncurses-base": {
+      "epoch": "0",
+      "version": "6.1",
+      "release": "9.20180224.el8",
+      "installdate": "1640302504",
+      "arch": "noarch"
+    },
+    "quota-nls": {
+      "epoch": "1",
+      "version": "4.04",
+      "release": "14.el8",
+      "installdate": "1640302504",
+      "arch": "noarch"
+    },
+    "python3-libselinux": {
+      "epoch": "0",
+      "version": "2.9",
+      "release": "5.el8",
+      "installdate": "1640302537",
+      "arch": "x86_64"
+    },
+    "cronie": {
+      "epoch": "0",
+      "version": "1.5.2",
+      "release": "6.el8",
+      "installdate": "1640302537",
+      "arch": "x86_64"
+    },
+    "libssh-config": {
+      "epoch": "0",
+      "version": "0.9.6",
+      "release": "3.el8",
+      "installdate": "1640302519",
+      "arch": "noarch"
+    },
+    "libsolv": {
+      "epoch": "0",
+      "version": "0.7.20",
+      "release": "1.el8",
+      "installdate": "1640302537",
+      "arch": "x86_64"
+    },
+    "dnf-data": {
+      "epoch": "0",
+      "version": "4.7.0",
+      "release": "5.el8",
+      "installdate": "1640302519",
+      "arch": "noarch"
+    },
+    "kbd-legacy": {
+      "epoch": "0",
+      "version": "2.0.4",
+      "release": "10.el8",
+      "installdate": "1640302519",
+      "arch": "noarch"
+    },
+    "kernel-core": {
+      "epoch": "0",
+      "version": "4.18.0",
+      "release": "358.el8",
+      "installdate": "1643238434",
+      "arch": "x86_64",
+      "versions": [
+        {
+          "epoch": "0",
+          "version": "4.18.0",
+          "release": "348.2.1.el8_5",
+          "installdate": "1640302542",
+          "arch": "x86_64"
+        },
+        {
+          "epoch": "0",
+          "version": "4.18.0",
+          "release": "358.el8",
+          "installdate": "1643238434",
+          "arch": "x86_64"
+        }
+      ]
+    },
+    "firewalld-filesystem": {
+      "epoch": "0",
+      "version": "0.9.3",
+      "release": "11.el8",
+      "installdate": "1640302520",
+      "arch": "noarch"
+    },
+    "centos-stream-release": {
+      "epoch": "0",
+      "version": "8.6",
+      "release": "1.el8",
+      "installdate": "1640302520",
+      "arch": "noarch"
+    },
+    "libuser": {
+      "epoch": "0",
+      "version": "0.62",
+      "release": "24.el8",
+      "installdate": "1640302542",
+      "arch": "x86_64"
+    },
+    "setup": {
+      "epoch": "0",
+      "version": "2.12.2",
+      "release": "6.el8",
+      "installdate": "1640302520",
+      "arch": "noarch"
+    },
+    "polkit": {
+      "epoch": "0",
+      "version": "0.115",
+      "release": "12.el8",
+      "installdate": "1640302543",
+      "arch": "x86_64"
+    },
+    "basesystem": {
+      "epoch": "0",
+      "version": "11",
+      "release": "5.el8",
+      "installdate": "1640302520",
+      "arch": "noarch"
+    },
+    "openssh": {
+      "epoch": "0",
+      "version": "8.0p1",
+      "release": "12.el8",
+      "installdate": "1640302543",
+      "arch": "x86_64"
+    },
+    "libselinux": {
+      "epoch": "0",
+      "version": "2.9",
+      "release": "5.el8",
+      "installdate": "1640302520",
+      "arch": "x86_64"
+    },
+    "logrotate": {
+      "epoch": "0",
+      "version": "3.14.0",
+      "release": "4.el8",
+      "installdate": "1640302543",
+      "arch": "x86_64"
+    },
+    "libnfsidmap": {
+      "epoch": "1",
+      "version": "2.3.3",
+      "release": "47.el8",
+      "installdate": "1640302543",
+      "arch": "x86_64"
+    },
+    "libldb": {
+      "epoch": "0",
+      "version": "2.4.1",
+      "release": "1.el8",
+      "installdate": "1640302543",
+      "arch": "x86_64"
+    },
+    "bash": {
+      "epoch": "0",
+      "version": "4.4.20",
+      "release": "3.el8",
+      "installdate": "1640302521",
+      "arch": "x86_64"
+    },
+    "cups-libs": {
+      "epoch": "1",
+      "version": "2.2.6",
+      "release": "41.el8",
+      "installdate": "1640302543",
+      "arch": "x86_64"
+    },
+    "zlib": {
+      "epoch": "0",
+      "version": "1.2.11",
+      "release": "17.el8",
+      "installdate": "1640302521",
+      "arch": "x86_64"
+    },
+    "network-scripts": {
+      "epoch": "0",
+      "version": "10.00.15",
+      "release": "1.el8",
+      "installdate": "1640302543",
+      "arch": "x86_64"
+    },
+    "xz-libs": {
+      "epoch": "0",
+      "version": "5.2.4",
+      "release": "3.el8",
+      "installdate": "1640302521",
+      "arch": "x86_64"
+    },
+    "teamd": {
+      "epoch": "0",
+      "version": "1.31",
+      "release": "2.el8",
+      "installdate": "1640302543",
+      "arch": "x86_64"
+    },
+    "popt": {
+      "epoch": "0",
+      "version": "1.18",
+      "release": "1.el8",
+      "installdate": "1640302521",
+      "arch": "x86_64"
+    },
+    "passwd": {
+      "epoch": "0",
+      "version": "0.80",
+      "release": "3.el8",
+      "installdate": "1640302543",
+      "arch": "x86_64"
+    },
+    "libcap": {
+      "epoch": "0",
+      "version": "2.26",
+      "release": "5.el8",
+      "installdate": "1640302521",
+      "arch": "x86_64"
+    },
+    "kernel-modules": {
+      "epoch": "0",
+      "version": "4.18.0",
+      "release": "358.el8",
+      "installdate": "1643238439",
+      "arch": "x86_64",
+      "versions": [
+        {
+          "epoch": "0",
+          "version": "4.18.0",
+          "release": "348.2.1.el8_5",
+          "installdate": "1640302544",
+          "arch": "x86_64"
+        },
+        {
+          "epoch": "0",
+          "version": "4.18.0",
+          "release": "358.el8",
+          "installdate": "1643238439",
+          "arch": "x86_64"
+        }
+      ]
+    },
+    "elfutils-libelf": {
+      "epoch": "0",
+      "version": "0.186",
+      "release": "1.el8",
+      "installdate": "1640302521",
+      "arch": "x86_64"
+    },
+    "python3-setools": {
+      "epoch": "0",
+      "version": "4.3.0",
+      "release": "3.el8",
+      "installdate": "1640302552",
+      "arch": "x86_64"
+    },
+    "libverto-libevent": {
+      "epoch": "0",
+      "version": "0.3.0",
+      "release": "5.el8",
+      "installdate": "1640302552",
+      "arch": "x86_64"
+    },
+    "libxcrypt": {
+      "epoch": "0",
+      "version": "4.1.1",
+      "release": "6.el8",
+      "installdate": "1640302522",
+      "arch": "x86_64"
+    },
+    "unbound-libs": {
+      "epoch": "0",
+      "version": "1.7.3",
+      "release": "17.el8",
+      "installdate": "1640302552",
+      "arch": "x86_64"
+    },
+    "libxml2": {
+      "epoch": "0",
+      "version": "2.9.7",
+      "release": "11.el8",
+      "installdate": "1640302522",
+      "arch": "x86_64"
+    },
+    "rpcbind": {
+      "epoch": "0",
+      "version": "1.2.5",
+      "release": "8.el8",
+      "installdate": "1640302552",
+      "arch": "x86_64"
+    },
+    "expat": {
+      "epoch": "0",
+      "version": "2.2.5",
+      "release": "4.el8",
+      "installdate": "1640302522",
+      "arch": "x86_64"
+    },
+    "python3-dateutil": {
+      "epoch": "1",
+      "version": "2.6.1",
+      "release": "6.el8",
+      "installdate": "1640302552",
+      "arch": "noarch"
+    },
+    "findutils": {
+      "epoch": "1",
+      "version": "4.6.0",
+      "release": "20.el8",
+      "installdate": "1640302522",
+      "arch": "x86_64"
+    },
+    "python3-pyudev": {
+      "epoch": "0",
+      "version": "0.21.0",
+      "release": "7.el8",
+      "installdate": "1640302552",
+      "arch": "noarch"
+    },
+    "libacl": {
+      "epoch": "0",
+      "version": "2.2.53",
+      "release": "1.el8",
+      "installdate": "1640302522",
+      "arch": "x86_64"
+    },
+    "authselect-libs": {
+      "epoch": "0",
+      "version": "1.2.2",
+      "release": "3.el8",
+      "installdate": "1640302553",
+      "arch": "x86_64"
+    },
+    "libmnl": {
+      "epoch": "0",
+      "version": "1.0.4",
+      "release": "6.el8",
+      "installdate": "1640302522",
+      "arch": "x86_64"
+    },
+    "dracut-network": {
+      "epoch": "0",
+      "version": "049",
+      "release": "191.git20210920.el8",
+      "installdate": "1640302553",
+      "arch": "x86_64"
+    },
+    "keyutils-libs": {
+      "epoch": "0",
+      "version": "1.5.10",
+      "release": "9.el8",
+      "installdate": "1640302522",
+      "arch": "x86_64"
+    },
+    "dbus-glib": {
+      "epoch": "0",
+      "version": "0.110",
+      "release": "2.el8",
+      "installdate": "1640302554",
+      "arch": "x86_64"
+    },
+    "audit-libs": {
+      "epoch": "0",
+      "version": "3.0",
+      "release": "0.17.20191104git1c2f876.el8",
+      "installdate": "1640302522",
+      "arch": "x86_64"
+    },
+    "python3-slip-dbus": {
+      "epoch": "0",
+      "version": "0.6.4",
+      "release": "11.el8",
+      "installdate": "1640302554",
+      "arch": "noarch"
+    },
+    "nspr": {
+      "epoch": "0",
+      "version": "4.32.0",
+      "release": "1.el8_4",
+      "installdate": "1640302522",
+      "arch": "x86_64"
+    },
+    "libgcc": {
+      "epoch": "0",
+      "version": "8.5.0",
+      "release": "7.el8",
+      "installdate": "1643238282",
+      "arch": "x86_64"
+    },
+    "python3-gobject-base": {
+      "epoch": "0",
+      "version": "3.28.3",
+      "release": "2.el8",
+      "installdate": "1640302554",
+      "arch": "x86_64"
+    },
+    "libunistring": {
+      "epoch": "0",
+      "version": "0.9.9",
+      "release": "3.el8",
+      "installdate": "1640302522",
+      "arch": "x86_64"
+    },
+    "glibc-langpack-en": {
+      "epoch": "0",
+      "version": "2.28",
+      "release": "184.el8",
+      "installdate": "1643238283",
+      "arch": "x86_64"
+    },
+    "pinentry": {
+      "epoch": "0",
+      "version": "1.1.0",
+      "release": "2.el8",
+      "installdate": "1640302554",
+      "arch": "x86_64"
+    },
+    "grub2-common": {
+      "epoch": "1",
+      "version": "2.02",
+      "release": "106.el8",
+      "installdate": "1640302522",
+      "arch": "noarch"
+    },
+    "glibc-gconv-extra": {
+      "epoch": "0",
+      "version": "2.28",
+      "release": "184.el8",
+      "installdate": "1643238284",
+      "arch": "x86_64"
+    },
+    "dracut-squash": {
+      "epoch": "0",
+      "version": "049",
+      "release": "191.git20210920.el8",
+      "installdate": "1640302554",
+      "arch": "x86_64"
+    },
+    "p11-kit": {
+      "epoch": "0",
+      "version": "0.23.22",
+      "release": "1.el8",
+      "installdate": "1640302522",
+      "arch": "x86_64"
+    },
+    "libtalloc": {
+      "epoch": "0",
+      "version": "2.3.3",
+      "release": "1.el8",
+      "installdate": "1640302522",
+      "arch": "x86_64"
+    },
+    "libsemanage": {
+      "epoch": "0",
+      "version": "2.9",
+      "release": "6.el8",
+      "installdate": "1640302522",
+      "arch": "x86_64"
+    },
+    "mailx": {
+      "epoch": "0",
+      "version": "12.5",
+      "release": "29.el8",
+      "installdate": "1640302555",
+      "arch": "x86_64"
+    },
+    "diffutils": {
+      "epoch": "0",
+      "version": "3.6",
+      "release": "6.el8",
+      "installdate": "1640302523",
+      "arch": "x86_64"
+    },
+    "ima-evm-utils": {
+      "epoch": "0",
+      "version": "1.3.2",
+      "release": "12.el8",
+      "installdate": "1640302555",
+      "arch": "x86_64"
+    },
+    "file": {
+      "epoch": "0",
+      "version": "5.33",
+      "release": "20.el8",
+      "installdate": "1640302523",
+      "arch": "x86_64"
+    },
+    "gnupg2-smime": {
+      "epoch": "0",
+      "version": "2.2.20",
+      "release": "2.el8",
+      "installdate": "1640302555",
+      "arch": "x86_64"
+    },
+    "json-c": {
+      "epoch": "0",
+      "version": "0.13.1",
+      "release": "3.el8",
+      "installdate": "1640302523",
+      "arch": "x86_64"
+    },
+    "gpgme": {
+      "epoch": "0",
+      "version": "1.13.1",
+      "release": "9.el8",
+      "installdate": "1640302555",
+      "arch": "x86_64"
+    },
+    "libcollection": {
+      "epoch": "0",
+      "version": "0.7.0",
+      "release": "39.el8",
+      "installdate": "1640302523",
+      "arch": "x86_64"
+    },
+    "libdnf": {
+      "epoch": "0",
+      "version": "0.63.0",
+      "release": "5.el8",
+      "installdate": "1640302555",
+      "arch": "x86_64"
+    },
+    "libsmartcols": {
+      "epoch": "0",
+      "version": "2.32.1",
+      "release": "28.el8",
+      "installdate": "1640302523",
+      "arch": "x86_64"
+    },
+    "python3-hawkey": {
+      "epoch": "0",
+      "version": "0.63.0",
+      "release": "5.el8",
+      "installdate": "1640302555",
+      "arch": "x86_64"
+    },
+    "libtevent": {
+      "epoch": "0",
+      "version": "0.11.0",
+      "release": "0.el8",
+      "installdate": "1640302523",
+      "arch": "x86_64"
+    },
+    "make": {
+      "epoch": "1",
+      "version": "4.2.1",
+      "release": "11.el8",
+      "installdate": "1640302523",
+      "arch": "x86_64"
+    },
+    "plymouth-core-libs": {
+      "epoch": "0",
+      "version": "0.9.4",
+      "release": "10.20200615git1e36e30.el8",
+      "installdate": "1640302555",
+      "arch": "x86_64"
+    },
+    "cpio": {
+      "epoch": "0",
+      "version": "2.12",
+      "release": "11.el8",
+      "installdate": "1640302523",
+      "arch": "x86_64"
+    },
+    "plymouth": {
+      "epoch": "0",
+      "version": "0.9.4",
+      "release": "10.20200615git1e36e30.el8",
+      "installdate": "1640302555",
+      "arch": "x86_64"
+    },
+    "libtdb": {
+      "epoch": "0",
+      "version": "1.4.4",
+      "release": "1.el8",
+      "installdate": "1640302523",
+      "arch": "x86_64"
+    },
+    "man-db": {
+      "epoch": "0",
+      "version": "2.7.6.1",
+      "release": "18.el8",
+      "installdate": "1640302556",
+      "arch": "x86_64"
+    },
+    "libnl3-cli": {
+      "epoch": "0",
+      "version": "3.5.0",
+      "release": "1.el8",
+      "installdate": "1640302523",
+      "arch": "x86_64"
+    },
+    "nss": {
+      "epoch": "0",
+      "version": "3.67.0",
+      "release": "7.el8_5",
+      "installdate": "1640302556",
+      "arch": "x86_64"
+    },
+    "ethtool": {
+      "epoch": "2",
+      "version": "5.13",
+      "release": "1.el8",
+      "installdate": "1640302523",
+      "arch": "x86_64"
+    },
+    "quota": {
+      "epoch": "1",
+      "version": "4.04",
+      "release": "14.el8",
+      "installdate": "1640302556",
+      "arch": "x86_64"
+    },
+    "bc": {
+      "epoch": "0",
+      "version": "1.07.1",
+      "release": "5.el8",
+      "installdate": "1640302523",
+      "arch": "x86_64"
+    },
+    "python3-audit": {
+      "epoch": "0",
+      "version": "3.0",
+      "release": "0.17.20191104git1c2f876.el8",
+      "installdate": "1640302556",
+      "arch": "x86_64"
+    },
+    "e2fsprogs-libs": {
+      "epoch": "0",
+      "version": "1.45.6",
+      "release": "2.el8",
+      "installdate": "1640302523",
+      "arch": "x86_64"
+    },
+    "m4": {
+      "epoch": "0",
+      "version": "1.4.18",
+      "release": "7.el8",
+      "installdate": "1640302523",
+      "arch": "x86_64"
+    },
+    "python3-dnf": {
+      "epoch": "0",
+      "version": "4.7.0",
+      "release": "5.el8",
+      "installdate": "1640302557",
+      "arch": "noarch"
+    },
+    "libedit": {
+      "epoch": "0",
+      "version": "3.1",
+      "release": "23.20170329cvs.el8",
+      "installdate": "1640302523",
+      "arch": "x86_64"
+    },
+    "libseccomp": {
+      "epoch": "0",
+      "version": "2.5.2",
+      "release": "1.el8",
+      "installdate": "1640302523",
+      "arch": "x86_64"
+    },
+    "python3-nftables": {
+      "epoch": "1",
+      "version": "0.9.3",
+      "release": "24.el8",
+      "installdate": "1640302565",
+      "arch": "x86_64"
+    },
+    "libtasn1": {
+      "epoch": "0",
+      "version": "4.13",
+      "release": "3.el8",
+      "installdate": "1640302523",
+      "arch": "x86_64"
+    },
+    "libyaml": {
+      "epoch": "0",
+      "version": "0.1.7",
+      "release": "5.el8",
+      "installdate": "1640302523",
+      "arch": "x86_64"
+    },
+    "numactl-libs": {
+      "epoch": "0",
+      "version": "2.0.12",
+      "release": "13.el8",
+      "installdate": "1640302523",
+      "arch": "x86_64"
+    },
+    "nfs-utils": {
+      "epoch": "1",
+      "version": "2.3.3",
+      "release": "47.el8",
+      "installdate": "1640302566",
+      "arch": "x86_64"
+    },
+    "pcre": {
+      "epoch": "0",
+      "version": "8.42",
+      "release": "6.el8",
+      "installdate": "1640302523",
+      "arch": "x86_64"
+    },
+    "psmisc": {
+      "epoch": "0",
+      "version": "23.1",
+      "release": "5.el8",
+      "installdate": "1640302524",
+      "arch": "x86_64"
+    },
+    "redhat-lsb-core": {
+      "epoch": "0",
+      "version": "4.1",
+      "release": "47.el8",
+      "installdate": "1640302566",
+      "arch": "x86_64"
+    },
+    "squashfs-tools": {
+      "epoch": "0",
+      "version": "4.3",
+      "release": "20.el8",
+      "installdate": "1640302524",
+      "arch": "x86_64"
+    },
+    "libteam": {
+      "epoch": "0",
+      "version": "1.31",
+      "release": "2.el8",
+      "installdate": "1640302524",
+      "arch": "x86_64"
+    },
+    "grub2-pc": {
+      "epoch": "1",
+      "version": "2.02",
+      "release": "106.el8",
+      "installdate": "1640302566",
+      "arch": "x86_64"
+    },
+    "nss-softokn-freebl": {
+      "epoch": "0",
+      "version": "3.67.0",
+      "release": "7.el8_5",
+      "installdate": "1640302524",
+      "arch": "x86_64"
+    },
+    "iptables-libs": {
+      "epoch": "0",
+      "version": "1.8.4",
+      "release": "22.el8",
+      "installdate": "1640302524",
+      "arch": "x86_64"
+    },
+    "openssh-clients": {
+      "epoch": "0",
+      "version": "8.0p1",
+      "release": "12.el8",
+      "installdate": "1640302567",
+      "arch": "x86_64"
+    },
+    "iptables-ebtables": {
+      "epoch": "0",
+      "version": "1.8.4",
+      "release": "22.el8",
+      "installdate": "1640302524",
+      "arch": "x86_64"
+    },
+    "grub2-pc-modules": {
+      "epoch": "1",
+      "version": "2.02",
+      "release": "106.el8",
+      "installdate": "1640302524",
+      "arch": "noarch"
+    },
+    "mpfr": {
+      "epoch": "0",
+      "version": "3.1.6",
+      "release": "1.el8",
+      "installdate": "1640302524",
+      "arch": "x86_64"
+    },
+    "ipset": {
+      "epoch": "0",
+      "version": "7.1",
+      "release": "1.el8",
+      "installdate": "1640302524",
+      "arch": "x86_64"
+    },
+    "acl": {
+      "epoch": "0",
+      "version": "2.2.53",
+      "release": "1.el8",
+      "installdate": "1640302525",
+      "arch": "x86_64"
+    },
+    "tar": {
+      "epoch": "2",
+      "version": "1.30",
+      "release": "5.el8",
+      "installdate": "1640302525",
+      "arch": "x86_64"
+    },
+    "patch": {
+      "epoch": "0",
+      "version": "2.7.6",
+      "release": "11.el8",
+      "installdate": "1640302525",
+      "arch": "x86_64"
+    },
+    "libmetalink": {
+      "epoch": "0",
+      "version": "0.1.3",
+      "release": "7.el8",
+      "installdate": "1640302525",
+      "arch": "x86_64"
+    },
+    "mozjs60": {
+      "epoch": "0",
+      "version": "60.9.0",
+      "release": "4.el8",
+      "installdate": "1640302526",
+      "arch": "x86_64"
+    },
+    "snappy": {
+      "epoch": "0",
+      "version": "1.1.8",
+      "release": "3.el8",
+      "installdate": "1640302527",
+      "arch": "x86_64"
+    },
+    "libss": {
+      "epoch": "0",
+      "version": "1.45.6",
+      "release": "2.el8",
+      "installdate": "1640302527",
+      "arch": "x86_64"
+    },
+    "ed": {
+      "epoch": "0",
+      "version": "1.14.2",
+      "release": "4.el8",
+      "installdate": "1640302527",
+      "arch": "x86_64"
+    },
+    "libpng": {
+      "epoch": "2",
+      "version": "1.6.34",
+      "release": "5.el8",
+      "installdate": "1640302527",
+      "arch": "x86_64"
+    },
+    "pigz": {
+      "epoch": "0",
+      "version": "2.4",
+      "release": "4.el8",
+      "installdate": "1640302527",
+      "arch": "x86_64"
+    },
+    "brotli": {
+      "epoch": "0",
+      "version": "1.0.6",
+      "release": "3.el8",
+      "installdate": "1640302527",
+      "arch": "x86_64"
+    },
+    "fuse-libs": {
+      "epoch": "0",
+      "version": "2.9.7",
+      "release": "12.el8",
+      "installdate": "1640302527",
+      "arch": "x86_64"
+    },
+    "hdparm": {
+      "epoch": "0",
+      "version": "9.54",
+      "release": "4.el8",
+      "installdate": "1640302527",
+      "arch": "x86_64"
+    },
+    "libndp": {
+      "epoch": "0",
+      "version": "1.7",
+      "release": "6.el8",
+      "installdate": "1640302527",
+      "arch": "x86_64"
+    },
+    "libpath_utils": {
+      "epoch": "0",
+      "version": "0.2.1",
+      "release": "39.el8",
+      "installdate": "1640302527",
+      "arch": "x86_64"
+    },
+    "libpipeline": {
+      "epoch": "0",
+      "version": "1.5.0",
+      "release": "2.el8",
+      "installdate": "1640302527",
+      "arch": "x86_64"
+    },
+    "gawk": {
+      "epoch": "0",
+      "version": "4.2.1",
+      "release": "2.el8",
+      "installdate": "1640302527",
+      "arch": "x86_64"
+    },
+    "lmdb-libs": {
+      "epoch": "0",
+      "version": "0.9.24",
+      "release": "1.el8",
+      "installdate": "1640302527",
+      "arch": "x86_64"
+    },
+    "ncurses": {
+      "epoch": "0",
+      "version": "6.1",
+      "release": "9.20180224.el8",
+      "installdate": "1640302528",
+      "arch": "x86_64"
+    },
+    "sg3_utils-libs": {
+      "epoch": "0",
+      "version": "1.44",
+      "release": "5.el8",
+      "installdate": "1640302528",
+      "arch": "x86_64"
+    },
+    "newt": {
+      "epoch": "0",
+      "version": "0.52.20",
+      "release": "11.el8",
+      "installdate": "1640302528",
+      "arch": "x86_64"
+    },
+    "libfastjson": {
+      "epoch": "0",
+      "version": "0.99.9",
+      "release": "1.el8",
+      "installdate": "1640302528",
+      "arch": "x86_64"
+    },
+    "ipcalc": {
+      "epoch": "0",
+      "version": "0.2.4",
+      "release": "4.el8",
+      "installdate": "1640302528",
+      "arch": "x86_64"
+    },
+    "cyrus-sasl-lib": {
+      "epoch": "0",
+      "version": "2.1.27",
+      "release": "5.el8",
+      "installdate": "1640302528",
+      "arch": "x86_64"
+    },
+    "platform-python-setuptools": {
+      "epoch": "0",
+      "version": "39.2.0",
+      "release": "6.el8",
+      "installdate": "1640302529",
+      "arch": "noarch"
+    },
+    "grub2-tools-minimal": {
+      "epoch": "1",
+      "version": "2.02",
+      "release": "106.el8",
+      "installdate": "1640302531",
+      "arch": "x86_64"
+    },
+    "openldap": {
+      "epoch": "0",
+      "version": "2.4.46",
+      "release": "18.el8",
+      "installdate": "1640302531",
+      "arch": "x86_64"
+    },
+    "grubby": {
+      "epoch": "0",
+      "version": "8.40",
+      "release": "42.el8",
+      "installdate": "1640302531",
+      "arch": "x86_64"
+    },
+    "libkcapi-hmaccalc": {
+      "epoch": "0",
+      "version": "1.2.0",
+      "release": "2.el8",
+      "installdate": "1640302531",
+      "arch": "x86_64"
+    },
+    "libdb-utils": {
+      "epoch": "0",
+      "version": "5.3.28",
+      "release": "42.el8_4",
+      "installdate": "1640302531",
+      "arch": "x86_64"
+    },
+    "libcurl": {
+      "epoch": "0",
+      "version": "7.61.1",
+      "release": "22.el8",
+      "installdate": "1640302531",
+      "arch": "x86_64"
+    },
+    "crypto-policies-scripts": {
+      "epoch": "0",
+      "version": "20211116",
+      "release": "1.gitae470d6.el8",
+      "installdate": "1640302531",
+      "arch": "noarch"
+    },
+    "elfutils-default-yama-scope": {
+      "epoch": "0",
+      "version": "0.186",
+      "release": "1.el8",
+      "installdate": "1640302531",
+      "arch": "noarch"
+    },
+    "cracklib": {
+      "epoch": "0",
+      "version": "2.9.6",
+      "release": "15.el8",
+      "installdate": "1640302531",
+      "arch": "x86_64"
+    },
+    "procps-ng": {
+      "epoch": "0",
+      "version": "3.3.15",
+      "release": "6.el8",
+      "installdate": "1640302532",
+      "arch": "x86_64"
+    },
+    "libtirpc": {
+      "epoch": "0",
+      "version": "1.1.4",
+      "release": "6.el8",
+      "installdate": "1640302532",
+      "arch": "x86_64"
+    },
+    "kpartx": {
+      "epoch": "0",
+      "version": "0.8.4",
+      "release": "20.el8",
+      "installdate": "1640302532",
+      "arch": "x86_64"
+    },
+    "elfutils-debuginfod-client": {
+      "epoch": "0",
+      "version": "0.186",
+      "release": "1.el8",
+      "installdate": "1640302532",
+      "arch": "x86_64"
+    },
+    "openssl-pkcs11": {
+      "epoch": "0",
+      "version": "0.4.10",
+      "release": "2.el8",
+      "installdate": "1640302532",
+      "arch": "x86_64"
+    },
+    "gettext-libs": {
+      "epoch": "0",
+      "version": "0.19.8.1",
+      "release": "17.el8",
+      "installdate": "1640302532",
+      "arch": "x86_64"
+    },
+    "dbus-common": {
+      "epoch": "1",
+      "version": "1.12.8",
+      "release": "18.el8",
+      "installdate": "1640302532",
+      "arch": "noarch"
+    },
+    "libmount": {
+      "epoch": "0",
+      "version": "2.32.1",
+      "release": "28.el8",
+      "installdate": "1640302532",
+      "arch": "x86_64"
+    },
+    "dbus-tools": {
+      "epoch": "1",
+      "version": "1.12.8",
+      "release": "18.el8",
+      "installdate": "1640302532",
+      "arch": "x86_64"
+    },
+    "coreutils": {
+      "epoch": "0",
+      "version": "8.30",
+      "release": "12.el8",
+      "installdate": "1640302533",
+      "arch": "x86_64"
+    },
+    "shadow-utils": {
+      "epoch": "2",
+      "version": "4.6",
+      "release": "16.el8",
+      "installdate": "1640302533",
+      "arch": "x86_64"
+    },
+    "openssl-libs": {
+      "epoch": "1",
+      "version": "1.1.1k",
+      "release": "5.el8_5",
+      "installdate": "1640302533",
+      "arch": "x86_64"
+    },
+    "kmod-libs": {
+      "epoch": "0",
+      "version": "25",
+      "release": "19.el8",
+      "installdate": "1640302533",
+      "arch": "x86_64"
+    },
+    "trousers-lib": {
+      "epoch": "0",
+      "version": "0.3.15",
+      "release": "1.el8",
+      "installdate": "1640302534",
+      "arch": "x86_64"
+    },
+    "libutempter": {
+      "epoch": "0",
+      "version": "1.1.6",
+      "release": "14.el8",
+      "installdate": "1640302534",
+      "arch": "x86_64"
+    },
+    "libpwquality": {
+      "epoch": "0",
+      "version": "1.4.4",
+      "release": "3.el8",
+      "installdate": "1640302534",
+      "arch": "x86_64"
+    },
+    "util-linux": {
+      "epoch": "0",
+      "version": "2.32.1",
+      "release": "28.el8",
+      "installdate": "1640302534",
+      "arch": "x86_64"
+    },
+    "dracut": {
+      "epoch": "0",
+      "version": "049",
+      "release": "191.git20210920.el8",
+      "installdate": "1640302535",
+      "arch": "x86_64"
+    },
+    "gettext": {
+      "epoch": "0",
+      "version": "0.19.8.1",
+      "release": "17.el8",
+      "installdate": "1640302535",
+      "arch": "x86_64"
+    },
+    "glib2": {
+      "epoch": "0",
+      "version": "2.56.4",
+      "release": "158.el8",
+      "installdate": "1640302535",
+      "arch": "x86_64"
+    },
+    "perl-Memoize": {
+      "epoch": "0",
+      "version": "1.03",
+      "release": "421.el8",
+      "installdate": "1640302878",
+      "arch": "noarch"
+    },
+    "perl-Package-Generator": {
+      "epoch": "0",
+      "version": "1.106",
+      "release": "11.el8",
+      "installdate": "1640302878",
+      "arch": "noarch"
+    },
+    "perl-Pod-Checker": {
+      "epoch": "4",
+      "version": "1.73",
+      "release": "395.el8",
+      "installdate": "1640302878",
+      "arch": "noarch"
+    },
+    "perl-Sys-Syslog": {
+      "epoch": "0",
+      "version": "0.35",
+      "release": "397.el8",
+      "installdate": "1640302878",
+      "arch": "x86_64"
+    },
+    "perl-Test": {
+      "epoch": "0",
+      "version": "1.30",
+      "release": "421.el8",
+      "installdate": "1640302878",
+      "arch": "noarch"
+    },
+    "perl-Text-Glob": {
+      "epoch": "0",
+      "version": "0.11",
+      "release": "4.el8",
+      "installdate": "1640302878",
+      "arch": "noarch"
+    },
+    "perl-Time-Piece": {
+      "epoch": "0",
+      "version": "1.31",
+      "release": "421.el8",
+      "installdate": "1640302878",
+      "arch": "x86_64"
+    },
+    "perl-local-lib": {
+      "epoch": "0",
+      "version": "2.000024",
+      "release": "2.el8",
+      "installdate": "1640302879",
+      "arch": "noarch"
+    },
+    "perl-Algorithm-Diff": {
+      "epoch": "0",
+      "version": "1.1903",
+      "release": "9.el8",
+      "installdate": "1640302879",
+      "arch": "noarch"
+    },
+    "perl-Archive-Tar": {
+      "epoch": "0",
+      "version": "2.30",
+      "release": "1.el8",
+      "installdate": "1640302879",
+      "arch": "noarch"
+    },
+    "perl-File-Which": {
+      "epoch": "0",
+      "version": "1.22",
+      "release": "2.el8",
+      "installdate": "1640302879",
+      "arch": "noarch"
+    },
+    "perl-Devel-Peek": {
+      "epoch": "0",
+      "version": "1.26",
+      "release": "421.el8",
+      "installdate": "1640302879",
+      "arch": "x86_64"
+    },
+    "perl-Data-Section": {
+      "epoch": "0",
+      "version": "0.200007",
+      "release": "3.el8",
+      "installdate": "1640302879",
+      "arch": "noarch"
+    },
+    "perl-PerlIO-via-QuotedPrint": {
+      "epoch": "0",
+      "version": "0.08",
+      "release": "395.el8",
+      "installdate": "1640302879",
+      "arch": "noarch"
+    },
+    "unzip": {
+      "epoch": "0",
+      "version": "6.0",
+      "release": "45.el8",
+      "installdate": "1640302879",
+      "arch": "x86_64"
+    },
+    "python3-pyparsing": {
+      "epoch": "0",
+      "version": "2.1.10",
+      "release": "7.el8",
+      "installdate": "1640302879",
+      "arch": "noarch"
+    },
+    "rust-srpm-macros": {
+      "epoch": "0",
+      "version": "5",
+      "release": "2.el8",
+      "installdate": "1640302881",
+      "arch": "noarch"
+    },
+    "perl-srpm-macros": {
+      "epoch": "0",
+      "version": "1",
+      "release": "25.el8",
+      "installdate": "1640302881",
+      "arch": "noarch"
+    },
+    "ocaml-srpm-macros": {
+      "epoch": "0",
+      "version": "5",
+      "release": "4.el8",
+      "installdate": "1640302881",
+      "arch": "noarch"
+    },
+    "go-srpm-macros": {
+      "epoch": "0",
+      "version": "2",
+      "release": "17.el8",
+      "installdate": "1640302883",
+      "arch": "noarch"
+    },
+    "efi-srpm-macros": {
+      "epoch": "0",
+      "version": "3",
+      "release": "3.el8",
+      "installdate": "1640302883",
+      "arch": "noarch"
+    },
+    "perl-devel": {
+      "epoch": "4",
+      "version": "5.26.3",
+      "release": "421.el8",
+      "installdate": "1640302883",
+      "arch": "x86_64"
+    },
+    "perl-ExtUtils-CBuilder": {
+      "epoch": "1",
+      "version": "0.280230",
+      "release": "2.el8",
+      "installdate": "1640302883",
+      "arch": "noarch"
+    },
+    "perl-ExtUtils-Miniperl": {
+      "epoch": "0",
+      "version": "1.06",
+      "release": "421.el8",
+      "installdate": "1640302883",
+      "arch": "noarch"
+    },
+    "perl-Encode-devel": {
+      "epoch": "4",
+      "version": "2.97",
+      "release": "3.el8",
+      "installdate": "1640302883",
+      "arch": "x86_64"
+    },
+    "perl-Module-Build": {
+      "epoch": "2",
+      "version": "0.42.24",
+      "release": "5.el8",
+      "installdate": "1640302883",
+      "arch": "noarch"
+    },
+    "perl": {
+      "epoch": "4",
+      "version": "5.26.3",
+      "release": "421.el8",
+      "installdate": "1640302883",
+      "arch": "x86_64"
+    },
+    "python3-libs": {
+      "epoch": "0",
+      "version": "3.6.8",
+      "release": "45.el8",
+      "installdate": "1643238290",
+      "arch": "x86_64"
+    },
+    "systemd": {
+      "epoch": "0",
+      "version": "239",
+      "release": "55.el8",
+      "installdate": "1643238292",
+      "arch": "x86_64"
+    },
+    "rpm": {
+      "epoch": "0",
+      "version": "4.14.3",
+      "release": "21.el8",
+      "installdate": "1643238293",
+      "arch": "x86_64"
+    },
+    "policycoreutils": {
+      "epoch": "0",
+      "version": "2.9",
+      "release": "18.el8",
+      "installdate": "1643238293",
+      "arch": "x86_64"
+    },
+    "selinux-policy": {
+      "epoch": "0",
+      "version": "3.14.3",
+      "release": "86.el8",
+      "installdate": "1643238293",
+      "arch": "noarch"
+    },
+    "systemd-udev": {
+      "epoch": "0",
+      "version": "239",
+      "release": "55.el8",
+      "installdate": "1643238372",
+      "arch": "x86_64"
+    },
+    "NetworkManager": {
+      "epoch": "1",
+      "version": "1.36.0",
+      "release": "0.4.el8",
+      "installdate": "1643238374",
+      "arch": "x86_64"
+    },
+    "python3-policycoreutils": {
+      "epoch": "0",
+      "version": "2.9",
+      "release": "18.el8",
+      "installdate": "1643238375",
+      "arch": "noarch"
+    },
+    "policycoreutils-devel": {
+      "epoch": "0",
+      "version": "2.9",
+      "release": "18.el8",
+      "installdate": "1643238376",
+      "arch": "x86_64"
+    },
+    "rpm-build-libs": {
+      "epoch": "0",
+      "version": "4.14.3",
+      "release": "21.el8",
+      "installdate": "1643238390",
+      "arch": "x86_64"
+    },
+    "device-mapper": {
+      "epoch": "8",
+      "version": "1.02.181",
+      "release": "2.el8",
+      "installdate": "1643238390",
+      "arch": "x86_64"
+    },
+    "dnf-plugins-core": {
+      "epoch": "0",
+      "version": "4.0.21",
+      "release": "8.el8",
+      "installdate": "1643238391",
+      "arch": "noarch"
+    },
+    "kernel-tools-libs": {
+      "epoch": "0",
+      "version": "4.18.0",
+      "release": "358.el8",
+      "installdate": "1643238391",
+      "arch": "x86_64"
+    },
+    "libsss_certmap": {
+      "epoch": "0",
+      "version": "2.6.1",
+      "release": "2.el8",
+      "installdate": "1643238391",
+      "arch": "x86_64"
+    },
+    "sssd-client": {
+      "epoch": "0",
+      "version": "2.6.1",
+      "release": "2.el8",
+      "installdate": "1643238392",
+      "arch": "x86_64"
+    },
+    "libstdc++": {
+      "epoch": "0",
+      "version": "8.5.0",
+      "release": "7.el8",
+      "installdate": "1643238392",
+      "arch": "x86_64"
+    },
+    "sssd-common": {
+      "epoch": "0",
+      "version": "2.6.1",
+      "release": "2.el8",
+      "installdate": "1643238393",
+      "arch": "x86_64"
+    },
+    "linux-firmware": {
+      "epoch": "0",
+      "version": "20211119",
+      "release": "105.gitf5d51956.el8",
+      "installdate": "1643238428",
+      "arch": "noarch"
+    },
+    "centos-stream-repos": {
+      "epoch": "0",
+      "version": "8",
+      "release": "4.el8",
+      "installdate": "1643238446",
+      "arch": "noarch"
+    },
+    "binutils": {
+      "epoch": "0",
+      "version": "2.30",
+      "release": "112.el8",
+      "installdate": "1643238448",
+      "arch": "x86_64"
+    },
+    "virt-what": {
+      "epoch": "0",
+      "version": "1.18",
+      "release": "13.el8",
+      "installdate": "1643238449",
+      "arch": "x86_64"
+    },
+    "python3-rpm": {
+      "epoch": "0",
+      "version": "4.14.3",
+      "release": "21.el8",
+      "installdate": "1643238449",
+      "arch": "x86_64"
+    },
+    "NetworkManager-tui": {
+      "epoch": "1",
+      "version": "1.36.0",
+      "release": "0.4.el8",
+      "installdate": "1643238449",
+      "arch": "x86_64"
+    },
+    "redhat-rpm-config": {
+      "epoch": "0",
+      "version": "127",
+      "release": "1.el8",
+      "installdate": "1643238449",
+      "arch": "noarch"
+    },
+    "gssproxy": {
+      "epoch": "0",
+      "version": "0.8.0",
+      "release": "20.el8",
+      "installdate": "1643238450",
+      "arch": "x86_64"
+    },
+    "kexec-tools": {
+      "epoch": "0",
+      "version": "2.0.20",
+      "release": "67.el8",
+      "installdate": "1643238451",
+      "arch": "x86_64"
+    },
+    "python3-perf": {
+      "epoch": "0",
+      "version": "4.18.0",
+      "release": "358.el8",
+      "installdate": "1643238454",
+      "arch": "x86_64"
+    },
+    "python3-syspurpose": {
+      "epoch": "0",
+      "version": "1.28.24",
+      "release": "1.el8",
+      "installdate": "1643238456",
+      "arch": "x86_64"
+    },
+    "libibverbs": {
+      "epoch": "0",
+      "version": "37.2",
+      "release": "1.el8",
+      "installdate": "1643238456",
+      "arch": "x86_64"
+    },
+    "hwdata": {
+      "epoch": "0",
+      "version": "0.314",
+      "release": "8.11.el8",
+      "installdate": "1643238457",
+      "arch": "noarch"
+    },
+    "net-tools": {
+      "epoch": "0",
+      "version": "2.0",
+      "release": "0.52.20160912git.el8",
+      "installdate": "1640302567",
+      "arch": "x86_64"
+    },
+    "dracut-config-rescue": {
+      "epoch": "0",
+      "version": "049",
+      "release": "191.git20210920.el8",
+      "installdate": "1640302567",
+      "arch": "x86_64"
+    },
+    "parted": {
+      "epoch": "0",
+      "version": "3.2",
+      "release": "39.el8",
+      "installdate": "1640302567",
+      "arch": "x86_64"
+    },
+    "e2fsprogs": {
+      "epoch": "0",
+      "version": "1.45.6",
+      "release": "2.el8",
+      "installdate": "1640302568",
+      "arch": "x86_64"
+    },
+    "sg3_utils": {
+      "epoch": "0",
+      "version": "1.44",
+      "release": "5.el8",
+      "installdate": "1640302568",
+      "arch": "x86_64"
+    },
+    "biosdevname": {
+      "epoch": "0",
+      "version": "0.7.3",
+      "release": "2.el8",
+      "installdate": "1640302568",
+      "arch": "x86_64"
+    },
+    "lshw": {
+      "epoch": "0",
+      "version": "B.02.19.2",
+      "release": "6.el8",
+      "installdate": "1640302568",
+      "arch": "x86_64"
+    },
+    "iprutils": {
+      "epoch": "0",
+      "version": "2.4.19",
+      "release": "1.el8",
+      "installdate": "1640302568",
+      "arch": "x86_64"
+    },
+    "lsscsi": {
+      "epoch": "0",
+      "version": "0.32",
+      "release": "3.el8",
+      "installdate": "1640302568",
+      "arch": "x86_64"
+    },
+    "rootfiles": {
+      "epoch": "0",
+      "version": "8.1",
+      "release": "22.el8",
+      "installdate": "1640302568",
+      "arch": "noarch"
+    },
+    "perl-Digest": {
+      "epoch": "0",
+      "version": "1.17",
+      "release": "395.el8",
+      "installdate": "1640302871",
+      "arch": "noarch"
+    },
+    "perl-Data-Dumper": {
+      "epoch": "0",
+      "version": "2.167",
+      "release": "399.el8",
+      "installdate": "1640302871",
+      "arch": "x86_64"
+    },
+    "perl-Net-SSLeay": {
+      "epoch": "0",
+      "version": "1.88",
+      "release": "1.module_el8.4.0+517+be1595ff",
+      "installdate": "1640302871",
+      "arch": "x86_64"
+    },
+    "perl-Pod-Escapes": {
+      "epoch": "1",
+      "version": "1.07",
+      "release": "395.el8",
+      "installdate": "1640302871",
+      "arch": "noarch"
+    },
+    "perl-IO-Socket-IP": {
+      "epoch": "0",
+      "version": "0.39",
+      "release": "5.el8",
+      "installdate": "1640302871",
+      "arch": "noarch"
+    },
+    "perl-IO-Socket-SSL": {
+      "epoch": "0",
+      "version": "2.066",
+      "release": "4.module_el8.4.0+517+be1595ff",
+      "installdate": "1640302871",
+      "arch": "noarch"
+    },
+    "perl-Term-Cap": {
+      "epoch": "0",
+      "version": "1.17",
+      "release": "395.el8",
+      "installdate": "1640302871",
+      "arch": "noarch"
+    },
+    "perl-Pod-Simple": {
+      "epoch": "1",
+      "version": "3.35",
+      "release": "395.el8",
+      "installdate": "1640302871",
+      "arch": "noarch"
+    },
+    "perl-podlators": {
+      "epoch": "0",
+      "version": "4.11",
+      "release": "1.el8",
+      "installdate": "1640302872",
+      "arch": "noarch"
+    },
+    "perl-Text-ParseWords": {
+      "epoch": "0",
+      "version": "3.30",
+      "release": "395.el8",
+      "installdate": "1640302872",
+      "arch": "noarch"
+    },
+    "perl-MIME-Base64": {
+      "epoch": "0",
+      "version": "3.15",
+      "release": "396.el8",
+      "installdate": "1640302872",
+      "arch": "x86_64"
+    },
+    "perl-Getopt-Long": {
+      "epoch": "1",
+      "version": "2.50",
+      "release": "4.el8",
+      "installdate": "1640302872",
+      "arch": "noarch"
+    },
+    "perl-Socket": {
+      "epoch": "4",
+      "version": "2.027",
+      "release": "3.el8",
+      "installdate": "1640302872",
+      "arch": "x86_64"
+    },
+    "perl-Carp": {
+      "epoch": "0",
+      "version": "1.42",
+      "release": "396.el8",
+      "installdate": "1640302872",
+      "arch": "noarch"
+    },
+    "perl-libs": {
+      "epoch": "4",
+      "version": "5.26.3",
+      "release": "421.el8",
+      "installdate": "1640302873",
+      "arch": "x86_64"
+    },
+    "perl-parent": {
+      "epoch": "1",
+      "version": "0.237",
+      "release": "1.el8",
+      "installdate": "1640302873",
+      "arch": "noarch"
+    },
+    "perl-Text-Tabs+Wrap": {
+      "epoch": "0",
+      "version": "2013.0523",
+      "release": "395.el8",
+      "installdate": "1640302873",
+      "arch": "noarch"
+    },
+    "perl-File-Path": {
+      "epoch": "0",
+      "version": "2.15",
+      "release": "2.el8",
+      "installdate": "1640302873",
+      "arch": "noarch"
+    },
+    "perl-PathTools": {
+      "epoch": "0",
+      "version": "3.74",
+      "release": "1.el8",
+      "installdate": "1640302873",
+      "arch": "x86_64"
+    },
+    "perl-threads": {
+      "epoch": "1",
+      "version": "2.21",
+      "release": "2.el8",
+      "installdate": "1640302873",
+      "arch": "x86_64"
+    },
+    "perl-interpreter": {
+      "epoch": "4",
+      "version": "5.26.3",
+      "release": "421.el8",
+      "installdate": "1640302874",
+      "arch": "x86_64"
+    },
+    "perl-Time-HiRes": {
+      "epoch": "4",
+      "version": "1.9758",
+      "release": "2.el8",
+      "installdate": "1640302874",
+      "arch": "x86_64"
+    },
+    "perl-ExtUtils-Manifest": {
+      "epoch": "0",
+      "version": "1.70",
+      "release": "395.el8",
+      "installdate": "1640302874",
+      "arch": "noarch"
+    },
+    "perl-Test-Harness": {
+      "epoch": "1",
+      "version": "3.42",
+      "release": "1.el8",
+      "installdate": "1640302875",
+      "arch": "noarch"
+    },
+    "perl-Module-Metadata": {
+      "epoch": "0",
+      "version": "1.000033",
+      "release": "395.el8",
+      "installdate": "1640302875",
+      "arch": "noarch"
+    },
+    "perl-SelfLoader": {
+      "epoch": "0",
+      "version": "1.23",
+      "release": "421.el8",
+      "installdate": "1640302875",
+      "arch": "noarch"
+    },
+    "perl-Module-Load": {
+      "epoch": "1",
+      "version": "0.32",
+      "release": "395.el8",
+      "installdate": "1640302875",
+      "arch": "noarch"
+    },
+    "perl-Text-Balanced": {
+      "epoch": "0",
+      "version": "2.03",
+      "release": "395.el8",
+      "installdate": "1640302875",
+      "arch": "noarch"
+    },
+    "perl-Net-Ping": {
+      "epoch": "0",
+      "version": "2.55",
+      "release": "421.el8",
+      "installdate": "1640302875",
+      "arch": "noarch"
+    },
+    "perl-Digest-SHA": {
+      "epoch": "1",
+      "version": "6.02",
+      "release": "1.el8",
+      "installdate": "1640302875",
+      "arch": "x86_64"
+    },
+    "perl-Locale-Maketext": {
+      "epoch": "0",
+      "version": "1.28",
+      "release": "396.el8",
+      "installdate": "1640302875",
+      "arch": "noarch"
+    },
+    "perl-Params-Check": {
+      "epoch": "1",
+      "version": "0.38",
+      "release": "395.el8",
+      "installdate": "1640302875",
+      "arch": "noarch"
+    },
+    "perl-Params-Util": {
+      "epoch": "0",
+      "version": "1.07",
+      "release": "22.el8",
+      "installdate": "1640302875",
+      "arch": "x86_64"
+    },
+    "perl-Sub-Install": {
+      "epoch": "0",
+      "version": "0.928",
+      "release": "14.el8",
+      "installdate": "1640302875",
+      "arch": "noarch"
+    },
+    "perl-IO-Compress": {
+      "epoch": "0",
+      "version": "2.081",
+      "release": "1.el8",
+      "installdate": "1640302875",
+      "arch": "noarch"
+    },
+    "perl-Math-Complex": {
+      "epoch": "0",
+      "version": "1.59",
+      "release": "421.el8",
+      "installdate": "1640302875",
+      "arch": "noarch"
+    },
+    "perl-JSON-PP": {
+      "epoch": "1",
+      "version": "2.97.001",
+      "release": "3.el8",
+      "installdate": "1640302875",
+      "arch": "noarch"
+    },
+    "perl-Math-BigRat": {
+      "epoch": "0",
+      "version": "0.2614",
+      "release": "1.el8",
+      "installdate": "1640302875",
+      "arch": "noarch"
+    },
+    "python-rpm-macros": {
+      "epoch": "0",
+      "version": "3",
+      "release": "41.el8",
+      "installdate": "1640302877",
+      "arch": "noarch"
+    },
+    "perl-bignum": {
+      "epoch": "0",
+      "version": "0.49",
+      "release": "2.el8",
+      "installdate": "1640302877",
+      "arch": "noarch"
+    },
+    "perl-Data-OptList": {
+      "epoch": "0",
+      "version": "0.110",
+      "release": "6.el8",
+      "installdate": "1640302877",
+      "arch": "noarch"
+    },
+    "perl-Filter-Simple": {
+      "epoch": "0",
+      "version": "0.94",
+      "release": "2.el8",
+      "installdate": "1640302877",
+      "arch": "noarch"
+    },
+    "perl-Devel-SelfStubber": {
+      "epoch": "0",
+      "version": "1.06",
+      "release": "421.el8",
+      "installdate": "1640302877",
+      "arch": "noarch"
+    },
+    "perl-experimental": {
+      "epoch": "0",
+      "version": "0.019",
+      "release": "2.el8",
+      "installdate": "1640302877",
+      "arch": "noarch"
+    },
+    "perl-B-Debug": {
+      "epoch": "0",
+      "version": "1.26",
+      "release": "2.el8",
+      "installdate": "1640302877",
+      "arch": "noarch"
+    },
+    "perl-Config-Perl-V": {
+      "epoch": "0",
+      "version": "0.30",
+      "release": "1.el8",
+      "installdate": "1640302877",
+      "arch": "noarch"
+    },
+    "perl-Devel-PPPort": {
+      "epoch": "0",
+      "version": "3.36",
+      "release": "5.el8",
+      "installdate": "1640302877",
+      "arch": "x86_64"
+    },
+    "perl-Encode-Locale": {
+      "epoch": "0",
+      "version": "1.05",
+      "release": "10.module_el8.3.0+416+dee7bcef",
+      "installdate": "1640302877",
+      "arch": "noarch"
+    },
+    "perl-ExtUtils-MM-Utils": {
+      "epoch": "1",
+      "version": "7.34",
+      "release": "1.el8",
+      "installdate": "1640302877",
+      "arch": "noarch"
+    },
+    "perl-File-Fetch": {
+      "epoch": "0",
+      "version": "0.56",
+      "release": "2.el8",
+      "installdate": "1640302877",
+      "arch": "noarch"
+    },
+    "perl-IPC-System-Simple": {
+      "epoch": "0",
+      "version": "1.25",
+      "release": "17.el8",
+      "installdate": "1640302878",
+      "arch": "noarch"
+    },
+    "perl-Locale-Codes": {
+      "epoch": "0",
+      "version": "3.57",
+      "release": "1.el8",
+      "installdate": "1640302878",
+      "arch": "noarch"
+    },
+    "gnutls": {
+      "epoch": "0",
+      "version": "3.6.16",
+      "release": "4.el8",
+      "installdate": "1640302535",
+      "arch": "x86_64"
+    },
+    "geolite2-country": {
+      "epoch": "0",
+      "version": "20180605",
+      "release": "1.el8",
+      "installdate": "1640302501",
+      "arch": "noarch"
+    },
+    "perl-Sub-Exporter": {
+      "epoch": "0",
+      "version": "0.987",
+      "release": "15.el8",
+      "installdate": "1640302878",
+      "arch": "noarch"
+    },
+    "trousers": {
+      "epoch": "0",
+      "version": "0.3.15",
+      "release": "1.el8",
+      "installdate": "1640302537",
+      "arch": "x86_64"
+    },
+    "python3-pip-wheel": {
+      "epoch": "0",
+      "version": "9.0.3",
+      "release": "22.el8",
+      "installdate": "1640302504",
+      "arch": "noarch"
+    },
+    "perl-TermReadKey": {
+      "epoch": "0",
+      "version": "2.37",
+      "release": "7.el8",
+      "installdate": "1640302878",
+      "arch": "x86_64"
+    },
+    "libevent": {
+      "epoch": "0",
+      "version": "2.1.8",
+      "release": "5.el8",
+      "installdate": "1640302537",
+      "arch": "x86_64"
+    },
+    "publicsuffix-list-dafsa": {
+      "epoch": "0",
+      "version": "20180723",
+      "release": "1.el8",
+      "installdate": "1640302504",
+      "arch": "noarch"
+    },
+    "perl-Text-Template": {
+      "epoch": "0",
+      "version": "1.51",
+      "release": "1.el8",
+      "installdate": "1640302878",
+      "arch": "noarch"
+    },
+    "cronie-anacron": {
+      "epoch": "0",
+      "version": "1.5.2",
+      "release": "6.el8",
+      "installdate": "1640302537",
+      "arch": "x86_64"
+    },
+    "libreport-filesystem": {
+      "epoch": "0",
+      "version": "2.9.5",
+      "release": "15.el8",
+      "installdate": "1640302519",
+      "arch": "x86_64"
+    },
+    "perl-utils": {
+      "epoch": "0",
+      "version": "5.26.3",
+      "release": "421.el8",
+      "installdate": "1640302879",
+      "arch": "noarch"
+    },
+    "perl-Thread-Queue": {
+      "epoch": "0",
+      "version": "3.13",
+      "release": "1.el8",
+      "installdate": "1640302879",
+      "arch": "noarch"
+    },
+    "perl-MRO-Compat": {
+      "epoch": "0",
+      "version": "0.13",
+      "release": "4.el8",
+      "installdate": "1640302879",
+      "arch": "noarch"
+    },
+    "polkit-pkla-compat": {
+      "epoch": "0",
+      "version": "0.1",
+      "release": "12.el8",
+      "installdate": "1640302543",
+      "arch": "x86_64"
+    },
+    "pcre2": {
+      "epoch": "0",
+      "version": "10.32",
+      "release": "2.el8",
+      "installdate": "1640302520",
+      "arch": "x86_64"
+    },
+    "perl-perlfaq": {
+      "epoch": "0",
+      "version": "5.20180605",
+      "release": "1.el8",
+      "installdate": "1640302879",
+      "arch": "noarch"
+    },
+    "avahi-libs": {
+      "epoch": "0",
+      "version": "0.7",
+      "release": "20.el8",
+      "installdate": "1640302543",
+      "arch": "x86_64"
+    },
+    "systemtap-sdt-devel": {
+      "epoch": "0",
+      "version": "4.6",
+      "release": "4.el8",
+      "installdate": "1640302879",
+      "arch": "x86_64"
+    },
+    "libsepol": {
+      "epoch": "0",
+      "version": "2.9",
+      "release": "3.el8",
+      "installdate": "1640302521",
+      "arch": "x86_64"
+    },
+    "network-scripts-team": {
+      "epoch": "0",
+      "version": "1.31",
+      "release": "2.el8",
+      "installdate": "1640302543",
+      "arch": "x86_64"
+    },
+    "libcom_err": {
+      "epoch": "0",
+      "version": "1.45.6",
+      "release": "2.el8",
+      "installdate": "1640302521",
+      "arch": "x86_64"
+    },
+    "openblas-srpm-macros": {
+      "epoch": "0",
+      "version": "2",
+      "release": "2.el8",
+      "installdate": "1640302881",
+      "arch": "noarch"
+    },
+    "util-linux-user": {
+      "epoch": "0",
+      "version": "2.32.1",
+      "release": "28.el8",
+      "installdate": "1640302543",
+      "arch": "x86_64"
+    },
+    "sqlite-libs": {
+      "epoch": "0",
+      "version": "3.26.0",
+      "release": "15.el8",
+      "installdate": "1640302521",
+      "arch": "x86_64"
+    },
+    "python3-slip": {
+      "epoch": "0",
+      "version": "0.6.4",
+      "release": "11.el8",
+      "installdate": "1640302552",
+      "arch": "noarch"
+    },
+    "chkconfig": {
+      "epoch": "0",
+      "version": "1.19.1",
+      "release": "1.el8",
+      "installdate": "1640302522",
+      "arch": "x86_64"
+    },
+    "dwz": {
+      "epoch": "0",
+      "version": "0.12",
+      "release": "10.el8",
+      "installdate": "1640302883",
+      "arch": "x86_64"
+    },
+    "python3-unbound": {
+      "epoch": "0",
+      "version": "1.7.3",
+      "release": "17.el8",
+      "installdate": "1640302552",
+      "arch": "x86_64"
+    },
+    "readline": {
+      "epoch": "0",
+      "version": "7.0",
+      "release": "10.el8",
+      "installdate": "1640302522",
+      "arch": "x86_64"
+    },
+    "perl-ExtUtils-MakeMaker": {
+      "epoch": "1",
+      "version": "7.34",
+      "release": "1.el8",
+      "installdate": "1640302883",
+      "arch": "noarch"
+    },
+    "libattr": {
+      "epoch": "0",
+      "version": "2.4.48",
+      "release": "3.el8",
+      "installdate": "1640302522",
+      "arch": "x86_64"
+    },
+    "perl-libnetcfg": {
+      "epoch": "4",
+      "version": "5.26.3",
+      "release": "421.el8",
+      "installdate": "1640302883",
+      "arch": "noarch"
+    },
+    "gmp": {
+      "epoch": "1",
+      "version": "6.1.2",
+      "release": "10.el8",
+      "installdate": "1640302522",
+      "arch": "x86_64"
+    },
+    "perl-CPAN": {
+      "epoch": "0",
+      "version": "2.18",
+      "release": "397.el8",
+      "installdate": "1640302883",
+      "arch": "noarch"
+    },
+    "python3-dbus": {
+      "epoch": "0",
+      "version": "1.2.4",
+      "release": "15.el8",
+      "installdate": "1640302554",
+      "arch": "x86_64"
+    },
+    "lua-libs": {
+      "epoch": "0",
+      "version": "5.3.4",
+      "release": "12.el8",
+      "installdate": "1640302522",
+      "arch": "x86_64"
+    },
+    "glibc-common": {
+      "epoch": "0",
+      "version": "2.28",
+      "release": "184.el8",
+      "installdate": "1643238282",
+      "arch": "x86_64"
+    },
+    "libsecret": {
+      "epoch": "0",
+      "version": "0.18.6",
+      "release": "1.el8",
+      "installdate": "1640302554",
+      "arch": "x86_64"
+    },
+    "libidn2": {
+      "epoch": "0",
+      "version": "2.2.0",
+      "release": "1.el8",
+      "installdate": "1640302522",
+      "arch": "x86_64"
+    },
+    "platform-python": {
+      "epoch": "0",
+      "version": "3.6.8",
+      "release": "45.el8",
+      "installdate": "1643238284",
+      "arch": "x86_64"
+    },
+    "libnl3": {
+      "epoch": "0",
+      "version": "3.5.0",
+      "release": "1.el8",
+      "installdate": "1640302522",
+      "arch": "x86_64"
+    },
+    "systemd-pam": {
+      "epoch": "0",
+      "version": "239",
+      "release": "55.el8",
+      "installdate": "1643238292",
+      "arch": "x86_64"
+    },
+    "libassuan": {
+      "epoch": "0",
+      "version": "2.5.1",
+      "release": "3.el8",
+      "installdate": "1640302522",
+      "arch": "x86_64"
+    },
+    "rpm-plugin-selinux": {
+      "epoch": "0",
+      "version": "4.14.3",
+      "release": "21.el8",
+      "installdate": "1643238293",
+      "arch": "x86_64"
+    },
+    "libusbx": {
+      "epoch": "0",
+      "version": "1.0.23",
+      "release": "4.el8",
+      "installdate": "1640302555",
+      "arch": "x86_64"
+    },
+    "jansson": {
+      "epoch": "0",
+      "version": "2.14",
+      "release": "1.el8",
+      "installdate": "1640302523",
+      "arch": "x86_64"
+    },
+    "NetworkManager-libnm": {
+      "epoch": "1",
+      "version": "1.36.0",
+      "release": "0.4.el8",
+      "installdate": "1643238373",
+      "arch": "x86_64"
+    },
+    "librepo": {
+      "epoch": "0",
+      "version": "1.14.2",
+      "release": "1.el8",
+      "installdate": "1640302555",
+      "arch": "x86_64"
+    },
+    "libref_array": {
+      "epoch": "0",
+      "version": "0.1.5",
+      "release": "39.el8",
+      "installdate": "1640302523",
+      "arch": "x86_64"
+    },
+    "policycoreutils-python-utils": {
+      "epoch": "0",
+      "version": "2.9",
+      "release": "18.el8",
+      "installdate": "1643238376",
+      "arch": "noarch"
+    },
+    "python3-gpg": {
+      "epoch": "0",
+      "version": "1.13.1",
+      "release": "9.el8",
+      "installdate": "1640302555",
+      "arch": "x86_64"
+    },
+    "nettle": {
+      "epoch": "0",
+      "version": "3.4.1",
+      "release": "7.el8",
+      "installdate": "1640302523",
+      "arch": "x86_64"
+    },
+    "device-mapper-libs": {
+      "epoch": "8",
+      "version": "1.02.181",
+      "release": "2.el8",
+      "installdate": "1643238390",
+      "arch": "x86_64"
+    },
+    "plymouth-scripts": {
+      "epoch": "0",
+      "version": "0.9.4",
+      "release": "10.20200615git1e36e30.el8",
+      "installdate": "1640302555",
+      "arch": "x86_64"
+    },
+    "gdbm-libs": {
+      "epoch": "1",
+      "version": "1.18",
+      "release": "1.el8",
+      "installdate": "1640302523",
+      "arch": "x86_64"
+    },
+    "dmidecode": {
+      "epoch": "1",
+      "version": "3.3",
+      "release": "1.el8",
+      "installdate": "1643238391",
+      "arch": "x86_64"
+    },
+    "nss-sysinit": {
+      "epoch": "0",
+      "version": "3.67.0",
+      "release": "7.el8_5",
+      "installdate": "1640302556",
+      "arch": "x86_64"
+    },
+    "libpsl": {
+      "epoch": "0",
+      "version": "0.20.2",
+      "release": "6.el8",
+      "installdate": "1640302523",
+      "arch": "x86_64"
+    },
+    "libsss_nss_idmap": {
+      "epoch": "0",
+      "version": "2.6.1",
+      "release": "2.el8",
+      "installdate": "1643238391",
+      "arch": "x86_64"
+    },
+    "libksba": {
+      "epoch": "0",
+      "version": "1.3.5",
+      "release": "7.el8",
+      "installdate": "1640302523",
+      "arch": "x86_64"
+    },
+    "sssd-nfs-idmap": {
+      "epoch": "0",
+      "version": "2.6.1",
+      "release": "2.el8",
+      "installdate": "1643238392",
+      "arch": "x86_64"
+    },
+    "python3-libcomps": {
+      "epoch": "0",
+      "version": "0.1.18",
+      "release": "1.el8",
+      "installdate": "1640302557",
+      "arch": "x86_64"
+    },
+    "checkpolicy": {
+      "epoch": "0",
+      "version": "2.9",
+      "release": "1.el8",
+      "installdate": "1640302523",
+      "arch": "x86_64"
+    },
+    "libnfnetlink": {
+      "epoch": "0",
+      "version": "1.0.1",
+      "release": "13.el8",
+      "installdate": "1640302523",
+      "arch": "x86_64"
+    },
+    "sssd-kcm": {
+      "epoch": "0",
+      "version": "2.6.1",
+      "release": "2.el8",
+      "installdate": "1643238446",
+      "arch": "x86_64"
+    },
+    "python3-firewall": {
+      "epoch": "0",
+      "version": "0.9.3",
+      "release": "11.el8",
+      "installdate": "1640302565",
+      "arch": "noarch"
+    },
+    "p11-kit-trust": {
+      "epoch": "0",
+      "version": "0.23.22",
+      "release": "1.el8",
+      "installdate": "1640302523",
+      "arch": "x86_64"
+    },
+    "yum-utils": {
+      "epoch": "0",
+      "version": "4.0.21",
+      "release": "8.el8",
+      "installdate": "1643238449",
+      "arch": "noarch"
+    },
+    "tuned": {
+      "epoch": "0",
+      "version": "2.16.0",
+      "release": "1.el8",
+      "installdate": "1640302565",
+      "arch": "noarch"
+    },
+    "pciutils-libs": {
+      "epoch": "0",
+      "version": "3.7.0",
+      "release": "1.el8",
+      "installdate": "1640302523",
+      "arch": "x86_64"
+    },
+    "rpm-plugin-systemd-inhibit": {
+      "epoch": "0",
+      "version": "4.14.3",
+      "release": "21.el8",
+      "installdate": "1643238449",
+      "arch": "x86_64"
+    },
+    "yum": {
+      "epoch": "0",
+      "version": "4.7.0",
+      "release": "5.el8",
+      "installdate": "1640302566",
+      "arch": "noarch"
+    },
+    "xz": {
+      "epoch": "0",
+      "version": "5.2.4",
+      "release": "3.el8",
+      "installdate": "1640302524",
+      "arch": "x86_64"
+    },
+    "iputils": {
+      "epoch": "0",
+      "version": "20180629",
+      "release": "8.el8",
+      "installdate": "1643238450",
+      "arch": "x86_64"
+    },
+    "gdbm": {
+      "epoch": "1",
+      "version": "1.18",
+      "release": "1.el8",
+      "installdate": "1640302524",
+      "arch": "x86_64"
+    },
+    "python3-linux-procfs": {
+      "epoch": "0",
+      "version": "0.7.0",
+      "release": "1.el8",
+      "installdate": "1643238455",
+      "arch": "noarch"
+    },
+    "chrony": {
+      "epoch": "0",
+      "version": "4.1",
+      "release": "1.el8",
+      "installdate": "1640302566",
+      "arch": "x86_64"
+    },
+    "libpcap": {
+      "epoch": "14",
+      "version": "1.9.1",
+      "release": "5.el8",
+      "installdate": "1640302524",
+      "arch": "x86_64"
+    },
+    "vim-minimal": {
+      "epoch": "2",
+      "version": "8.0.1763",
+      "release": "16.el8_5.3",
+      "installdate": "1643238457",
+      "arch": "x86_64"
+    },
+    "openssh-server": {
+      "epoch": "0",
+      "version": "8.0p1",
+      "release": "12.el8",
+      "installdate": "1640302567",
+      "arch": "x86_64"
+    },
+    "nftables": {
+      "epoch": "1",
+      "version": "0.9.3",
+      "release": "24.el8",
+      "installdate": "1640302524",
+      "arch": "x86_64"
+    },
+    "irqbalance": {
+      "epoch": "2",
+      "version": "1.4.0",
+      "release": "6.el8",
+      "installdate": "1640302567",
+      "arch": "x86_64"
+    },
+    "ipset-libs": {
+      "epoch": "0",
+      "version": "7.1",
+      "release": "1.el8",
+      "installdate": "1640302524",
+      "arch": "x86_64"
+    },
+    "xfsprogs": {
+      "epoch": "0",
+      "version": "5.0.0",
+      "release": "10.el8",
+      "installdate": "1640302567",
+      "arch": "x86_64"
+    },
+    "spax": {
+      "epoch": "0",
+      "version": "1.5.3",
+      "release": "13.el8",
+      "installdate": "1640302525",
+      "arch": "x86_64"
+    },
+    "libcomps": {
+      "epoch": "0",
+      "version": "0.1.18",
+      "release": "1.el8",
+      "installdate": "1640302525",
+      "arch": "x86_64"
+    },
+    "bzip2": {
+      "epoch": "0",
+      "version": "1.0.6",
+      "release": "26.el8",
+      "installdate": "1640302568",
+      "arch": "x86_64"
+    },
+    "ncurses-compat-libs": {
+      "epoch": "0",
+      "version": "6.1",
+      "release": "9.20180224.el8",
+      "installdate": "1640302527",
+      "arch": "x86_64"
+    },
+    "langpacks-en": {
+      "epoch": "0",
+      "version": "1.0",
+      "release": "12.el8",
+      "installdate": "1640302568",
+      "arch": "noarch"
+    },
+    "coreutils-common": {
+      "epoch": "0",
+      "version": "8.30",
+      "release": "12.el8",
+      "installdate": "1640302527",
+      "arch": "x86_64"
+    },
+    "perl-Digest-MD5": {
+      "epoch": "0",
+      "version": "2.55",
+      "release": "396.el8",
+      "installdate": "1640302871",
+      "arch": "x86_64"
+    },
+    "freetype": {
+      "epoch": "0",
+      "version": "2.9.1",
+      "release": "4.el8_3.1",
+      "installdate": "1640302527",
+      "arch": "x86_64"
+    },
+    "perl-URI": {
+      "epoch": "0",
+      "version": "1.73",
+      "release": "3.el8",
+      "installdate": "1640302871",
+      "arch": "noarch"
+    },
+    "less": {
+      "epoch": "0",
+      "version": "530",
+      "release": "1.el8",
+      "installdate": "1640302527",
+      "arch": "x86_64"
+    },
+    "perl-Time-Local": {
+      "epoch": "1",
+      "version": "1.280",
+      "release": "1.el8",
+      "installdate": "1640302871",
+      "arch": "noarch"
+    },
+    "hardlink": {
+      "epoch": "1",
+      "version": "1.3",
+      "release": "6.el8",
+      "installdate": "1640302527",
+      "arch": "x86_64"
+    },
+    "perl-File-Temp": {
+      "epoch": "0",
+      "version": "0.230.600",
+      "release": "1.el8",
+      "installdate": "1640302871",
+      "arch": "noarch"
+    },
+    "libnghttp2": {
+      "epoch": "0",
+      "version": "1.33.0",
+      "release": "3.el8_2.1",
+      "installdate": "1640302527",
+      "arch": "x86_64"
+    },
+    "perl-Pod-Perldoc": {
+      "epoch": "0",
+      "version": "3.28",
+      "release": "396.el8",
+      "installdate": "1640302872",
+      "arch": "noarch"
+    },
+    "perl-Storable": {
+      "epoch": "1",
+      "version": "3.11",
+      "release": "3.el8",
+      "installdate": "1640302872",
+      "arch": "x86_64"
+    },
+    "libsigsegv": {
+      "epoch": "0",
+      "version": "2.11",
+      "release": "5.el8",
+      "installdate": "1640302527",
+      "arch": "x86_64"
+    },
+    "perl-Encode": {
+      "epoch": "4",
+      "version": "2.97",
+      "release": "3.el8",
+      "installdate": "1640302872",
+      "arch": "x86_64"
+    },
+    "perl-Scalar-List-Utils": {
+      "epoch": "3",
+      "version": "1.49",
+      "release": "2.el8",
+      "installdate": "1640302873",
+      "arch": "x86_64"
+    },
+    "npth": {
+      "epoch": "0",
+      "version": "1.5",
+      "release": "4.el8",
+      "installdate": "1640302528",
+      "arch": "x86_64"
+    },
+    "perl-Unicode-Normalize": {
+      "epoch": "0",
+      "version": "1.25",
+      "release": "396.el8",
+      "installdate": "1640302873",
+      "arch": "x86_64"
+    },
+    "libestr": {
+      "epoch": "0",
+      "version": "0.1.10",
+      "release": "1.el8",
+      "installdate": "1640302528",
+      "arch": "x86_64"
+    },
+    "perl-constant": {
+      "epoch": "0",
+      "version": "1.33",
+      "release": "396.el8",
+      "installdate": "1640302873",
+      "arch": "noarch"
+    },
+    "libxkbcommon": {
+      "epoch": "0",
+      "version": "0.9.1",
+      "release": "1.el8",
+      "installdate": "1640302528",
+      "arch": "x86_64"
+    },
+    "perl-version": {
+      "epoch": "6",
+      "version": "0.99.24",
+      "release": "1.el8",
+      "installdate": "1640302874",
+      "arch": "x86_64"
+    },
+    "perl-ExtUtils-ParseXS": {
+      "epoch": "1",
+      "version": "3.35",
+      "release": "2.el8",
+      "installdate": "1640302874",
+      "arch": "noarch"
+    },
+    "perl-Filter": {
+      "epoch": "2",
+      "version": "1.58",
+      "release": "2.el8",
+      "installdate": "1640302875",
+      "arch": "x86_64"
+    },
+    "libarchive": {
+      "epoch": "0",
+      "version": "3.3.3",
+      "release": "1.el8",
+      "installdate": "1640302531",
+      "arch": "x86_64"
+    },
+    "perl-Perl-OSType": {
+      "epoch": "0",
+      "version": "1.010",
+      "release": "396.el8",
+      "installdate": "1640302875",
+      "arch": "noarch"
+    },
+    "openssl": {
+      "epoch": "1",
+      "version": "1.1.1k",
+      "release": "5.el8_5",
+      "installdate": "1640302531",
+      "arch": "x86_64"
+    },
+    "perl-CPAN-Meta-YAML": {
+      "epoch": "0",
+      "version": "0.018",
+      "release": "397.el8",
+      "installdate": "1640302875",
+      "arch": "noarch"
+    },
+    "gzip": {
+      "epoch": "0",
+      "version": "1.9",
+      "release": "12.el8",
+      "installdate": "1640302531",
+      "arch": "x86_64"
+    },
+    "perl-Locale-Maketext-Simple": {
+      "epoch": "1",
+      "version": "0.21",
+      "release": "421.el8",
+      "installdate": "1640302875",
+      "arch": "noarch"
+    },
+    "krb5-libs": {
+      "epoch": "0",
+      "version": "1.18.2",
+      "release": "14.el8",
+      "installdate": "1640302532",
+      "arch": "x86_64"
+    },
+    "perl-Pod-Html": {
+      "epoch": "0",
+      "version": "1.22.02",
+      "release": "421.el8",
+      "installdate": "1640302875",
+      "arch": "noarch"
+    },
+    "perl-IO-Zlib": {
+      "epoch": "1",
+      "version": "1.10",
+      "release": "421.el8",
+      "installdate": "1640302875",
+      "arch": "noarch"
+    },
+    "perl-CPAN-Meta": {
+      "epoch": "0",
+      "version": "2.150010",
+      "release": "396.el8",
+      "installdate": "1640302875",
+      "arch": "noarch"
+    },
+    "libfdisk": {
+      "epoch": "0",
+      "version": "2.32.1",
+      "release": "28.el8",
+      "installdate": "1640302532",
+      "arch": "x86_64"
+    },
+    "which": {
+      "epoch": "0",
+      "version": "2.21",
+      "release": "17.el8",
+      "installdate": "1640302532",
+      "arch": "x86_64"
+    },
+    "perl-Math-BigInt-FastCalc": {
+      "epoch": "0",
+      "version": "0.500.600",
+      "release": "6.el8",
+      "installdate": "1640302877",
+      "arch": "x86_64"
+    },
+    "libblkid": {
+      "epoch": "0",
+      "version": "2.32.1",
+      "release": "28.el8",
+      "installdate": "1640302533",
+      "arch": "x86_64"
+    },
+    "perl-Archive-Zip": {
+      "epoch": "0",
+      "version": "1.60",
+      "release": "3.el8",
+      "installdate": "1640302877",
+      "arch": "noarch"
+    },
+    "libdb": {
+      "epoch": "0",
+      "version": "5.3.28",
+      "release": "42.el8_4",
+      "installdate": "1640302533",
+      "arch": "x86_64"
+    },
+    "perl-Attribute-Handlers": {
+      "epoch": "0",
+      "version": "0.99",
+      "release": "421.el8",
+      "installdate": "1640302877",
+      "arch": "noarch"
+    },
+    "cryptsetup-libs": {
+      "epoch": "0",
+      "version": "2.3.3",
+      "release": "4.el8",
+      "installdate": "1640302534",
+      "arch": "x86_64"
+    },
+    "perl-DB_File": {
+      "epoch": "0",
+      "version": "1.842",
+      "release": "1.el8",
+      "installdate": "1640302877",
+      "arch": "x86_64"
+    },
+    "kbd": {
+      "epoch": "0",
+      "version": "2.0.4",
+      "release": "10.el8",
+      "installdate": "1640302534",
+      "arch": "x86_64"
+    },
+    "perl-Env": {
+      "epoch": "0",
+      "version": "1.04",
+      "release": "395.el8",
+      "installdate": "1640302877",
+      "arch": "noarch"
+    },
+    "perl-IPC-SysV": {
+      "epoch": "0",
+      "version": "2.07",
+      "release": "397.el8",
+      "installdate": "1640302878",
+      "arch": "x86_64"
+    },
+    "grub2-tools": {
+      "epoch": "1",
+      "version": "2.02",
+      "release": "106.el8",
+      "installdate": "1640302535",
+      "arch": "x86_64"
+    }
+  },
+  "platform": "centos",
+  "platform_family": "rhel",
+  "platform_version": "8",
+  "root_group": "root",
+  "shard_seed": 246944626,
+  "shells": [
+    "/bin/sh",
+    "/bin/bash",
+    "/usr/bin/sh",
+    "/usr/bin/bash"
+  ],
+  "time": {
+    "timezone": "GMT"
+  },
+  "uptime": "30 days 15 hours 07 minutes 30 seconds",
+  "uptime_seconds": 2646450,
+  "virtualization": {
+    "systems": {
+    }
+  }
+}

--- a/lib/fauxhai/platforms/centos-stream/9.json
+++ b/lib/fauxhai/platforms/centos-stream/9.json
@@ -1,0 +1,4001 @@
+{
+  "block_device": {
+    "sda": {
+      "size": "134217728",
+      "removable": "0",
+      "model": "VBOX HARDDISK",
+      "rev": "1.0",
+      "state": "running",
+      "timeout": "30",
+      "vendor": "ATA",
+      "queue_depth": "32",
+      "rotational": "1",
+      "physical_block_size": "512",
+      "logical_block_size": "512"
+    }
+  },
+  "chef_packages": {
+    "chef": {
+      "version": "18.1.0",
+      "chef_root": "/opt/chef/embedded/lib/ruby/gems/3.1.0/gems/chef-18.1.0/lib",
+      "chef_effortless": null
+    },
+    "ohai": {
+      "version": "18.0.26",
+      "ohai_root": "/opt/chef/embedded/lib/ruby/gems/3.1.0/gems/ohai-18.0.26/lib/ohai"
+    }
+  },
+  "command": {
+    "ps": "ps -ef"
+  },
+  "counters": {
+    "network": {
+      "interfaces": {
+        "lo": {
+          "tx": {
+            "queuelen": "1",
+            "bytes": 0,
+            "packets": 0,
+            "errors": 0,
+            "drop": 0,
+            "carrier": 0,
+            "collisions": 0
+          },
+          "rx": {
+            "bytes": 0,
+            "packets": 0,
+            "errors": 0,
+            "drop": 0,
+            "overrun": 0
+          }
+        },
+        "eth0": {
+          "rx": {
+            "bytes": 0,
+            "packets": 0,
+            "errors": 0,
+            "drop": 0,
+            "overrun": 0,
+            "frame": 0,
+            "compressed": 0,
+            "multicast": 0
+          },
+          "tx": {
+            "bytes": 0,
+            "packets": 0,
+            "errors": 0,
+            "drop": 0,
+            "overrun": 0,
+            "collisions": 0,
+            "carrier": 0,
+            "compressed": 0
+          }
+        }
+      }
+    }
+  },
+  "cpu": {
+    "real": 1,
+    "total": 1,
+    "cores": 1
+  },
+  "current_user": "fauxhai",
+  "dmi": {
+  },
+  "domain": "local",
+  "filesystem": {
+    "by_device": {
+      "devtmpfs": {
+        "kb_size": "4096",
+        "kb_used": "0",
+        "kb_available": "4096",
+        "percent_used": "0%",
+        "total_inodes": "464128",
+        "inodes_used": "355",
+        "inodes_available": "463773",
+        "inodes_percent_used": "1%",
+        "fs_type": "devtmpfs",
+        "mount_options": [
+          "rw",
+          "nosuid",
+          "seclabel",
+          "size=4096k",
+          "nr_inodes=464128",
+          "mode=755",
+          "inode64"
+        ],
+        "mounts": [
+          "/dev"
+        ]
+      },
+      "tmpfs": {
+        "kb_size": "375012",
+        "kb_used": "0",
+        "kb_available": "375012",
+        "percent_used": "0%",
+        "total_inodes": "93753",
+        "inodes_used": "14",
+        "inodes_available": "93739",
+        "inodes_percent_used": "1%",
+        "fs_type": "tmpfs",
+        "mount_options": [
+          "rw",
+          "nosuid",
+          "nodev",
+          "relatime",
+          "seclabel",
+          "size=375012k",
+          "nr_inodes=93753",
+          "mode=700",
+          "uid=1000",
+          "gid=1000",
+          "inode64"
+        ],
+        "mounts": [
+          "/dev/shm",
+          "/run",
+          "/run/user/1000"
+        ]
+      },
+      "/dev/sda2": {
+        "kb_size": "64926748",
+        "kb_used": "1516856",
+        "kb_available": "63409892",
+        "percent_used": "3%",
+        "total_inodes": "32479232",
+        "inodes_used": "38483",
+        "inodes_available": "32440749",
+        "inodes_percent_used": "1%",
+        "fs_type": "xfs",
+        "mount_options": [
+          "rw",
+          "relatime",
+          "seclabel",
+          "attr2",
+          "inode64",
+          "logbufs=8",
+          "logbsize=32k",
+          "noquota"
+        ],
+        "uuid": "47919001-bd02-4834-b40c-25052d8c886c",
+        "mounts": [
+          "/"
+        ]
+      },
+      "vagrant": {
+        "kb_size": "492054648",
+        "kb_used": "396776216",
+        "kb_available": "95278432",
+        "percent_used": "81%",
+        "fs_type": "vboxsf",
+        "mount_options": [
+          "rw",
+          "nodev",
+          "relatime",
+          "iocharset=utf8",
+          "uid=1000",
+          "gid=1000",
+          "_netdev"
+        ],
+        "mounts": [
+          "/vagrant"
+        ]
+      },
+      "proc": {
+        "fs_type": "proc",
+        "mount_options": [
+          "rw",
+          "nosuid",
+          "nodev",
+          "noexec",
+          "relatime"
+        ],
+        "mounts": [
+          "/proc"
+        ]
+      },
+      "sysfs": {
+        "fs_type": "sysfs",
+        "mount_options": [
+          "rw",
+          "nosuid",
+          "nodev",
+          "noexec",
+          "relatime",
+          "seclabel"
+        ],
+        "mounts": [
+          "/sys"
+        ]
+      },
+      "securityfs": {
+        "fs_type": "securityfs",
+        "mount_options": [
+          "rw",
+          "nosuid",
+          "nodev",
+          "noexec",
+          "relatime"
+        ],
+        "mounts": [
+          "/sys/kernel/security"
+        ]
+      },
+      "devpts": {
+        "fs_type": "devpts",
+        "mount_options": [
+          "rw",
+          "nosuid",
+          "noexec",
+          "relatime",
+          "seclabel",
+          "gid=5",
+          "mode=620",
+          "ptmxmode=000"
+        ],
+        "mounts": [
+          "/dev/pts"
+        ]
+      },
+      "cgroup2": {
+        "fs_type": "cgroup2",
+        "mount_options": [
+          "rw",
+          "nosuid",
+          "nodev",
+          "noexec",
+          "relatime",
+          "seclabel",
+          "nsdelegate",
+          "memory_recursiveprot"
+        ],
+        "mounts": [
+          "/sys/fs/cgroup"
+        ]
+      },
+      "pstore": {
+        "fs_type": "pstore",
+        "mount_options": [
+          "rw",
+          "nosuid",
+          "nodev",
+          "noexec",
+          "relatime",
+          "seclabel"
+        ],
+        "mounts": [
+          "/sys/fs/pstore"
+        ]
+      },
+      "bpf": {
+        "fs_type": "bpf",
+        "mount_options": [
+          "rw",
+          "nosuid",
+          "nodev",
+          "noexec",
+          "relatime",
+          "mode=700"
+        ],
+        "mounts": [
+          "/sys/fs/bpf"
+        ]
+      },
+      "selinuxfs": {
+        "fs_type": "selinuxfs",
+        "mount_options": [
+          "rw",
+          "nosuid",
+          "noexec",
+          "relatime"
+        ],
+        "mounts": [
+          "/sys/fs/selinux"
+        ]
+      },
+      "systemd-1": {
+        "fs_type": "autofs",
+        "mount_options": [
+          "rw",
+          "relatime",
+          "fd=29",
+          "pgrp=1",
+          "timeout=0",
+          "minproto=5",
+          "maxproto=5",
+          "direct",
+          "pipe_ino=18057"
+        ],
+        "mounts": [
+          "/proc/sys/fs/binfmt_misc"
+        ]
+      },
+      "mqueue": {
+        "fs_type": "mqueue",
+        "mount_options": [
+          "rw",
+          "nosuid",
+          "nodev",
+          "noexec",
+          "relatime",
+          "seclabel"
+        ],
+        "mounts": [
+          "/dev/mqueue"
+        ]
+      },
+      "hugetlbfs": {
+        "fs_type": "hugetlbfs",
+        "mount_options": [
+          "rw",
+          "relatime",
+          "seclabel",
+          "pagesize=2M"
+        ],
+        "mounts": [
+          "/dev/hugepages"
+        ]
+      },
+      "debugfs": {
+        "fs_type": "debugfs",
+        "mount_options": [
+          "rw",
+          "nosuid",
+          "nodev",
+          "noexec",
+          "relatime",
+          "seclabel"
+        ],
+        "mounts": [
+          "/sys/kernel/debug"
+        ]
+      },
+      "tracefs": {
+        "fs_type": "tracefs",
+        "mount_options": [
+          "rw",
+          "nosuid",
+          "nodev",
+          "noexec",
+          "relatime",
+          "seclabel"
+        ],
+        "mounts": [
+          "/sys/kernel/tracing"
+        ]
+      },
+      "none": {
+        "fs_type": "ramfs",
+        "mount_options": [
+          "ro",
+          "nosuid",
+          "nodev",
+          "noexec",
+          "relatime",
+          "seclabel",
+          "mode=700"
+        ],
+        "mounts": [
+          "/run/credentials/systemd-sysctl.service",
+          "/run/credentials/systemd-tmpfiles-setup-dev.service",
+          "/run/credentials/systemd-tmpfiles-setup.service"
+        ]
+      },
+      "configfs": {
+        "fs_type": "configfs",
+        "mount_options": [
+          "rw",
+          "nosuid",
+          "nodev",
+          "noexec",
+          "relatime"
+        ],
+        "mounts": [
+          "/sys/kernel/config"
+        ]
+      },
+      "fusectl": {
+        "fs_type": "fusectl",
+        "mount_options": [
+          "rw",
+          "nosuid",
+          "nodev",
+          "noexec",
+          "relatime"
+        ],
+        "mounts": [
+          "/sys/fs/fuse/connections"
+        ]
+      },
+      "sunrpc": {
+        "fs_type": "rpc_pipefs",
+        "mount_options": [
+          "rw",
+          "relatime"
+        ],
+        "mounts": [
+          "/var/lib/nfs/rpc_pipefs"
+        ]
+      },
+      "/dev/sda": {
+        "mounts": [
+
+        ]
+      },
+      "/dev/sda1": {
+        "fs_type": "swap",
+        "uuid": "69a4d716-0761-40cc-ad0f-e33d91a53b93",
+        "mounts": [
+
+        ]
+      }
+    },
+    "by_mountpoint": {
+      "/dev": {
+        "kb_size": "4096",
+        "kb_used": "0",
+        "kb_available": "4096",
+        "percent_used": "0%",
+        "total_inodes": "464128",
+        "inodes_used": "355",
+        "inodes_available": "463773",
+        "inodes_percent_used": "1%",
+        "fs_type": "devtmpfs",
+        "mount_options": [
+          "rw",
+          "nosuid",
+          "seclabel",
+          "size=4096k",
+          "nr_inodes=464128",
+          "mode=755",
+          "inode64"
+        ],
+        "devices": [
+          "devtmpfs"
+        ]
+      },
+      "/dev/shm": {
+        "kb_size": "1875072",
+        "kb_used": "0",
+        "kb_available": "1875072",
+        "percent_used": "0%",
+        "total_inodes": "468768",
+        "inodes_used": "1",
+        "inodes_available": "468767",
+        "inodes_percent_used": "1%",
+        "fs_type": "tmpfs",
+        "mount_options": [
+          "rw",
+          "nosuid",
+          "nodev",
+          "seclabel",
+          "inode64"
+        ],
+        "devices": [
+          "tmpfs"
+        ]
+      },
+      "/run": {
+        "kb_size": "750032",
+        "kb_used": "16868",
+        "kb_available": "733164",
+        "percent_used": "3%",
+        "total_inodes": "819200",
+        "inodes_used": "533",
+        "inodes_available": "818667",
+        "inodes_percent_used": "1%",
+        "fs_type": "tmpfs",
+        "mount_options": [
+          "rw",
+          "nosuid",
+          "nodev",
+          "seclabel",
+          "size=750032k",
+          "nr_inodes=819200",
+          "mode=755",
+          "inode64"
+        ],
+        "devices": [
+          "tmpfs"
+        ]
+      },
+      "/": {
+        "kb_size": "64926748",
+        "kb_used": "1516856",
+        "kb_available": "63409892",
+        "percent_used": "3%",
+        "total_inodes": "32479232",
+        "inodes_used": "38483",
+        "inodes_available": "32440749",
+        "inodes_percent_used": "1%",
+        "fs_type": "xfs",
+        "mount_options": [
+          "rw",
+          "relatime",
+          "seclabel",
+          "attr2",
+          "inode64",
+          "logbufs=8",
+          "logbsize=32k",
+          "noquota"
+        ],
+        "uuid": "47919001-bd02-4834-b40c-25052d8c886c",
+        "devices": [
+          "/dev/sda2"
+        ]
+      },
+      "/vagrant": {
+        "kb_size": "492054648",
+        "kb_used": "396776216",
+        "kb_available": "95278432",
+        "percent_used": "81%",
+        "fs_type": "vboxsf",
+        "mount_options": [
+          "rw",
+          "nodev",
+          "relatime",
+          "iocharset=utf8",
+          "uid=1000",
+          "gid=1000",
+          "_netdev"
+        ],
+        "devices": [
+          "vagrant"
+        ]
+      },
+      "/run/user/1000": {
+        "kb_size": "375012",
+        "kb_used": "0",
+        "kb_available": "375012",
+        "percent_used": "0%",
+        "total_inodes": "93753",
+        "inodes_used": "14",
+        "inodes_available": "93739",
+        "inodes_percent_used": "1%",
+        "fs_type": "tmpfs",
+        "mount_options": [
+          "rw",
+          "nosuid",
+          "nodev",
+          "relatime",
+          "seclabel",
+          "size=375012k",
+          "nr_inodes=93753",
+          "mode=700",
+          "uid=1000",
+          "gid=1000",
+          "inode64"
+        ],
+        "devices": [
+          "tmpfs"
+        ]
+      },
+      "/proc": {
+        "fs_type": "proc",
+        "mount_options": [
+          "rw",
+          "nosuid",
+          "nodev",
+          "noexec",
+          "relatime"
+        ],
+        "devices": [
+          "proc"
+        ]
+      },
+      "/sys": {
+        "fs_type": "sysfs",
+        "mount_options": [
+          "rw",
+          "nosuid",
+          "nodev",
+          "noexec",
+          "relatime",
+          "seclabel"
+        ],
+        "devices": [
+          "sysfs"
+        ]
+      },
+      "/sys/kernel/security": {
+        "fs_type": "securityfs",
+        "mount_options": [
+          "rw",
+          "nosuid",
+          "nodev",
+          "noexec",
+          "relatime"
+        ],
+        "devices": [
+          "securityfs"
+        ]
+      },
+      "/dev/pts": {
+        "fs_type": "devpts",
+        "mount_options": [
+          "rw",
+          "nosuid",
+          "noexec",
+          "relatime",
+          "seclabel",
+          "gid=5",
+          "mode=620",
+          "ptmxmode=000"
+        ],
+        "devices": [
+          "devpts"
+        ]
+      },
+      "/sys/fs/cgroup": {
+        "fs_type": "cgroup2",
+        "mount_options": [
+          "rw",
+          "nosuid",
+          "nodev",
+          "noexec",
+          "relatime",
+          "seclabel",
+          "nsdelegate",
+          "memory_recursiveprot"
+        ],
+        "devices": [
+          "cgroup2"
+        ]
+      },
+      "/sys/fs/pstore": {
+        "fs_type": "pstore",
+        "mount_options": [
+          "rw",
+          "nosuid",
+          "nodev",
+          "noexec",
+          "relatime",
+          "seclabel"
+        ],
+        "devices": [
+          "pstore"
+        ]
+      },
+      "/sys/fs/bpf": {
+        "fs_type": "bpf",
+        "mount_options": [
+          "rw",
+          "nosuid",
+          "nodev",
+          "noexec",
+          "relatime",
+          "mode=700"
+        ],
+        "devices": [
+          "bpf"
+        ]
+      },
+      "/sys/fs/selinux": {
+        "fs_type": "selinuxfs",
+        "mount_options": [
+          "rw",
+          "nosuid",
+          "noexec",
+          "relatime"
+        ],
+        "devices": [
+          "selinuxfs"
+        ]
+      },
+      "/proc/sys/fs/binfmt_misc": {
+        "fs_type": "autofs",
+        "mount_options": [
+          "rw",
+          "relatime",
+          "fd=29",
+          "pgrp=1",
+          "timeout=0",
+          "minproto=5",
+          "maxproto=5",
+          "direct",
+          "pipe_ino=18057"
+        ],
+        "devices": [
+          "systemd-1"
+        ]
+      },
+      "/dev/mqueue": {
+        "fs_type": "mqueue",
+        "mount_options": [
+          "rw",
+          "nosuid",
+          "nodev",
+          "noexec",
+          "relatime",
+          "seclabel"
+        ],
+        "devices": [
+          "mqueue"
+        ]
+      },
+      "/dev/hugepages": {
+        "fs_type": "hugetlbfs",
+        "mount_options": [
+          "rw",
+          "relatime",
+          "seclabel",
+          "pagesize=2M"
+        ],
+        "devices": [
+          "hugetlbfs"
+        ]
+      },
+      "/sys/kernel/debug": {
+        "fs_type": "debugfs",
+        "mount_options": [
+          "rw",
+          "nosuid",
+          "nodev",
+          "noexec",
+          "relatime",
+          "seclabel"
+        ],
+        "devices": [
+          "debugfs"
+        ]
+      },
+      "/sys/kernel/tracing": {
+        "fs_type": "tracefs",
+        "mount_options": [
+          "rw",
+          "nosuid",
+          "nodev",
+          "noexec",
+          "relatime",
+          "seclabel"
+        ],
+        "devices": [
+          "tracefs"
+        ]
+      },
+      "/run/credentials/systemd-sysctl.service": {
+        "fs_type": "ramfs",
+        "mount_options": [
+          "ro",
+          "nosuid",
+          "nodev",
+          "noexec",
+          "relatime",
+          "seclabel",
+          "mode=700"
+        ],
+        "devices": [
+          "none"
+        ]
+      },
+      "/sys/kernel/config": {
+        "fs_type": "configfs",
+        "mount_options": [
+          "rw",
+          "nosuid",
+          "nodev",
+          "noexec",
+          "relatime"
+        ],
+        "devices": [
+          "configfs"
+        ]
+      },
+      "/run/credentials/systemd-tmpfiles-setup-dev.service": {
+        "fs_type": "ramfs",
+        "mount_options": [
+          "ro",
+          "nosuid",
+          "nodev",
+          "noexec",
+          "relatime",
+          "seclabel",
+          "mode=700"
+        ],
+        "devices": [
+          "none"
+        ]
+      },
+      "/sys/fs/fuse/connections": {
+        "fs_type": "fusectl",
+        "mount_options": [
+          "rw",
+          "nosuid",
+          "nodev",
+          "noexec",
+          "relatime"
+        ],
+        "devices": [
+          "fusectl"
+        ]
+      },
+      "/run/credentials/systemd-tmpfiles-setup.service": {
+        "fs_type": "ramfs",
+        "mount_options": [
+          "ro",
+          "nosuid",
+          "nodev",
+          "noexec",
+          "relatime",
+          "seclabel",
+          "mode=700"
+        ],
+        "devices": [
+          "none"
+        ]
+      },
+      "/var/lib/nfs/rpc_pipefs": {
+        "fs_type": "rpc_pipefs",
+        "mount_options": [
+          "rw",
+          "relatime"
+        ],
+        "devices": [
+          "sunrpc"
+        ]
+      }
+    },
+    "by_pair": {
+      "devtmpfs,/dev": {
+        "device": "devtmpfs",
+        "kb_size": "4096",
+        "kb_used": "0",
+        "kb_available": "4096",
+        "percent_used": "0%",
+        "mount": "/dev",
+        "total_inodes": "464128",
+        "inodes_used": "355",
+        "inodes_available": "463773",
+        "inodes_percent_used": "1%",
+        "fs_type": "devtmpfs",
+        "mount_options": [
+          "rw",
+          "nosuid",
+          "seclabel",
+          "size=4096k",
+          "nr_inodes=464128",
+          "mode=755",
+          "inode64"
+        ]
+      },
+      "tmpfs,/dev/shm": {
+        "device": "tmpfs",
+        "kb_size": "1875072",
+        "kb_used": "0",
+        "kb_available": "1875072",
+        "percent_used": "0%",
+        "mount": "/dev/shm",
+        "total_inodes": "468768",
+        "inodes_used": "1",
+        "inodes_available": "468767",
+        "inodes_percent_used": "1%",
+        "fs_type": "tmpfs",
+        "mount_options": [
+          "rw",
+          "nosuid",
+          "nodev",
+          "seclabel",
+          "inode64"
+        ]
+      },
+      "tmpfs,/run": {
+        "device": "tmpfs",
+        "kb_size": "750032",
+        "kb_used": "16868",
+        "kb_available": "733164",
+        "percent_used": "3%",
+        "mount": "/run",
+        "total_inodes": "819200",
+        "inodes_used": "533",
+        "inodes_available": "818667",
+        "inodes_percent_used": "1%",
+        "fs_type": "tmpfs",
+        "mount_options": [
+          "rw",
+          "nosuid",
+          "nodev",
+          "seclabel",
+          "size=750032k",
+          "nr_inodes=819200",
+          "mode=755",
+          "inode64"
+        ]
+      },
+      "/dev/sda2,/": {
+        "device": "/dev/sda2",
+        "kb_size": "64926748",
+        "kb_used": "1516856",
+        "kb_available": "63409892",
+        "percent_used": "3%",
+        "mount": "/",
+        "total_inodes": "32479232",
+        "inodes_used": "38483",
+        "inodes_available": "32440749",
+        "inodes_percent_used": "1%",
+        "fs_type": "xfs",
+        "mount_options": [
+          "rw",
+          "relatime",
+          "seclabel",
+          "attr2",
+          "inode64",
+          "logbufs=8",
+          "logbsize=32k",
+          "noquota"
+        ],
+        "uuid": "47919001-bd02-4834-b40c-25052d8c886c"
+      },
+      "vagrant,/vagrant": {
+        "device": "vagrant",
+        "kb_size": "492054648",
+        "kb_used": "396776216",
+        "kb_available": "95278432",
+        "percent_used": "81%",
+        "mount": "/vagrant",
+        "fs_type": "vboxsf",
+        "mount_options": [
+          "rw",
+          "nodev",
+          "relatime",
+          "iocharset=utf8",
+          "uid=1000",
+          "gid=1000",
+          "_netdev"
+        ]
+      },
+      "tmpfs,/run/user/1000": {
+        "device": "tmpfs",
+        "kb_size": "375012",
+        "kb_used": "0",
+        "kb_available": "375012",
+        "percent_used": "0%",
+        "mount": "/run/user/1000",
+        "total_inodes": "93753",
+        "inodes_used": "14",
+        "inodes_available": "93739",
+        "inodes_percent_used": "1%",
+        "fs_type": "tmpfs",
+        "mount_options": [
+          "rw",
+          "nosuid",
+          "nodev",
+          "relatime",
+          "seclabel",
+          "size=375012k",
+          "nr_inodes=93753",
+          "mode=700",
+          "uid=1000",
+          "gid=1000",
+          "inode64"
+        ]
+      },
+      "proc,/proc": {
+        "device": "proc",
+        "mount": "/proc",
+        "fs_type": "proc",
+        "mount_options": [
+          "rw",
+          "nosuid",
+          "nodev",
+          "noexec",
+          "relatime"
+        ]
+      },
+      "sysfs,/sys": {
+        "device": "sysfs",
+        "mount": "/sys",
+        "fs_type": "sysfs",
+        "mount_options": [
+          "rw",
+          "nosuid",
+          "nodev",
+          "noexec",
+          "relatime",
+          "seclabel"
+        ]
+      },
+      "securityfs,/sys/kernel/security": {
+        "device": "securityfs",
+        "mount": "/sys/kernel/security",
+        "fs_type": "securityfs",
+        "mount_options": [
+          "rw",
+          "nosuid",
+          "nodev",
+          "noexec",
+          "relatime"
+        ]
+      },
+      "devpts,/dev/pts": {
+        "device": "devpts",
+        "mount": "/dev/pts",
+        "fs_type": "devpts",
+        "mount_options": [
+          "rw",
+          "nosuid",
+          "noexec",
+          "relatime",
+          "seclabel",
+          "gid=5",
+          "mode=620",
+          "ptmxmode=000"
+        ]
+      },
+      "cgroup2,/sys/fs/cgroup": {
+        "device": "cgroup2",
+        "mount": "/sys/fs/cgroup",
+        "fs_type": "cgroup2",
+        "mount_options": [
+          "rw",
+          "nosuid",
+          "nodev",
+          "noexec",
+          "relatime",
+          "seclabel",
+          "nsdelegate",
+          "memory_recursiveprot"
+        ]
+      },
+      "pstore,/sys/fs/pstore": {
+        "device": "pstore",
+        "mount": "/sys/fs/pstore",
+        "fs_type": "pstore",
+        "mount_options": [
+          "rw",
+          "nosuid",
+          "nodev",
+          "noexec",
+          "relatime",
+          "seclabel"
+        ]
+      },
+      "bpf,/sys/fs/bpf": {
+        "device": "bpf",
+        "mount": "/sys/fs/bpf",
+        "fs_type": "bpf",
+        "mount_options": [
+          "rw",
+          "nosuid",
+          "nodev",
+          "noexec",
+          "relatime",
+          "mode=700"
+        ]
+      },
+      "selinuxfs,/sys/fs/selinux": {
+        "device": "selinuxfs",
+        "mount": "/sys/fs/selinux",
+        "fs_type": "selinuxfs",
+        "mount_options": [
+          "rw",
+          "nosuid",
+          "noexec",
+          "relatime"
+        ]
+      },
+      "systemd-1,/proc/sys/fs/binfmt_misc": {
+        "device": "systemd-1",
+        "mount": "/proc/sys/fs/binfmt_misc",
+        "fs_type": "autofs",
+        "mount_options": [
+          "rw",
+          "relatime",
+          "fd=29",
+          "pgrp=1",
+          "timeout=0",
+          "minproto=5",
+          "maxproto=5",
+          "direct",
+          "pipe_ino=18057"
+        ]
+      },
+      "mqueue,/dev/mqueue": {
+        "device": "mqueue",
+        "mount": "/dev/mqueue",
+        "fs_type": "mqueue",
+        "mount_options": [
+          "rw",
+          "nosuid",
+          "nodev",
+          "noexec",
+          "relatime",
+          "seclabel"
+        ]
+      },
+      "hugetlbfs,/dev/hugepages": {
+        "device": "hugetlbfs",
+        "mount": "/dev/hugepages",
+        "fs_type": "hugetlbfs",
+        "mount_options": [
+          "rw",
+          "relatime",
+          "seclabel",
+          "pagesize=2M"
+        ]
+      },
+      "debugfs,/sys/kernel/debug": {
+        "device": "debugfs",
+        "mount": "/sys/kernel/debug",
+        "fs_type": "debugfs",
+        "mount_options": [
+          "rw",
+          "nosuid",
+          "nodev",
+          "noexec",
+          "relatime",
+          "seclabel"
+        ]
+      },
+      "tracefs,/sys/kernel/tracing": {
+        "device": "tracefs",
+        "mount": "/sys/kernel/tracing",
+        "fs_type": "tracefs",
+        "mount_options": [
+          "rw",
+          "nosuid",
+          "nodev",
+          "noexec",
+          "relatime",
+          "seclabel"
+        ]
+      },
+      "none,/run/credentials/systemd-sysctl.service": {
+        "device": "none",
+        "mount": "/run/credentials/systemd-sysctl.service",
+        "fs_type": "ramfs",
+        "mount_options": [
+          "ro",
+          "nosuid",
+          "nodev",
+          "noexec",
+          "relatime",
+          "seclabel",
+          "mode=700"
+        ]
+      },
+      "configfs,/sys/kernel/config": {
+        "device": "configfs",
+        "mount": "/sys/kernel/config",
+        "fs_type": "configfs",
+        "mount_options": [
+          "rw",
+          "nosuid",
+          "nodev",
+          "noexec",
+          "relatime"
+        ]
+      },
+      "none,/run/credentials/systemd-tmpfiles-setup-dev.service": {
+        "device": "none",
+        "mount": "/run/credentials/systemd-tmpfiles-setup-dev.service",
+        "fs_type": "ramfs",
+        "mount_options": [
+          "ro",
+          "nosuid",
+          "nodev",
+          "noexec",
+          "relatime",
+          "seclabel",
+          "mode=700"
+        ]
+      },
+      "fusectl,/sys/fs/fuse/connections": {
+        "device": "fusectl",
+        "mount": "/sys/fs/fuse/connections",
+        "fs_type": "fusectl",
+        "mount_options": [
+          "rw",
+          "nosuid",
+          "nodev",
+          "noexec",
+          "relatime"
+        ]
+      },
+      "none,/run/credentials/systemd-tmpfiles-setup.service": {
+        "device": "none",
+        "mount": "/run/credentials/systemd-tmpfiles-setup.service",
+        "fs_type": "ramfs",
+        "mount_options": [
+          "ro",
+          "nosuid",
+          "nodev",
+          "noexec",
+          "relatime",
+          "seclabel",
+          "mode=700"
+        ]
+      },
+      "sunrpc,/var/lib/nfs/rpc_pipefs": {
+        "device": "sunrpc",
+        "mount": "/var/lib/nfs/rpc_pipefs",
+        "fs_type": "rpc_pipefs",
+        "mount_options": [
+          "rw",
+          "relatime"
+        ]
+      },
+      "/dev/sda,": {
+        "device": "/dev/sda"
+      },
+      "/dev/sda1,": {
+        "device": "/dev/sda1",
+        "fs_type": "swap",
+        "uuid": "69a4d716-0761-40cc-ad0f-e33d91a53b93"
+      }
+    }
+  },
+  "fips": {
+    "kernel": {
+      "enabled": false
+    }
+  },
+  "fqdn": "fauxhai.local",
+  "hostname": "Fauxhai",
+  "idle": "30 days 15 hours 07 minutes 30 seconds",
+  "idletime_seconds": 2646450,
+  "init_package": "systemd",
+  "ipaddress": "10.0.0.2",
+  "kernel": {
+    "name": "Linux",
+    "release": "5.14.0-234.el9.x86_64",
+    "version": "#1 SMP PREEMPT_DYNAMIC Thu Jan 12 18:16:31 UTC 2023",
+    "machine": "x86_64",
+    "processor": "x86_64",
+    "os": "GNU/Linux",
+    "modules": {
+      "tls": {
+        "size": "131072",
+        "refcount": "0"
+      },
+      "vboxsf": {
+        "size": "98304",
+        "refcount": "1",
+        "version": "7.0.6 r155176"
+      },
+      "rfkill": {
+        "size": "36864",
+        "refcount": "1"
+      },
+      "vmwgfx": {
+        "size": "393216",
+        "refcount": "2",
+        "version": "2.20.0.0"
+      },
+      "drm_ttm_helper": {
+        "size": "16384",
+        "refcount": "1"
+      },
+      "ttm": {
+        "size": "90112",
+        "refcount": "2"
+      },
+      "intel_rapl_msr": {
+        "size": "20480",
+        "refcount": "0"
+      },
+      "drm_kms_helper": {
+        "size": "192512",
+        "refcount": "1"
+      },
+      "intel_rapl_common": {
+        "size": "32768",
+        "refcount": "1"
+      },
+      "intel_pmc_core_pltdrv": {
+        "size": "16384",
+        "refcount": "0"
+      },
+      "intel_pmc_core": {
+        "size": "53248",
+        "refcount": "0"
+      },
+      "syscopyarea": {
+        "size": "16384",
+        "refcount": "1"
+      },
+      "sysfillrect": {
+        "size": "16384",
+        "refcount": "1"
+      },
+      "sysimgblt": {
+        "size": "16384",
+        "refcount": "1"
+      },
+      "fb_sys_fops": {
+        "size": "16384",
+        "refcount": "1"
+      },
+      "i2c_piix4": {
+        "size": "28672",
+        "refcount": "0"
+      },
+      "pcspkr": {
+        "size": "16384",
+        "refcount": "0"
+      },
+      "joydev": {
+        "size": "28672",
+        "refcount": "0"
+      },
+      "rapl": {
+        "size": "24576",
+        "refcount": "0"
+      },
+      "sunrpc": {
+        "size": "696320",
+        "refcount": "1"
+      },
+      "drm": {
+        "size": "581632",
+        "refcount": "6"
+      },
+      "fuse": {
+        "size": "176128",
+        "refcount": "1"
+      },
+      "xfs": {
+        "size": "2043904",
+        "refcount": "1"
+      },
+      "libcrc32c": {
+        "size": "16384",
+        "refcount": "1"
+      },
+      "sd_mod": {
+        "size": "69632",
+        "refcount": "3"
+      },
+      "t10_pi": {
+        "size": "16384",
+        "refcount": "1"
+      },
+      "sg": {
+        "size": "49152",
+        "refcount": "0",
+        "version": "3.5.36"
+      },
+      "ata_generic": {
+        "size": "16384",
+        "refcount": "0",
+        "version": "0.2.15"
+      },
+      "ahci": {
+        "size": "49152",
+        "refcount": "2",
+        "version": "3.0"
+      },
+      "libahci": {
+        "size": "53248",
+        "refcount": "1"
+      },
+      "e1000": {
+        "size": "176128",
+        "refcount": "0"
+      },
+      "crct10dif_pclmul": {
+        "size": "16384",
+        "refcount": "1"
+      },
+      "crc32_pclmul": {
+        "size": "16384",
+        "refcount": "0"
+      },
+      "crc32c_intel": {
+        "size": "24576",
+        "refcount": "1"
+      },
+      "ghash_clmulni_intel": {
+        "size": "16384",
+        "refcount": "0"
+      },
+      "video": {
+        "size": "61440",
+        "refcount": "0"
+      },
+      "ata_piix": {
+        "size": "45056",
+        "refcount": "0",
+        "version": "2.13"
+      },
+      "libata": {
+        "size": "425984",
+        "refcount": "4",
+        "version": "3.00"
+      },
+      "vboxguest": {
+        "size": "421888",
+        "refcount": "3",
+        "version": "7.0.6 r155176"
+      },
+      "serio_raw": {
+        "size": "20480",
+        "refcount": "0"
+      }
+    }
+  },
+  "keys": {
+    "ssh": {
+      "host_dsa_public": "ssh-dss AAAAB3NzaC1kc3MAAACBAJFo9BLAw4WKEs5hgipk5m423FzBsDXCZSMcC9ca/om/1VYzMqImixGe3uICDzNFUWxFoLJTQAOccyzo6MXZiQqwWJDLFi5qOSr6w2XcMyE+zd4wOyMoDiVM5fizmG8K3FzrqvGjwBcHcBdOQnavSijoj38DN25J9zhrid5BY4WlAAAAFQDxXrCyG52XCzn3FV4ej38wJBkomQAAAIBovGPJ4mP2P6BK8lHl0PPbktwQbWlpJ13oz6REJFDVcUi7vV26bX/BjQX+ohzZQzljdz1SpUbPc/8nuA4darYkVh91eBi307EN8IdxRHj2eBgp/ZG4yshIebG3WHrwJD/xUjjZ1MRfyDT1ermVi4LvjjPgWDxLZnPpMaR6S1nzgQAAAIEAj0Vd6DCWslvlsZ8+N53HWsqPi3gnx35JoLPz9Z2epkKIKqmEHav+93G3hdfztVa4I4t3phoPniQchYryF5+RNg8hqxKzjNtrIqUYCeuf2NJrksNsH7OZygPHZpqt4kTuwAGZxjxEGfAI0y8DhkU2ntp2LnzRnWH106BQBCmcXwo= fauxhai.local",
+      "host_rsa_public": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCtLCeqtqr/HbnORckw1ukdLhpfGoOPFi5/esKEokzTqq1gsgQ2V8emmyjfq1i6XXfRtSBxkdlHv/GWdP5wBTuE2G85MzBkVSQPvmwQN8lX/JMPEEtKXkeOo0o92/PiSmvY4eRsdF0mw40Uvg7jtE3f3fxj497kzh5fKtkrHnF4x9gXCbVdr3FqXJfggR5IJwAxToerbK7x/uRS+7YuZI9Pip3tt14nv9ezwXcuGb/tvjWOZINiFl8izVIFKi7sxfTX09p4NgamxRS7TD2Yd0jT8nEoF9UZTsgXcJ1kDSx7N7NxFfNfP6rCdOGRRz4gUhXtsUjG/XkxPeCwZ7A9VnOD fauxhai.local"
+    }
+  },
+  "languages": {
+    "ruby": {
+      "platform": "x86_64-linux",
+      "version": "3.1.2",
+      "release_date": "2022-04-12",
+      "target": "x86_64-pc-linux-gnu",
+      "target_cpu": "x86_64",
+      "target_vendor": "pc",
+      "target_os": "linux",
+      "host": "x86_64-pc-linux-gnu",
+      "host_cpu": "x86_64",
+      "host_os": "linux",
+      "host_vendor": "pc",
+      "bin_dir": "/usr/local/bin",
+      "ruby_bin": "/usr/local/bin/ruby",
+      "gem_bin": "/usr/local/bin/gem",
+      "gems_dir": "/usr/local/gems"
+    },
+    "powershell": null
+  },
+  "lsb": {
+  },
+  "macaddress": "11:11:11:11:11:11",
+  "machinename": "Fauxhai",
+  "memory": {
+    "total": "1048576kB"
+  },
+  "network": {
+    "interfaces": {
+      "lo": {
+        "mtu": "65536",
+        "flags": [
+          "LOOPBACK",
+          "UP",
+          "LOWER_UP"
+        ],
+        "encapsulation": "Loopback",
+        "addresses": {
+          "127.0.0.1": {
+            "family": "inet",
+            "prefixlen": "8",
+            "netmask": "255.0.0.0",
+            "scope": "Node",
+            "ip_scope": "LOOPBACK"
+          },
+          "::1": {
+            "family": "inet6",
+            "prefixlen": "128",
+            "scope": "Node",
+            "tags": [
+
+            ],
+            "ip_scope": "LINK LOCAL LOOPBACK"
+          }
+        },
+        "state": "unknown"
+      },
+      "eth0": {
+        "type": "eth",
+        "number": "0",
+        "mtu": "1500",
+        "flags": [
+          "BROADCAST",
+          "MULTICAST",
+          "UP",
+          "LOWER_UP"
+        ],
+        "encapsulation": "Ethernet",
+        "addresses": {
+          "11:11:11:11:11:11": {
+            "family": "lladdr"
+          },
+          "10.0.0.2": {
+            "family": "inet",
+            "prefixlen": "24",
+            "netmask": "255.255.255.0",
+            "broadcast": "10.0.0.255",
+            "scope": "Global",
+            "ip_scope": "RFC1918 PRIVATE"
+          },
+          "fe80::11:1111:1111:1111": {
+            "family": "inet6",
+            "prefixlen": "64",
+            "scope": "Link",
+            "tags": [
+
+            ],
+            "ip_scope": "LINK LOCAL UNICAST"
+          }
+        },
+        "state": "up",
+        "arp": {
+          "10.0.0.1": "fe:ff:ff:ff:ff:ff"
+        },
+        "routes": [
+          {
+            "destination": "default",
+            "family": "inet",
+            "via": "10.0.0.1"
+          },
+          {
+            "destination": "10.0.0.0/24",
+            "family": "inet",
+            "scope": "link",
+            "proto": "kernel",
+            "src": "10.0.0.2"
+          },
+          {
+            "destination": "fe80::/64",
+            "family": "inet6",
+            "metric": "256",
+            "proto": "kernel"
+          }
+        ],
+        "ring_params": {
+        }
+      }
+    },
+    "default_interface": "eth0",
+    "default_gateway": "10.0.0.1"
+  },
+  "ohai_time": 1675119889.7828636,
+  "os": "linux",
+  "os_release": {
+    "name": "CentOS Stream",
+    "version": "9",
+    "id": "centos",
+    "id_like": [
+      "rhel",
+      "fedora"
+    ],
+    "version_id": "9",
+    "platform_id": "platform:el9",
+    "pretty_name": "CentOS Stream 9",
+    "ansi_color": "0;31",
+    "logo": "fedora-logo-icon",
+    "cpe_name": "cpe:/o:centos:centos:9",
+    "home_url": "https://centos.org/",
+    "bug_report_url": "https://bugzilla.redhat.com/",
+    "redhat_support_product": "Red Hat Enterprise Linux 9",
+    "redhat_support_product_version": "CentOS Stream"
+  },
+  "os_version": "5.14.0-234.el9.x86_64",
+  "packages": {
+    "libgcc": {
+      "epoch": "0",
+      "version": "11.3.1",
+      "release": "4.3.el9",
+      "installdate": "1674235547",
+      "arch": "x86_64"
+    },
+    "crypto-policies": {
+      "epoch": "0",
+      "version": "20221215",
+      "release": "1.git9a18988.el9",
+      "installdate": "1674235547",
+      "arch": "noarch"
+    },
+    "tzdata": {
+      "epoch": "0",
+      "version": "2022g",
+      "release": "1.el9",
+      "installdate": "1674235548",
+      "arch": "noarch"
+    },
+    "gawk-all-langpacks": {
+      "epoch": "0",
+      "version": "5.1.0",
+      "release": "6.el9",
+      "installdate": "1674235548",
+      "arch": "x86_64"
+    },
+    "quota-nls": {
+      "epoch": "1",
+      "version": "4.06",
+      "release": "6.el9",
+      "installdate": "1674235548",
+      "arch": "noarch"
+    },
+    "python3-setuptools-wheel": {
+      "epoch": "0",
+      "version": "53.0.0",
+      "release": "12.el9",
+      "installdate": "1674235548",
+      "arch": "noarch"
+    },
+    "publicsuffix-list-dafsa": {
+      "epoch": "0",
+      "version": "20210518",
+      "release": "3.el9",
+      "installdate": "1674235548",
+      "arch": "noarch"
+    },
+    "pcre2-syntax": {
+      "epoch": "0",
+      "version": "10.40",
+      "release": "2.el9",
+      "installdate": "1674235548",
+      "arch": "noarch"
+    },
+    "ncurses-base": {
+      "epoch": "0",
+      "version": "6.2",
+      "release": "8.20210508.el9",
+      "installdate": "1674235548",
+      "arch": "noarch"
+    },
+    "libssh-config": {
+      "epoch": "0",
+      "version": "0.10.4",
+      "release": "7.el9",
+      "installdate": "1674235551",
+      "arch": "noarch"
+    },
+    "libreport-filesystem": {
+      "epoch": "0",
+      "version": "2.15.2",
+      "release": "6.el9",
+      "installdate": "1674235551",
+      "arch": "noarch"
+    },
+    "dnf-data": {
+      "epoch": "0",
+      "version": "4.14.0",
+      "release": "4.el9",
+      "installdate": "1674235551",
+      "arch": "noarch"
+    },
+    "kbd-misc": {
+      "epoch": "0",
+      "version": "2.4.0",
+      "release": "8.el9",
+      "installdate": "1674235551",
+      "arch": "noarch"
+    },
+    "hwdata": {
+      "epoch": "0",
+      "version": "0.348",
+      "release": "9.6.el9",
+      "installdate": "1674235551",
+      "arch": "noarch"
+    },
+    "fonts-filesystem": {
+      "epoch": "1",
+      "version": "2.0.5",
+      "release": "7.el9.1",
+      "installdate": "1674235551",
+      "arch": "noarch"
+    },
+    "dejavu-sans-fonts": {
+      "epoch": "0",
+      "version": "2.37",
+      "release": "18.el9",
+      "installdate": "1674235551",
+      "arch": "noarch"
+    },
+    "langpacks-core-font-en": {
+      "epoch": "0",
+      "version": "3.0",
+      "release": "16.el9",
+      "installdate": "1674235551",
+      "arch": "noarch"
+    },
+    "firewalld-filesystem": {
+      "epoch": "0",
+      "version": "1.2.1",
+      "release": "1.el9",
+      "installdate": "1674235551",
+      "arch": "noarch"
+    },
+    "coreutils-common": {
+      "epoch": "0",
+      "version": "8.32",
+      "release": "33.el9",
+      "installdate": "1674235551",
+      "arch": "x86_64"
+    },
+    "centos-gpg-keys": {
+      "epoch": "0",
+      "version": "9.0",
+      "release": "18.el9",
+      "installdate": "1674235551",
+      "arch": "noarch"
+    },
+    "centos-stream-repos": {
+      "epoch": "0",
+      "version": "9.0",
+      "release": "18.el9",
+      "installdate": "1674235551",
+      "arch": "noarch"
+    },
+    "centos-stream-release": {
+      "epoch": "0",
+      "version": "9.0",
+      "release": "18.el9",
+      "installdate": "1674235551",
+      "arch": "noarch"
+    },
+    "setup": {
+      "epoch": "0",
+      "version": "2.13.7",
+      "release": "8.el9",
+      "installdate": "1674235551",
+      "arch": "noarch"
+    },
+    "filesystem": {
+      "epoch": "0",
+      "version": "3.16",
+      "release": "2.el9",
+      "installdate": "1674235552",
+      "arch": "x86_64"
+    },
+    "basesystem": {
+      "epoch": "0",
+      "version": "11",
+      "release": "13.el9",
+      "installdate": "1674235552",
+      "arch": "noarch"
+    },
+    "glibc-gconv-extra": {
+      "epoch": "0",
+      "version": "2.34",
+      "release": "54.el9",
+      "installdate": "1674235552",
+      "arch": "x86_64"
+    },
+    "glibc-langpack-en": {
+      "epoch": "0",
+      "version": "2.34",
+      "release": "54.el9",
+      "installdate": "1674235552",
+      "arch": "x86_64"
+    },
+    "glibc-common": {
+      "epoch": "0",
+      "version": "2.34",
+      "release": "54.el9",
+      "installdate": "1674235552",
+      "arch": "x86_64"
+    },
+    "glibc": {
+      "epoch": "0",
+      "version": "2.34",
+      "release": "54.el9",
+      "installdate": "1674235552",
+      "arch": "x86_64"
+    },
+    "ncurses-libs": {
+      "epoch": "0",
+      "version": "6.2",
+      "release": "8.20210508.el9",
+      "installdate": "1674235552",
+      "arch": "x86_64"
+    },
+    "bash": {
+      "epoch": "0",
+      "version": "5.1.8",
+      "release": "6.el9",
+      "installdate": "1674235552",
+      "arch": "x86_64"
+    },
+    "zlib": {
+      "epoch": "0",
+      "version": "1.2.11",
+      "release": "36.el9",
+      "installdate": "1674235552",
+      "arch": "x86_64"
+    },
+    "xz-libs": {
+      "epoch": "0",
+      "version": "5.2.5",
+      "release": "8.el9",
+      "installdate": "1674235552",
+      "arch": "x86_64"
+    },
+    "libcap": {
+      "epoch": "0",
+      "version": "2.48",
+      "release": "8.el9",
+      "installdate": "1674235553",
+      "arch": "x86_64"
+    },
+    "libzstd": {
+      "epoch": "0",
+      "version": "1.5.1",
+      "release": "2.el9",
+      "installdate": "1674235553",
+      "arch": "x86_64"
+    },
+    "popt": {
+      "epoch": "0",
+      "version": "1.18",
+      "release": "8.el9",
+      "installdate": "1674235553",
+      "arch": "x86_64"
+    },
+    "bzip2-libs": {
+      "epoch": "0",
+      "version": "1.0.8",
+      "release": "8.el9",
+      "installdate": "1674235553",
+      "arch": "x86_64"
+    },
+    "libuuid": {
+      "epoch": "0",
+      "version": "2.37.4",
+      "release": "9.el9",
+      "installdate": "1674235553",
+      "arch": "x86_64"
+    },
+    "libxcrypt": {
+      "epoch": "0",
+      "version": "4.4.18",
+      "release": "3.el9",
+      "installdate": "1674235553",
+      "arch": "x86_64"
+    },
+    "sqlite-libs": {
+      "epoch": "0",
+      "version": "3.34.1",
+      "release": "6.el9",
+      "installdate": "1674235553",
+      "arch": "x86_64"
+    },
+    "libcom_err": {
+      "epoch": "0",
+      "version": "1.46.5",
+      "release": "3.el9",
+      "installdate": "1674235553",
+      "arch": "x86_64"
+    },
+    "libmnl": {
+      "epoch": "0",
+      "version": "1.0.4",
+      "release": "15.el9",
+      "installdate": "1674235553",
+      "arch": "x86_64"
+    },
+    "libxml2": {
+      "epoch": "0",
+      "version": "2.9.13",
+      "release": "3.el9",
+      "installdate": "1674235553",
+      "arch": "x86_64"
+    },
+    "elfutils-libelf": {
+      "epoch": "0",
+      "version": "0.188",
+      "release": "3.el9",
+      "installdate": "1674235553",
+      "arch": "x86_64"
+    },
+    "readline": {
+      "epoch": "0",
+      "version": "8.1",
+      "release": "4.el9",
+      "installdate": "1674235553",
+      "arch": "x86_64"
+    },
+    "libcap-ng": {
+      "epoch": "0",
+      "version": "0.8.2",
+      "release": "7.el9",
+      "installdate": "1674235553",
+      "arch": "x86_64"
+    },
+    "audit-libs": {
+      "epoch": "0",
+      "version": "3.0.7",
+      "release": "103.el9",
+      "installdate": "1674235553",
+      "arch": "x86_64"
+    },
+    "libstdc++": {
+      "epoch": "0",
+      "version": "11.3.1",
+      "release": "4.3.el9",
+      "installdate": "1674235553",
+      "arch": "x86_64"
+    },
+    "keyutils-libs": {
+      "epoch": "0",
+      "version": "1.6.3",
+      "release": "1.el9",
+      "installdate": "1674235553",
+      "arch": "x86_64"
+    },
+    "libunistring": {
+      "epoch": "0",
+      "version": "0.9.10",
+      "release": "15.el9",
+      "installdate": "1674235553",
+      "arch": "x86_64"
+    },
+    "lua-libs": {
+      "epoch": "0",
+      "version": "5.4.2",
+      "release": "7.el9",
+      "installdate": "1674235553",
+      "arch": "x86_64"
+    },
+    "libidn2": {
+      "epoch": "0",
+      "version": "2.3.0",
+      "release": "7.el9",
+      "installdate": "1674235553",
+      "arch": "x86_64"
+    },
+    "alternatives": {
+      "epoch": "0",
+      "version": "1.20",
+      "release": "2.el9",
+      "installdate": "1674235553",
+      "arch": "x86_64"
+    },
+    "libffi": {
+      "epoch": "0",
+      "version": "3.4.2",
+      "release": "7.el9",
+      "installdate": "1674235553",
+      "arch": "x86_64"
+    },
+    "p11-kit": {
+      "epoch": "0",
+      "version": "0.24.1",
+      "release": "2.el9",
+      "installdate": "1674235553",
+      "arch": "x86_64"
+    },
+    "libgpg-error": {
+      "epoch": "0",
+      "version": "1.42",
+      "release": "5.el9",
+      "installdate": "1674235553",
+      "arch": "x86_64"
+    },
+    "libnl3": {
+      "epoch": "0",
+      "version": "3.7.0",
+      "release": "1.el9",
+      "installdate": "1674235553",
+      "arch": "x86_64"
+    },
+    "libsepol": {
+      "epoch": "0",
+      "version": "3.5",
+      "release": "0.rc1.2.el9",
+      "installdate": "1674235553",
+      "arch": "x86_64"
+    },
+    "libtalloc": {
+      "epoch": "0",
+      "version": "2.3.4",
+      "release": "1.el9",
+      "installdate": "1674235553",
+      "arch": "x86_64"
+    },
+    "lz4-libs": {
+      "epoch": "0",
+      "version": "1.9.3",
+      "release": "5.el9",
+      "installdate": "1674235553",
+      "arch": "x86_64"
+    },
+    "pcre2": {
+      "epoch": "0",
+      "version": "10.40",
+      "release": "2.el9",
+      "installdate": "1674235553",
+      "arch": "x86_64"
+    },
+    "libselinux": {
+      "epoch": "0",
+      "version": "3.5",
+      "release": "0.rc1.1.el9",
+      "installdate": "1674235553",
+      "arch": "x86_64"
+    },
+    "libsemanage": {
+      "epoch": "0",
+      "version": "3.5",
+      "release": "0.rc1.1.el9",
+      "installdate": "1674235553",
+      "arch": "x86_64"
+    },
+    "gmp": {
+      "epoch": "1",
+      "version": "6.2.0",
+      "release": "10.el9",
+      "installdate": "1674235553",
+      "arch": "x86_64"
+    },
+    "libsmartcols": {
+      "epoch": "0",
+      "version": "2.37.4",
+      "release": "9.el9",
+      "installdate": "1674235553",
+      "arch": "x86_64"
+    },
+    "findutils": {
+      "epoch": "1",
+      "version": "4.8.0",
+      "release": "5.el9",
+      "installdate": "1674235553",
+      "arch": "x86_64"
+    },
+    "libtevent": {
+      "epoch": "0",
+      "version": "0.13.0",
+      "release": "1.el9",
+      "installdate": "1674235553",
+      "arch": "x86_64"
+    },
+    "libgcrypt": {
+      "epoch": "0",
+      "version": "1.10.0",
+      "release": "8.el9",
+      "installdate": "1674235553",
+      "arch": "x86_64"
+    },
+    "file-libs": {
+      "epoch": "0",
+      "version": "5.39",
+      "release": "10.el9",
+      "installdate": "1674235553",
+      "arch": "x86_64"
+    },
+    "libedit": {
+      "epoch": "0",
+      "version": "3.1",
+      "release": "37.20210216cvs.el9",
+      "installdate": "1674235553",
+      "arch": "x86_64"
+    },
+    "expat": {
+      "epoch": "0",
+      "version": "2.5.0",
+      "release": "1.el9",
+      "installdate": "1674235553",
+      "arch": "x86_64"
+    },
+    "gdbm-libs": {
+      "epoch": "1",
+      "version": "1.19",
+      "release": "4.el9",
+      "installdate": "1674235553",
+      "arch": "x86_64"
+    },
+    "jansson": {
+      "epoch": "0",
+      "version": "2.14",
+      "release": "1.el9",
+      "installdate": "1674235553",
+      "arch": "x86_64"
+    },
+    "json-c": {
+      "epoch": "0",
+      "version": "0.14",
+      "release": "11.el9",
+      "installdate": "1674235553",
+      "arch": "x86_64"
+    },
+    "libattr": {
+      "epoch": "0",
+      "version": "2.5.1",
+      "release": "3.el9",
+      "installdate": "1674235553",
+      "arch": "x86_64"
+    },
+    "libacl": {
+      "epoch": "0",
+      "version": "2.3.1",
+      "release": "3.el9",
+      "installdate": "1674235553",
+      "arch": "x86_64"
+    },
+    "sed": {
+      "epoch": "0",
+      "version": "4.8",
+      "release": "9.el9",
+      "installdate": "1674235553",
+      "arch": "x86_64"
+    },
+    "shadow-utils": {
+      "epoch": "2",
+      "version": "4.9",
+      "release": "6.el9",
+      "installdate": "1674235553",
+      "arch": "x86_64"
+    },
+    "libref_array": {
+      "epoch": "0",
+      "version": "0.1.5",
+      "release": "53.el9",
+      "installdate": "1674235553",
+      "arch": "x86_64"
+    },
+    "libtdb": {
+      "epoch": "0",
+      "version": "1.4.7",
+      "release": "1.el9",
+      "installdate": "1674235553",
+      "arch": "x86_64"
+    },
+    "libverto": {
+      "epoch": "0",
+      "version": "0.3.2",
+      "release": "3.el9",
+      "installdate": "1674235553",
+      "arch": "x86_64"
+    },
+    "file": {
+      "epoch": "0",
+      "version": "5.39",
+      "release": "10.el9",
+      "installdate": "1674235553",
+      "arch": "x86_64"
+    },
+    "libassuan": {
+      "epoch": "0",
+      "version": "2.5.5",
+      "release": "3.el9",
+      "installdate": "1674235553",
+      "arch": "x86_64"
+    },
+    "libpsl": {
+      "epoch": "0",
+      "version": "0.21.1",
+      "release": "5.el9",
+      "installdate": "1674235553",
+      "arch": "x86_64"
+    },
+    "libbpf": {
+      "epoch": "2",
+      "version": "1.0.0",
+      "release": "1.el9",
+      "installdate": "1674235553",
+      "arch": "x86_64"
+    },
+    "libnftnl": {
+      "epoch": "0",
+      "version": "1.2.2",
+      "release": "1.el9",
+      "installdate": "1674235553",
+      "arch": "x86_64"
+    },
+    "e2fsprogs-libs": {
+      "epoch": "0",
+      "version": "1.46.5",
+      "release": "3.el9",
+      "installdate": "1674235553",
+      "arch": "x86_64"
+    },
+    "fuse-libs": {
+      "epoch": "0",
+      "version": "2.9.9",
+      "release": "15.el9",
+      "installdate": "1674235553",
+      "arch": "x86_64"
+    },
+    "libbasicobjects": {
+      "epoch": "0",
+      "version": "0.1.1",
+      "release": "53.el9",
+      "installdate": "1674235553",
+      "arch": "x86_64"
+    },
+    "libcollection": {
+      "epoch": "0",
+      "version": "0.7.0",
+      "release": "53.el9",
+      "installdate": "1674235553",
+      "arch": "x86_64"
+    },
+    "libdb": {
+      "epoch": "0",
+      "version": "5.3.28",
+      "release": "53.el9",
+      "installdate": "1674235553",
+      "arch": "x86_64"
+    },
+    "libdhash": {
+      "epoch": "0",
+      "version": "0.5.0",
+      "release": "53.el9",
+      "installdate": "1674235553",
+      "arch": "x86_64"
+    },
+    "libgomp": {
+      "epoch": "0",
+      "version": "11.3.1",
+      "release": "4.3.el9",
+      "installdate": "1674235553",
+      "arch": "x86_64"
+    },
+    "libseccomp": {
+      "epoch": "0",
+      "version": "2.5.2",
+      "release": "2.el9",
+      "installdate": "1674235553",
+      "arch": "x86_64"
+    },
+    "libsigsegv": {
+      "epoch": "0",
+      "version": "2.13",
+      "release": "4.el9",
+      "installdate": "1674235553",
+      "arch": "x86_64"
+    },
+    "libsss_idmap": {
+      "epoch": "0",
+      "version": "2.8.2",
+      "release": "1.el9",
+      "installdate": "1674235553",
+      "arch": "x86_64"
+    },
+    "libtasn1": {
+      "epoch": "0",
+      "version": "4.16.0",
+      "release": "8.el9",
+      "installdate": "1674235553",
+      "arch": "x86_64"
+    },
+    "p11-kit-trust": {
+      "epoch": "0",
+      "version": "0.24.1",
+      "release": "2.el9",
+      "installdate": "1674235553",
+      "arch": "x86_64"
+    },
+    "libyaml": {
+      "epoch": "0",
+      "version": "0.2.5",
+      "release": "7.el9",
+      "installdate": "1674235554",
+      "arch": "x86_64"
+    },
+    "lzo": {
+      "epoch": "0",
+      "version": "2.10",
+      "release": "7.el9",
+      "installdate": "1674235554",
+      "arch": "x86_64"
+    },
+    "make": {
+      "epoch": "1",
+      "version": "4.3",
+      "release": "7.el9",
+      "installdate": "1674235554",
+      "arch": "x86_64"
+    },
+    "nettle": {
+      "epoch": "0",
+      "version": "3.8",
+      "release": "3.el9",
+      "installdate": "1674235554",
+      "arch": "x86_64"
+    },
+    "gnutls": {
+      "epoch": "0",
+      "version": "3.7.6",
+      "release": "15.el9",
+      "installdate": "1674235554",
+      "arch": "x86_64"
+    },
+    "pcre": {
+      "epoch": "0",
+      "version": "8.44",
+      "release": "3.el9.3",
+      "installdate": "1674235554",
+      "arch": "x86_64"
+    },
+    "grep": {
+      "epoch": "0",
+      "version": "3.6",
+      "release": "5.el9",
+      "installdate": "1674235554",
+      "arch": "x86_64"
+    },
+    "openssl-libs": {
+      "epoch": "1",
+      "version": "3.0.7",
+      "release": "2.el9",
+      "installdate": "1674235554",
+      "arch": "x86_64"
+    },
+    "coreutils": {
+      "epoch": "0",
+      "version": "8.32",
+      "release": "33.el9",
+      "installdate": "1674235554",
+      "arch": "x86_64"
+    },
+    "ca-certificates": {
+      "epoch": "0",
+      "version": "2022.2.54",
+      "release": "90.2.el9",
+      "installdate": "1674235554",
+      "arch": "noarch"
+    },
+    "systemd-libs": {
+      "epoch": "0",
+      "version": "252",
+      "release": "2.el9",
+      "installdate": "1674235555",
+      "arch": "x86_64"
+    },
+    "libblkid": {
+      "epoch": "0",
+      "version": "2.37.4",
+      "release": "9.el9",
+      "installdate": "1674235555",
+      "arch": "x86_64"
+    },
+    "libmount": {
+      "epoch": "0",
+      "version": "2.37.4",
+      "release": "9.el9",
+      "installdate": "1674235555",
+      "arch": "x86_64"
+    },
+    "glib2": {
+      "epoch": "0",
+      "version": "2.68.4",
+      "release": "6.el9",
+      "installdate": "1674235555",
+      "arch": "x86_64"
+    },
+    "dbus-libs": {
+      "epoch": "1",
+      "version": "1.12.20",
+      "release": "7.el9",
+      "installdate": "1674235555",
+      "arch": "x86_64"
+    },
+    "kmod": {
+      "epoch": "0",
+      "version": "28",
+      "release": "7.el9",
+      "installdate": "1674235555",
+      "arch": "x86_64"
+    },
+    "libfdisk": {
+      "epoch": "0",
+      "version": "2.37.4",
+      "release": "9.el9",
+      "installdate": "1674235555",
+      "arch": "x86_64"
+    },
+    "gzip": {
+      "epoch": "0",
+      "version": "1.12",
+      "release": "1.el9",
+      "installdate": "1674235555",
+      "arch": "x86_64"
+    },
+    "kmod-libs": {
+      "epoch": "0",
+      "version": "28",
+      "release": "7.el9",
+      "installdate": "1674235555",
+      "arch": "x86_64"
+    },
+    "cracklib": {
+      "epoch": "0",
+      "version": "2.9.6",
+      "release": "27.el9",
+      "installdate": "1674235555",
+      "arch": "x86_64"
+    },
+    "NetworkManager-libnm": {
+      "epoch": "1",
+      "version": "1.41.8",
+      "release": "1.el9",
+      "installdate": "1674235555",
+      "arch": "x86_64"
+    },
+    "util-linux-core": {
+      "epoch": "0",
+      "version": "2.37.4",
+      "release": "9.el9",
+      "installdate": "1674235555",
+      "arch": "x86_64"
+    },
+    "libevent": {
+      "epoch": "0",
+      "version": "2.1.12",
+      "release": "6.el9",
+      "installdate": "1674235555",
+      "arch": "x86_64"
+    },
+    "which": {
+      "epoch": "0",
+      "version": "2.21",
+      "release": "28.el9",
+      "installdate": "1674235555",
+      "arch": "x86_64"
+    },
+    "checkpolicy": {
+      "epoch": "0",
+      "version": "3.5",
+      "release": "0.rc1.1.el9",
+      "installdate": "1674235555",
+      "arch": "x86_64"
+    },
+    "cracklib-dicts": {
+      "epoch": "0",
+      "version": "2.9.6",
+      "release": "27.el9",
+      "installdate": "1674235555",
+      "arch": "x86_64"
+    },
+    "gobject-introspection": {
+      "epoch": "0",
+      "version": "1.68.0",
+      "release": "11.el9",
+      "installdate": "1674235555",
+      "arch": "x86_64"
+    },
+    "procps-ng": {
+      "epoch": "0",
+      "version": "3.3.17",
+      "release": "9.el9",
+      "installdate": "1674235555",
+      "arch": "x86_64"
+    },
+    "openssl": {
+      "epoch": "1",
+      "version": "3.0.7",
+      "release": "2.el9",
+      "installdate": "1674235556",
+      "arch": "x86_64"
+    },
+    "libarchive": {
+      "epoch": "0",
+      "version": "3.5.3",
+      "release": "4.el9",
+      "installdate": "1674235556",
+      "arch": "x86_64"
+    },
+    "libsss_certmap": {
+      "epoch": "0",
+      "version": "2.8.2",
+      "release": "1.el9",
+      "installdate": "1674235556",
+      "arch": "x86_64"
+    },
+    "xz": {
+      "epoch": "0",
+      "version": "5.2.5",
+      "release": "8.el9",
+      "installdate": "1674235556",
+      "arch": "x86_64"
+    },
+    "squashfs-tools": {
+      "epoch": "0",
+      "version": "4.4",
+      "release": "8.git1.el9",
+      "installdate": "1674235556",
+      "arch": "x86_64"
+    },
+    "libutempter": {
+      "epoch": "0",
+      "version": "1.2.1",
+      "release": "6.el9",
+      "installdate": "1674235556",
+      "arch": "x86_64"
+    },
+    "acl": {
+      "epoch": "0",
+      "version": "2.3.1",
+      "release": "3.el9",
+      "installdate": "1674235556",
+      "arch": "x86_64"
+    },
+    "gettext-libs": {
+      "epoch": "0",
+      "version": "0.21",
+      "release": "7.el9",
+      "installdate": "1674235556",
+      "arch": "x86_64"
+    },
+    "gettext": {
+      "epoch": "0",
+      "version": "0.21",
+      "release": "7.el9",
+      "installdate": "1674235556",
+      "arch": "x86_64"
+    },
+    "libcomps": {
+      "epoch": "0",
+      "version": "0.1.18",
+      "release": "1.el9",
+      "installdate": "1674235556",
+      "arch": "x86_64"
+    },
+    "mpfr": {
+      "epoch": "0",
+      "version": "4.1.0",
+      "release": "7.el9",
+      "installdate": "1674235556",
+      "arch": "x86_64"
+    },
+    "gawk": {
+      "epoch": "0",
+      "version": "5.1.0",
+      "release": "6.el9",
+      "installdate": "1674235556",
+      "arch": "x86_64"
+    },
+    "krb5-libs": {
+      "epoch": "0",
+      "version": "1.19.1",
+      "release": "22.el9",
+      "installdate": "1674235556",
+      "arch": "x86_64"
+    },
+    "libtirpc": {
+      "epoch": "0",
+      "version": "1.3.3",
+      "release": "1.el9",
+      "installdate": "1674235556",
+      "arch": "x86_64"
+    },
+    "quota": {
+      "epoch": "1",
+      "version": "4.06",
+      "release": "6.el9",
+      "installdate": "1674235556",
+      "arch": "x86_64"
+    },
+    "cyrus-sasl-lib": {
+      "epoch": "0",
+      "version": "2.1.27",
+      "release": "21.el9",
+      "installdate": "1674235556",
+      "arch": "x86_64"
+    },
+    "openldap": {
+      "epoch": "0",
+      "version": "2.6.2",
+      "release": "3.el9",
+      "installdate": "1674235556",
+      "arch": "x86_64"
+    },
+    "libnfsidmap": {
+      "epoch": "1",
+      "version": "2.5.4",
+      "release": "17.el9",
+      "installdate": "1674235556",
+      "arch": "x86_64"
+    },
+    "sssd-nfs-idmap": {
+      "epoch": "0",
+      "version": "2.8.2",
+      "release": "1.el9",
+      "installdate": "1674235556",
+      "arch": "x86_64"
+    },
+    "libssh": {
+      "epoch": "0",
+      "version": "0.10.4",
+      "release": "7.el9",
+      "installdate": "1674235556",
+      "arch": "x86_64"
+    },
+    "libselinux-utils": {
+      "epoch": "0",
+      "version": "3.5",
+      "release": "0.rc1.1.el9",
+      "installdate": "1674235556",
+      "arch": "x86_64"
+    },
+    "libibverbs": {
+      "epoch": "0",
+      "version": "41.0",
+      "release": "3.el9",
+      "installdate": "1674235556",
+      "arch": "x86_64"
+    },
+    "libpcap": {
+      "epoch": "14",
+      "version": "1.10.0",
+      "release": "4.el9",
+      "installdate": "1674235556",
+      "arch": "x86_64"
+    },
+    "libnl3-cli": {
+      "epoch": "0",
+      "version": "3.7.0",
+      "release": "1.el9",
+      "installdate": "1674235556",
+      "arch": "x86_64"
+    },
+    "libteam": {
+      "epoch": "0",
+      "version": "1.31",
+      "release": "16.el9",
+      "installdate": "1674235556",
+      "arch": "x86_64"
+    },
+    "libksba": {
+      "epoch": "0",
+      "version": "1.5.1",
+      "release": "5.el9",
+      "installdate": "1674235556",
+      "arch": "x86_64"
+    },
+    "keyutils": {
+      "epoch": "0",
+      "version": "1.6.3",
+      "release": "1.el9",
+      "installdate": "1674235556",
+      "arch": "x86_64"
+    },
+    "groff-base": {
+      "epoch": "0",
+      "version": "1.22.4",
+      "release": "10.el9",
+      "installdate": "1674235556",
+      "arch": "x86_64"
+    },
+    "snappy": {
+      "epoch": "0",
+      "version": "1.1.8",
+      "release": "8.el9",
+      "installdate": "1674235556",
+      "arch": "x86_64"
+    },
+    "ethtool": {
+      "epoch": "2",
+      "version": "5.10",
+      "release": "4.el9",
+      "installdate": "1674235556",
+      "arch": "x86_64"
+    },
+    "ipset-libs": {
+      "epoch": "0",
+      "version": "7.11",
+      "release": "7.el9",
+      "installdate": "1674235557",
+      "arch": "x86_64"
+    },
+    "ipset": {
+      "epoch": "0",
+      "version": "7.11",
+      "release": "7.el9",
+      "installdate": "1674235557",
+      "arch": "x86_64"
+    },
+    "libss": {
+      "epoch": "0",
+      "version": "1.46.5",
+      "release": "3.el9",
+      "installdate": "1674235557",
+      "arch": "x86_64"
+    },
+    "libxcrypt-compat": {
+      "epoch": "0",
+      "version": "4.4.18",
+      "release": "3.el9",
+      "installdate": "1674235557",
+      "arch": "x86_64"
+    },
+    "python3-pip-wheel": {
+      "epoch": "0",
+      "version": "21.2.3",
+      "release": "6.el9",
+      "installdate": "1674235557",
+      "arch": "noarch"
+    },
+    "python-unversioned-command": {
+      "epoch": "0",
+      "version": "3.9.16",
+      "release": "1.el9",
+      "installdate": "1674235557",
+      "arch": "noarch"
+    },
+    "python3": {
+      "epoch": "0",
+      "version": "3.9.16",
+      "release": "1.el9",
+      "installdate": "1674235557",
+      "arch": "x86_64"
+    },
+    "python3-libs": {
+      "epoch": "0",
+      "version": "3.9.16",
+      "release": "1.el9",
+      "installdate": "1674235558",
+      "arch": "x86_64"
+    },
+    "python3-dbus": {
+      "epoch": "0",
+      "version": "1.2.18",
+      "release": "2.el9",
+      "installdate": "1674235558",
+      "arch": "x86_64"
+    },
+    "python3-gobject-base-noarch": {
+      "epoch": "0",
+      "version": "3.40.1",
+      "release": "6.el9",
+      "installdate": "1674235558",
+      "arch": "noarch"
+    },
+    "python3-gobject-base": {
+      "epoch": "0",
+      "version": "3.40.1",
+      "release": "6.el9",
+      "installdate": "1674235558",
+      "arch": "x86_64"
+    },
+    "python3-setuptools": {
+      "epoch": "0",
+      "version": "53.0.0",
+      "release": "12.el9",
+      "installdate": "1674235558",
+      "arch": "noarch"
+    },
+    "python3-libselinux": {
+      "epoch": "0",
+      "version": "3.5",
+      "release": "0.rc1.1.el9",
+      "installdate": "1674235558",
+      "arch": "x86_64"
+    },
+    "python3-libsemanage": {
+      "epoch": "0",
+      "version": "3.5",
+      "release": "0.rc1.1.el9",
+      "installdate": "1674235558",
+      "arch": "x86_64"
+    },
+    "python3-setools": {
+      "epoch": "0",
+      "version": "4.4.0",
+      "release": "5.el9",
+      "installdate": "1674235558",
+      "arch": "x86_64"
+    },
+    "python3-distro": {
+      "epoch": "0",
+      "version": "1.5.0",
+      "release": "7.el9",
+      "installdate": "1674235558",
+      "arch": "noarch"
+    },
+    "python3-libcomps": {
+      "epoch": "0",
+      "version": "0.1.18",
+      "release": "1.el9",
+      "installdate": "1674235558",
+      "arch": "x86_64"
+    },
+    "python3-pyyaml": {
+      "epoch": "0",
+      "version": "5.4.1",
+      "release": "6.el9",
+      "installdate": "1674235558",
+      "arch": "x86_64"
+    },
+    "python3-six": {
+      "epoch": "0",
+      "version": "1.15.0",
+      "release": "9.el9",
+      "installdate": "1674235558",
+      "arch": "noarch"
+    },
+    "python3-dateutil": {
+      "epoch": "1",
+      "version": "2.8.1",
+      "release": "6.el9",
+      "installdate": "1674235558",
+      "arch": "noarch"
+    },
+    "python3-systemd": {
+      "epoch": "0",
+      "version": "234",
+      "release": "18.el9",
+      "installdate": "1674235558",
+      "arch": "x86_64"
+    },
+    "libcap-ng-python3": {
+      "epoch": "0",
+      "version": "0.8.2",
+      "release": "7.el9",
+      "installdate": "1674235558",
+      "arch": "x86_64"
+    },
+    "python3-audit": {
+      "epoch": "0",
+      "version": "3.0.7",
+      "release": "103.el9",
+      "installdate": "1674235558",
+      "arch": "x86_64"
+    },
+    "pigz": {
+      "epoch": "0",
+      "version": "2.5",
+      "release": "4.el9",
+      "installdate": "1674235558",
+      "arch": "x86_64"
+    },
+    "hostname": {
+      "epoch": "0",
+      "version": "3.23",
+      "release": "6.el9",
+      "installdate": "1674235558",
+      "arch": "x86_64"
+    },
+    "kernel-tools-libs": {
+      "epoch": "0",
+      "version": "5.14.0",
+      "release": "234.el9",
+      "installdate": "1674235558",
+      "arch": "x86_64"
+    },
+    "less": {
+      "epoch": "0",
+      "version": "590",
+      "release": "1.el9",
+      "installdate": "1674235559",
+      "arch": "x86_64"
+    },
+    "systemd-rpm-macros": {
+      "epoch": "0",
+      "version": "252",
+      "release": "2.el9",
+      "installdate": "1674235559",
+      "arch": "noarch"
+    },
+    "psmisc": {
+      "epoch": "0",
+      "version": "23.4",
+      "release": "3.el9",
+      "installdate": "1674235559",
+      "arch": "x86_64"
+    },
+    "iproute": {
+      "epoch": "0",
+      "version": "6.0.0",
+      "release": "2.el9",
+      "installdate": "1674235559",
+      "arch": "x86_64"
+    },
+    "c-ares": {
+      "epoch": "0",
+      "version": "1.17.1",
+      "release": "5.el9",
+      "installdate": "1674235559",
+      "arch": "x86_64"
+    },
+    "cpio": {
+      "epoch": "0",
+      "version": "2.13",
+      "release": "16.el9",
+      "installdate": "1674235559",
+      "arch": "x86_64"
+    },
+    "diffutils": {
+      "epoch": "0",
+      "version": "3.7",
+      "release": "12.el9",
+      "installdate": "1674235559",
+      "arch": "x86_64"
+    },
+    "inih": {
+      "epoch": "0",
+      "version": "49",
+      "release": "6.el9",
+      "installdate": "1674235559",
+      "arch": "x86_64"
+    },
+    "libbrotli": {
+      "epoch": "0",
+      "version": "1.0.9",
+      "release": "6.el9",
+      "installdate": "1674235559",
+      "arch": "x86_64"
+    },
+    "libcbor": {
+      "epoch": "0",
+      "version": "0.7.0",
+      "release": "5.el9",
+      "installdate": "1674235559",
+      "arch": "x86_64"
+    },
+    "libdaemon": {
+      "epoch": "0",
+      "version": "0.14",
+      "release": "23.el9",
+      "installdate": "1674235559",
+      "arch": "x86_64"
+    },
+    "teamd": {
+      "epoch": "0",
+      "version": "1.31",
+      "release": "16.el9",
+      "installdate": "1674235559",
+      "arch": "x86_64"
+    },
+    "libeconf": {
+      "epoch": "0",
+      "version": "0.4.1",
+      "release": "2.el9",
+      "installdate": "1674235559",
+      "arch": "x86_64"
+    },
+    "libpwquality": {
+      "epoch": "0",
+      "version": "1.4.4",
+      "release": "8.el9",
+      "installdate": "1674235559",
+      "arch": "x86_64"
+    },
+    "pam": {
+      "epoch": "0",
+      "version": "1.5.1",
+      "release": "14.el9",
+      "installdate": "1674235559",
+      "arch": "x86_64"
+    },
+    "util-linux": {
+      "epoch": "0",
+      "version": "2.37.4",
+      "release": "9.el9",
+      "installdate": "1674235559",
+      "arch": "x86_64"
+    },
+    "dbus": {
+      "epoch": "1",
+      "version": "1.12.20",
+      "release": "7.el9",
+      "installdate": "1674235559",
+      "arch": "x86_64"
+    },
+    "systemd-pam": {
+      "epoch": "0",
+      "version": "252",
+      "release": "2.el9",
+      "installdate": "1674235559",
+      "arch": "x86_64"
+    },
+    "systemd": {
+      "epoch": "0",
+      "version": "252",
+      "release": "2.el9",
+      "installdate": "1674235560",
+      "arch": "x86_64"
+    },
+    "dbus-common": {
+      "epoch": "1",
+      "version": "1.12.20",
+      "release": "7.el9",
+      "installdate": "1674235560",
+      "arch": "noarch"
+    },
+    "dbus-broker": {
+      "epoch": "0",
+      "version": "28",
+      "release": "7.el9",
+      "installdate": "1674235560",
+      "arch": "x86_64"
+    },
+    "grub2-common": {
+      "epoch": "1",
+      "version": "2.06",
+      "release": "46.el9",
+      "installdate": "1674235560",
+      "arch": "noarch"
+    },
+    "cronie-anacron": {
+      "epoch": "0",
+      "version": "1.5.7",
+      "release": "8.el9",
+      "installdate": "1674235560",
+      "arch": "x86_64"
+    },
+    "cronie": {
+      "epoch": "0",
+      "version": "1.5.7",
+      "release": "8.el9",
+      "installdate": "1674235560",
+      "arch": "x86_64"
+    },
+    "crontabs": {
+      "epoch": "0",
+      "version": "1.11",
+      "release": "26.20190603git.el9",
+      "installdate": "1674235560",
+      "arch": "noarch"
+    },
+    "openssh": {
+      "epoch": "0",
+      "version": "8.7p1",
+      "release": "25.el9",
+      "installdate": "1674235560",
+      "arch": "x86_64"
+    },
+    "grub2-pc-modules": {
+      "epoch": "1",
+      "version": "2.06",
+      "release": "46.el9",
+      "installdate": "1674235560",
+      "arch": "noarch"
+    },
+    "authselect-libs": {
+      "epoch": "0",
+      "version": "1.2.6",
+      "release": "1.el9",
+      "installdate": "1674235560",
+      "arch": "x86_64"
+    },
+    "device-mapper-libs": {
+      "epoch": "9",
+      "version": "1.02.187",
+      "release": "4.el9",
+      "installdate": "1674235561",
+      "arch": "x86_64"
+    },
+    "device-mapper": {
+      "epoch": "9",
+      "version": "1.02.187",
+      "release": "4.el9",
+      "installdate": "1674235561",
+      "arch": "x86_64"
+    },
+    "grub2-tools-minimal": {
+      "epoch": "1",
+      "version": "2.06",
+      "release": "46.el9",
+      "installdate": "1674235561",
+      "arch": "x86_64"
+    },
+    "cryptsetup-libs": {
+      "epoch": "0",
+      "version": "2.6.0",
+      "release": "2.el9",
+      "installdate": "1674235561",
+      "arch": "x86_64"
+    },
+    "kpartx": {
+      "epoch": "0",
+      "version": "0.8.7",
+      "release": "16.el9",
+      "installdate": "1674235561",
+      "arch": "x86_64"
+    },
+    "elfutils-default-yama-scope": {
+      "epoch": "0",
+      "version": "0.188",
+      "release": "3.el9",
+      "installdate": "1674235561",
+      "arch": "noarch"
+    },
+    "elfutils-libs": {
+      "epoch": "0",
+      "version": "0.188",
+      "release": "3.el9",
+      "installdate": "1674235561",
+      "arch": "x86_64"
+    },
+    "initscripts-service": {
+      "epoch": "0",
+      "version": "10.11.5",
+      "release": "1.el9",
+      "installdate": "1674235561",
+      "arch": "noarch"
+    },
+    "iputils": {
+      "epoch": "0",
+      "version": "20210202",
+      "release": "8.el9",
+      "installdate": "1674235561",
+      "arch": "x86_64"
+    },
+    "libkcapi": {
+      "epoch": "0",
+      "version": "1.3.1",
+      "release": "3.el9",
+      "installdate": "1674235561",
+      "arch": "x86_64"
+    },
+    "libkcapi-hmaccalc": {
+      "epoch": "0",
+      "version": "1.3.1",
+      "release": "3.el9",
+      "installdate": "1674235561",
+      "arch": "x86_64"
+    },
+    "logrotate": {
+      "epoch": "0",
+      "version": "3.18.0",
+      "release": "7.el9",
+      "installdate": "1674235561",
+      "arch": "x86_64"
+    },
+    "kbd": {
+      "epoch": "0",
+      "version": "2.4.0",
+      "release": "8.el9",
+      "installdate": "1674235561",
+      "arch": "x86_64"
+    },
+    "libuser": {
+      "epoch": "0",
+      "version": "0.63",
+      "release": "12.el9",
+      "installdate": "1674235561",
+      "arch": "x86_64"
+    },
+    "libev": {
+      "epoch": "0",
+      "version": "4.33",
+      "release": "5.el9",
+      "installdate": "1674235561",
+      "arch": "x86_64"
+    },
+    "libverto-libev": {
+      "epoch": "0",
+      "version": "0.3.2",
+      "release": "3.el9",
+      "installdate": "1674235561",
+      "arch": "x86_64"
+    },
+    "libndp": {
+      "epoch": "0",
+      "version": "1.8",
+      "release": "4.el9",
+      "installdate": "1674235561",
+      "arch": "x86_64"
+    },
+    "libnfnetlink": {
+      "epoch": "0",
+      "version": "1.0.1",
+      "release": "21.el9",
+      "installdate": "1674235561",
+      "arch": "x86_64"
+    },
+    "libnetfilter_conntrack": {
+      "epoch": "0",
+      "version": "1.0.9",
+      "release": "1.el9",
+      "installdate": "1674235561",
+      "arch": "x86_64"
+    },
+    "iptables-libs": {
+      "epoch": "0",
+      "version": "1.8.8",
+      "release": "6.el9",
+      "installdate": "1674235561",
+      "arch": "x86_64"
+    },
+    "iptables-nft": {
+      "epoch": "0",
+      "version": "1.8.8",
+      "release": "6.el9",
+      "installdate": "1674235561",
+      "arch": "x86_64"
+    },
+    "nftables": {
+      "epoch": "1",
+      "version": "1.0.4",
+      "release": "3.el9",
+      "installdate": "1674235561",
+      "arch": "x86_64"
+    },
+    "python3-nftables": {
+      "epoch": "1",
+      "version": "1.0.4",
+      "release": "3.el9",
+      "installdate": "1674235561",
+      "arch": "x86_64"
+    },
+    "python3-firewall": {
+      "epoch": "0",
+      "version": "1.2.1",
+      "release": "1.el9",
+      "installdate": "1674235561",
+      "arch": "noarch"
+    },
+    "libnghttp2": {
+      "epoch": "0",
+      "version": "1.43.0",
+      "release": "5.el9",
+      "installdate": "1674235561",
+      "arch": "x86_64"
+    },
+    "libcurl": {
+      "epoch": "0",
+      "version": "7.76.1",
+      "release": "22.el9",
+      "installdate": "1674235561",
+      "arch": "x86_64"
+    },
+    "tpm2-tss": {
+      "epoch": "0",
+      "version": "3.0.3",
+      "release": "8.el9",
+      "installdate": "1674235561",
+      "arch": "x86_64"
+    },
+    "systemd-udev": {
+      "epoch": "0",
+      "version": "252",
+      "release": "2.el9",
+      "installdate": "1674235562",
+      "arch": "x86_64"
+    },
+    "dracut": {
+      "epoch": "0",
+      "version": "057",
+      "release": "20.git20221213.el9",
+      "installdate": "1674235562",
+      "arch": "x86_64"
+    },
+    "NetworkManager": {
+      "epoch": "1",
+      "version": "1.41.8",
+      "release": "1.el9",
+      "installdate": "1674235562",
+      "arch": "x86_64"
+    },
+    "kernel-core": {
+      "epoch": "0",
+      "version": "5.14.0",
+      "release": "234.el9",
+      "installdate": "1674235564",
+      "arch": "x86_64"
+    },
+    "kernel-modules": {
+      "epoch": "0",
+      "version": "5.14.0",
+      "release": "234.el9",
+      "installdate": "1674235565",
+      "arch": "x86_64"
+    },
+    "dracut-network": {
+      "epoch": "0",
+      "version": "057",
+      "release": "20.git20221213.el9",
+      "installdate": "1674235573",
+      "arch": "x86_64"
+    },
+    "dracut-squash": {
+      "epoch": "0",
+      "version": "057",
+      "release": "20.git20221213.el9",
+      "installdate": "1674235573",
+      "arch": "x86_64"
+    },
+    "libfido2": {
+      "epoch": "0",
+      "version": "1.6.0",
+      "release": "7.el9",
+      "installdate": "1674235573",
+      "arch": "x86_64"
+    },
+    "os-prober": {
+      "epoch": "0",
+      "version": "1.77",
+      "release": "9.el9",
+      "installdate": "1674235573",
+      "arch": "x86_64"
+    },
+    "ima-evm-utils": {
+      "epoch": "0",
+      "version": "1.4",
+      "release": "4.el9",
+      "installdate": "1674235573",
+      "arch": "x86_64"
+    },
+    "curl": {
+      "epoch": "0",
+      "version": "7.76.1",
+      "release": "22.el9",
+      "installdate": "1674235573",
+      "arch": "x86_64"
+    },
+    "rpm": {
+      "epoch": "0",
+      "version": "4.16.1.3",
+      "release": "22.el9",
+      "installdate": "1674235573",
+      "arch": "x86_64"
+    },
+    "rpm-libs": {
+      "epoch": "0",
+      "version": "4.16.1.3",
+      "release": "22.el9",
+      "installdate": "1674235573",
+      "arch": "x86_64"
+    },
+    "policycoreutils": {
+      "epoch": "0",
+      "version": "3.5",
+      "release": "0.rc1.2.el9",
+      "installdate": "1674235573",
+      "arch": "x86_64"
+    },
+    "selinux-policy": {
+      "epoch": "0",
+      "version": "38.1.4",
+      "release": "1.el9",
+      "installdate": "1674235573",
+      "arch": "noarch"
+    },
+    "selinux-policy-targeted": {
+      "epoch": "0",
+      "version": "38.1.4",
+      "release": "1.el9",
+      "installdate": "1674235574",
+      "arch": "noarch"
+    },
+    "grub2-tools": {
+      "epoch": "1",
+      "version": "2.06",
+      "release": "46.el9",
+      "installdate": "1674235582",
+      "arch": "x86_64"
+    },
+    "grubby": {
+      "epoch": "0",
+      "version": "8.40",
+      "release": "61.el9",
+      "installdate": "1674235582",
+      "arch": "x86_64"
+    },
+    "libmodulemd": {
+      "epoch": "0",
+      "version": "2.13.0",
+      "release": "2.el9",
+      "installdate": "1674235582",
+      "arch": "x86_64"
+    },
+    "libsolv": {
+      "epoch": "0",
+      "version": "0.7.22",
+      "release": "4.el9",
+      "installdate": "1674235582",
+      "arch": "x86_64"
+    },
+    "rpcbind": {
+      "epoch": "0",
+      "version": "1.2.6",
+      "release": "5.el9",
+      "installdate": "1674235582",
+      "arch": "x86_64"
+    },
+    "python3-policycoreutils": {
+      "epoch": "0",
+      "version": "3.5",
+      "release": "0.rc1.2.el9",
+      "installdate": "1674235583",
+      "arch": "noarch"
+    },
+    "policycoreutils-python-utils": {
+      "epoch": "0",
+      "version": "3.5",
+      "release": "0.rc1.2.el9",
+      "installdate": "1674235583",
+      "arch": "noarch"
+    },
+    "rpm-build-libs": {
+      "epoch": "0",
+      "version": "4.16.1.3",
+      "release": "22.el9",
+      "installdate": "1674235583",
+      "arch": "x86_64"
+    },
+    "rpm-plugin-systemd-inhibit": {
+      "epoch": "0",
+      "version": "4.16.1.3",
+      "release": "22.el9",
+      "installdate": "1674235583",
+      "arch": "x86_64"
+    },
+    "libpath_utils": {
+      "epoch": "0",
+      "version": "0.2.1",
+      "release": "53.el9",
+      "installdate": "1674235583",
+      "arch": "x86_64"
+    },
+    "libini_config": {
+      "epoch": "0",
+      "version": "1.3.1",
+      "release": "53.el9",
+      "installdate": "1674235583",
+      "arch": "x86_64"
+    },
+    "gssproxy": {
+      "epoch": "0",
+      "version": "0.8.4",
+      "release": "4.el9",
+      "installdate": "1674235583",
+      "arch": "x86_64"
+    },
+    "libpipeline": {
+      "epoch": "0",
+      "version": "1.5.3",
+      "release": "4.el9",
+      "installdate": "1674235583",
+      "arch": "x86_64"
+    },
+    "libsss_nss_idmap": {
+      "epoch": "0",
+      "version": "2.8.2",
+      "release": "1.el9",
+      "installdate": "1674235583",
+      "arch": "x86_64"
+    },
+    "sssd-client": {
+      "epoch": "0",
+      "version": "2.8.2",
+      "release": "1.el9",
+      "installdate": "1674235583",
+      "arch": "x86_64"
+    },
+    "libsss_sudo": {
+      "epoch": "0",
+      "version": "2.8.2",
+      "release": "1.el9",
+      "installdate": "1674235583",
+      "arch": "x86_64"
+    },
+    "lmdb-libs": {
+      "epoch": "0",
+      "version": "0.9.29",
+      "release": "3.el9",
+      "installdate": "1674235583",
+      "arch": "x86_64"
+    },
+    "libldb": {
+      "epoch": "0",
+      "version": "2.6.1",
+      "release": "1.el9",
+      "installdate": "1674235583",
+      "arch": "x86_64"
+    },
+    "sssd-common": {
+      "epoch": "0",
+      "version": "2.8.2",
+      "release": "1.el9",
+      "installdate": "1674235583",
+      "arch": "x86_64"
+    },
+    "npth": {
+      "epoch": "0",
+      "version": "1.6",
+      "release": "8.el9",
+      "installdate": "1674235583",
+      "arch": "x86_64"
+    },
+    "gnupg2": {
+      "epoch": "0",
+      "version": "2.3.3",
+      "release": "2.el9",
+      "installdate": "1674235583",
+      "arch": "x86_64"
+    },
+    "gpgme": {
+      "epoch": "0",
+      "version": "1.15.1",
+      "release": "6.el9",
+      "installdate": "1674235583",
+      "arch": "x86_64"
+    },
+    "librepo": {
+      "epoch": "0",
+      "version": "1.14.5",
+      "release": "1.el9",
+      "installdate": "1674235583",
+      "arch": "x86_64"
+    },
+    "libdnf": {
+      "epoch": "0",
+      "version": "0.69.0",
+      "release": "2.el9",
+      "installdate": "1674235583",
+      "arch": "x86_64"
+    },
+    "python3-libdnf": {
+      "epoch": "0",
+      "version": "0.69.0",
+      "release": "2.el9",
+      "installdate": "1674235583",
+      "arch": "x86_64"
+    },
+    "python3-hawkey": {
+      "epoch": "0",
+      "version": "0.69.0",
+      "release": "2.el9",
+      "installdate": "1674235583",
+      "arch": "x86_64"
+    },
+    "python3-gpg": {
+      "epoch": "0",
+      "version": "1.15.1",
+      "release": "6.el9",
+      "installdate": "1674235583",
+      "arch": "x86_64"
+    },
+    "rpm-sign-libs": {
+      "epoch": "0",
+      "version": "4.16.1.3",
+      "release": "22.el9",
+      "installdate": "1674235583",
+      "arch": "x86_64"
+    },
+    "python3-rpm": {
+      "epoch": "0",
+      "version": "4.16.1.3",
+      "release": "22.el9",
+      "installdate": "1674235583",
+      "arch": "x86_64"
+    },
+    "python3-dnf": {
+      "epoch": "0",
+      "version": "4.14.0",
+      "release": "4.el9",
+      "installdate": "1674235583",
+      "arch": "noarch"
+    },
+    "dnf": {
+      "epoch": "0",
+      "version": "4.14.0",
+      "release": "4.el9",
+      "installdate": "1674235584",
+      "arch": "noarch"
+    },
+    "python3-dnf-plugins-core": {
+      "epoch": "0",
+      "version": "4.3.0",
+      "release": "4.el9",
+      "installdate": "1674235584",
+      "arch": "noarch"
+    },
+    "dnf-plugins-core": {
+      "epoch": "0",
+      "version": "4.3.0",
+      "release": "4.el9",
+      "installdate": "1674235584",
+      "arch": "noarch"
+    },
+    "numactl-libs": {
+      "epoch": "0",
+      "version": "2.0.14",
+      "release": "7.el9",
+      "installdate": "1674235584",
+      "arch": "x86_64"
+    },
+    "pciutils-libs": {
+      "epoch": "0",
+      "version": "3.7.0",
+      "release": "5.el9",
+      "installdate": "1674235584",
+      "arch": "x86_64"
+    },
+    "sg3_utils-libs": {
+      "epoch": "0",
+      "version": "1.47",
+      "release": "9.el9",
+      "installdate": "1674235584",
+      "arch": "x86_64"
+    },
+    "slang": {
+      "epoch": "0",
+      "version": "2.3.2",
+      "release": "11.el9",
+      "installdate": "1674235584",
+      "arch": "x86_64"
+    },
+    "newt": {
+      "epoch": "0",
+      "version": "0.52.21",
+      "release": "11.el9",
+      "installdate": "1674235584",
+      "arch": "x86_64"
+    },
+    "userspace-rcu": {
+      "epoch": "0",
+      "version": "0.12.1",
+      "release": "6.el9",
+      "installdate": "1674235584",
+      "arch": "x86_64"
+    },
+    "libestr": {
+      "epoch": "0",
+      "version": "0.1.11",
+      "release": "4.el9",
+      "installdate": "1674235584",
+      "arch": "x86_64"
+    },
+    "libfastjson": {
+      "epoch": "0",
+      "version": "0.99.9",
+      "release": "3.el9",
+      "installdate": "1674235584",
+      "arch": "x86_64"
+    },
+    "rsyslog-logrotate": {
+      "epoch": "0",
+      "version": "8.2102.0",
+      "release": "109.el9",
+      "installdate": "1674235584",
+      "arch": "x86_64"
+    },
+    "rsyslog": {
+      "epoch": "0",
+      "version": "8.2102.0",
+      "release": "109.el9",
+      "installdate": "1674235584",
+      "arch": "x86_64"
+    },
+    "m4": {
+      "epoch": "0",
+      "version": "1.4.19",
+      "release": "1.el9",
+      "installdate": "1674235584",
+      "arch": "x86_64"
+    },
+    "policycoreutils-devel": {
+      "epoch": "0",
+      "version": "3.5",
+      "release": "0.rc1.2.el9",
+      "installdate": "1674235584",
+      "arch": "x86_64"
+    },
+    "selinux-policy-devel": {
+      "epoch": "0",
+      "version": "38.1.4",
+      "release": "1.el9",
+      "installdate": "1674235585",
+      "arch": "noarch"
+    },
+    "langpacks-core-en": {
+      "epoch": "0",
+      "version": "3.0",
+      "release": "16.el9",
+      "installdate": "1674235591",
+      "arch": "noarch"
+    },
+    "langpacks-en": {
+      "epoch": "0",
+      "version": "3.0",
+      "release": "16.el9",
+      "installdate": "1674235591",
+      "arch": "noarch"
+    },
+    "xfsprogs": {
+      "epoch": "0",
+      "version": "5.14.2",
+      "release": "1.el9",
+      "installdate": "1674235591",
+      "arch": "x86_64"
+    },
+    "NetworkManager-tui": {
+      "epoch": "1",
+      "version": "1.41.8",
+      "release": "1.el9",
+      "installdate": "1674235591",
+      "arch": "x86_64"
+    },
+    "sg3_utils": {
+      "epoch": "0",
+      "version": "1.47",
+      "release": "9.el9",
+      "installdate": "1674235591",
+      "arch": "x86_64"
+    },
+    "kernel-tools": {
+      "epoch": "0",
+      "version": "5.14.0",
+      "release": "234.el9",
+      "installdate": "1674235591",
+      "arch": "x86_64"
+    },
+    "irqbalance": {
+      "epoch": "2",
+      "version": "1.9.0",
+      "release": "3.el9",
+      "installdate": "1674235591",
+      "arch": "x86_64"
+    },
+    "yum-utils": {
+      "epoch": "0",
+      "version": "4.3.0",
+      "release": "4.el9",
+      "installdate": "1674235591",
+      "arch": "noarch"
+    },
+    "yum": {
+      "epoch": "0",
+      "version": "4.14.0",
+      "release": "4.el9",
+      "installdate": "1674235591",
+      "arch": "noarch"
+    },
+    "sssd-kcm": {
+      "epoch": "0",
+      "version": "2.8.2",
+      "release": "1.el9",
+      "installdate": "1674235591",
+      "arch": "x86_64"
+    },
+    "man-db": {
+      "epoch": "0",
+      "version": "2.9.3",
+      "release": "7.el9",
+      "installdate": "1674235591",
+      "arch": "x86_64"
+    },
+    "nfs-utils": {
+      "epoch": "1",
+      "version": "2.5.4",
+      "release": "17.el9",
+      "installdate": "1674235592",
+      "arch": "x86_64"
+    },
+    "crypto-policies-scripts": {
+      "epoch": "0",
+      "version": "20221215",
+      "release": "1.git9a18988.el9",
+      "installdate": "1674235592",
+      "arch": "noarch"
+    },
+    "kexec-tools": {
+      "epoch": "0",
+      "version": "2.0.25",
+      "release": "11.el9",
+      "installdate": "1674235592",
+      "arch": "x86_64"
+    },
+    "grub2-pc": {
+      "epoch": "1",
+      "version": "2.06",
+      "release": "46.el9",
+      "installdate": "1674235592",
+      "arch": "x86_64"
+    },
+    "rpm-plugin-selinux": {
+      "epoch": "0",
+      "version": "4.16.1.3",
+      "release": "22.el9",
+      "installdate": "1674235592",
+      "arch": "x86_64"
+    },
+    "rpm-plugin-audit": {
+      "epoch": "0",
+      "version": "4.16.1.3",
+      "release": "22.el9",
+      "installdate": "1674235592",
+      "arch": "x86_64"
+    },
+    "openssh-clients": {
+      "epoch": "0",
+      "version": "8.7p1",
+      "release": "25.el9",
+      "installdate": "1674235592",
+      "arch": "x86_64"
+    },
+    "kernel": {
+      "epoch": "0",
+      "version": "5.14.0",
+      "release": "234.el9",
+      "installdate": "1674235592",
+      "arch": "x86_64"
+    },
+    "NetworkManager-team": {
+      "epoch": "1",
+      "version": "1.41.8",
+      "release": "1.el9",
+      "installdate": "1674235592",
+      "arch": "x86_64"
+    },
+    "dracut-config-rescue": {
+      "epoch": "0",
+      "version": "057",
+      "release": "20.git20221213.el9",
+      "installdate": "1674235592",
+      "arch": "x86_64"
+    },
+    "firewalld": {
+      "epoch": "0",
+      "version": "1.2.1",
+      "release": "1.el9",
+      "installdate": "1674235592",
+      "arch": "noarch"
+    },
+    "iproute-tc": {
+      "epoch": "0",
+      "version": "6.0.0",
+      "release": "2.el9",
+      "installdate": "1674235592",
+      "arch": "x86_64"
+    },
+    "passwd": {
+      "epoch": "0",
+      "version": "0.80",
+      "release": "12.el9",
+      "installdate": "1674235592",
+      "arch": "x86_64"
+    },
+    "audit": {
+      "epoch": "0",
+      "version": "3.0.7",
+      "release": "103.el9",
+      "installdate": "1674235592",
+      "arch": "x86_64"
+    },
+    "parted": {
+      "epoch": "0",
+      "version": "3.5",
+      "release": "2.el9",
+      "installdate": "1674235592",
+      "arch": "x86_64"
+    },
+    "authselect": {
+      "epoch": "0",
+      "version": "1.2.6",
+      "release": "1.el9",
+      "installdate": "1674235592",
+      "arch": "x86_64"
+    },
+    "openssh-server": {
+      "epoch": "0",
+      "version": "8.7p1",
+      "release": "25.el9",
+      "installdate": "1674235593",
+      "arch": "x86_64"
+    },
+    "chrony": {
+      "epoch": "0",
+      "version": "4.3",
+      "release": "1.el9",
+      "installdate": "1674235593",
+      "arch": "x86_64"
+    },
+    "net-tools": {
+      "epoch": "0",
+      "version": "2.0",
+      "release": "0.62.20160912git.el9",
+      "installdate": "1674235593",
+      "arch": "x86_64"
+    },
+    "sudo": {
+      "epoch": "0",
+      "version": "1.9.5p2",
+      "release": "8.el9",
+      "installdate": "1674235593",
+      "arch": "x86_64"
+    },
+    "e2fsprogs": {
+      "epoch": "0",
+      "version": "1.46.5",
+      "release": "3.el9",
+      "installdate": "1674235593",
+      "arch": "x86_64"
+    },
+    "initscripts-rename-device": {
+      "epoch": "0",
+      "version": "10.11.5",
+      "release": "1.el9",
+      "installdate": "1674235593",
+      "arch": "x86_64"
+    },
+    "prefixdevname": {
+      "epoch": "0",
+      "version": "0.1.0",
+      "release": "8.el9",
+      "installdate": "1674235593",
+      "arch": "x86_64"
+    },
+    "rsync": {
+      "epoch": "0",
+      "version": "3.2.3",
+      "release": "19.el9",
+      "installdate": "1674235593",
+      "arch": "x86_64"
+    },
+    "wget": {
+      "epoch": "0",
+      "version": "1.21.1",
+      "release": "7.el9",
+      "installdate": "1674235593",
+      "arch": "x86_64"
+    },
+    "tar": {
+      "epoch": "2",
+      "version": "1.34",
+      "release": "5.el9",
+      "installdate": "1674235593",
+      "arch": "x86_64"
+    },
+    "vim-minimal": {
+      "epoch": "2",
+      "version": "8.2.2637",
+      "release": "16.el9",
+      "installdate": "1674235593",
+      "arch": "x86_64"
+    },
+    "lshw": {
+      "epoch": "0",
+      "version": "B.02.19.2",
+      "release": "9.el9",
+      "installdate": "1674235593",
+      "arch": "x86_64"
+    },
+    "bzip2": {
+      "epoch": "0",
+      "version": "1.0.8",
+      "release": "8.el9",
+      "installdate": "1674235593",
+      "arch": "x86_64"
+    },
+    "ncurses": {
+      "epoch": "0",
+      "version": "6.2",
+      "release": "8.20210508.el9",
+      "installdate": "1674235593",
+      "arch": "x86_64"
+    },
+    "libsysfs": {
+      "epoch": "0",
+      "version": "2.1.1",
+      "release": "10.el9",
+      "installdate": "1674235593",
+      "arch": "x86_64"
+    },
+    "lsscsi": {
+      "epoch": "0",
+      "version": "0.32",
+      "release": "6.el9",
+      "installdate": "1674235593",
+      "arch": "x86_64"
+    },
+    "rootfiles": {
+      "epoch": "0",
+      "version": "8.1",
+      "release": "31.el9",
+      "installdate": "1674235593",
+      "arch": "noarch"
+    },
+    "gpg-pubkey": {
+      "epoch": "0",
+      "version": "8483c65d",
+      "release": "5ccc5b19",
+      "installdate": "1674235842",
+      "arch": "(none)"
+    },
+    "chef": {
+      "epoch": "0",
+      "version": "18.1.0",
+      "release": "1.el9",
+      "installdate": "1675119682",
+      "arch": "x86_64"
+    }
+  },
+  "platform": "centos",
+  "platform_family": "rhel",
+  "platform_version": "9",
+  "root_group": "root",
+  "shells": [
+    "/bin/sh",
+    "/bin/bash",
+    "/usr/bin/sh",
+    "/usr/bin/bash"
+  ],
+  "time": {
+    "timezone": "GMT"
+  },
+  "uptime": "30 days 15 hours 07 minutes 30 seconds",
+  "uptime_seconds": 2646450,
+  "virtualization": {
+    "systems": {
+    }
+  }
+}

--- a/lib/fauxhai/runner/default.rb
+++ b/lib/fauxhai/runner/default.rb
@@ -268,6 +268,7 @@ module Fauxhai
           lsb
           ohai_time
           os
+          os_release
           os_version
           packages
           platform

--- a/platforms.json
+++ b/platforms.json
@@ -49,6 +49,12 @@
       "path": "lib/fauxhai/platforms/centos/8.json"
     }
   },
+  "centos-stream": {
+    "8": {
+      "deprecated": false,
+      "path": "lib/fauxhai/platforms/centos-stream/8.json"
+    }
+  },
   "clearos": {
     "7.4": {
       "deprecated": false,

--- a/platforms.json
+++ b/platforms.json
@@ -53,6 +53,10 @@
     "8": {
       "deprecated": false,
       "path": "lib/fauxhai/platforms/centos-stream/8.json"
+    },
+    "9": {
+      "deprecated": false,
+      "path": "lib/fauxhai/platforms/centos-stream/9.json"
     }
   },
   "clearos": {


### PR DESCRIPTION
This also adds the `os_release` ohai data which is needed to properly distinguish between CentOS Linux and CentOS Stream. ~~I updated the CentOS Linux 8 data to include this new data as well.~~

Signed-off-by: Lance Albertson <lance@osuosl.org>
