### PR TITLE
Support for ruby 3.1 and CI run on main branch

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,14 +4,14 @@ on:
   pull_request:
   push:
     branches:
-      - master
+      - main
 
 jobs:
   test:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        ruby: [ '2.4', '2.5', '2.6', '2.7', '3.0']
+        ruby: [ '2.7', '3.0', '3.1' ]
     name: Validate JSON on Ruby ${{ matrix.ruby }}
     steps:
       - uses: actions/checkout@v2

--- a/fauxhai-ng.gemspec
+++ b/fauxhai-ng.gemspec
@@ -12,7 +12,7 @@ Gem::Specification.new do |spec|
   spec.homepage      = "https://github.com/chefspec/fauxhai"
   spec.license       = "MIT"
 
-  spec.required_ruby_version = ">= 2.3"
+  spec.required_ruby_version = ">= 2.7"
 
   spec.files         = %w{LICENSE Gemfile fauxhai-ng.gemspec} + Dir.glob("{lib,bin}/**/*", File::FNM_DOTMATCH).reject { |f| File.directory?(f) }
   spec.executables   = "fauxhai"


### PR DESCRIPTION
Signed-off-by: sachin007jain <sachin.jain@chef.io>

Support Ruby 3.1 and Depreciate ruby '2.4', '2.5', '26'